### PR TITLE
packaging: add files for packaging velum in openbuildservice

### DIFF
--- a/packaging/suse/.gitignore
+++ b/packaging/suse/.gitignore
@@ -1,0 +1,2 @@
+build/
+velum.spec

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+if [ -z "$1" ]; then
+  cat <<EOF
+usage:
+  ./make_spec.sh PACKAGENAME
+EOF
+  exit 1
+fi
+
+packagename=$1
+
+bundle version 2>/dev/null
+if [ $? != 0 ];then
+  echo "bundler is not installed. Please install it."
+  exit -1
+fi
+cd $(dirname $0)
+
+if [ $TRAVIS_BRANCH ];then
+  branch=$TRAVIS_BRANCH
+else
+  branch=$(git rev-parse --abbrev-ref HEAD)
+fi
+if [ $TRAVIS_COMMIT ];then
+  commit=$TRAVIS_COMMIT
+else
+  commit=$(git rev-parse HEAD)
+fi
+version=$(sed s/-/~/g ../../VERSION)
+version="$version+git$commit"
+date=$(date --rfc-2822)
+year=$(date +%Y)
+
+# clean
+[ ! -d build ] || rm -rf build
+
+additional_native_build_requirements() {
+  if [ $1 == "nokogiri" ];then
+    echo "BuildRequires: libxml2-devel libxslt-devel\n"
+  elif [ $1 == "mysql2" ];then
+    echo "BuildRequires: libmysqlclient-devel < 10.1\nRequires: libmysqlclient18 < 10.1\nRecommends: mariadb\n"
+  elif [ $1 == "ethon" ];then
+    echo "BuildRequires: libcurl-devel\nRequires: libcurl4\n"
+  elif [ $1 == "ffi" ];then
+    echo "BuildRequires: libffi-devel\n"
+  fi
+}
+
+mkdir -p build/$packagename-$branch
+cp -v ../../Gemfile* build/$packagename-$branch
+cp -v patches/*.patch build/$packagename-$branch
+
+pushd build/$packagename-$branch/
+  echo "apply patches if needed"
+  if ls *.patch >/dev/null 2>&1 ;then
+      for p in *.patch;do
+          number=$(echo "$p" | cut -d"_" -f1)
+          patchsources="$patchsources\nPatch$number: $p\n"
+          patchexecs="$patchexecs\n%patch$number -p1\n"
+          # skip applying rpm patches
+          [[ $p =~ .rpm\.patch$ ]] && continue
+          echo "applying patch $p"
+          patch -p1 < $p || exit -1
+      done
+  fi
+  echo "generate the Gemfile.lock for packaging"
+  export BUNDLE_GEMFILE=$PWD/Gemfile
+  cp Gemfile.lock Gemfile.lock.orig
+  bundle config build.nokogiri --use-system-libraries
+  PACKAGING=yes bundle install --retry=3 --no-deployment
+  grep "git-review" Gemfile.lock
+  if [ $? == 0 ];then
+    echo "DEBUG: ohoh something went wrong and you have devel packages"
+    diff Gemfile.lock Gemfile.lock.orig
+    exit -1
+  fi
+  echo "get requirements from Gemfile.lock"
+  IFS=$'\n' # do not split on spaces
+  build_requires=""
+  for gem in $(cat Gemfile.lock | grep "    "  | grep "     " -v | sort | uniq);do
+    gem_name=$(echo $gem | cut -d" " -f5)
+    gem_version=$(echo $gem | cut -d "(" -f2 | cut -d ")" -f1)
+    build_requires="$build_requires\nBuildRequires: %{rubygem $gem_name} = $gem_version"
+    build_requires="$build_requires\n$(additional_native_build_requirements $gem_name)"
+  done
+popd
+
+echo "create ${packagename}.spec based on ${packagename}.spec.in"
+cp ${packagename}.spec.in ${packagename}.spec
+sed -e "s/__BRANCH__/$branch/g" -i ${packagename}.spec
+sed -e "s/__RUBYGEMS_BUILD_REQUIRES__/$build_requires/g" -i ${packagename}.spec
+sed -e "s/__DATE__/$date/g" -i ${packagename}.spec
+sed -e "s/__COMMIT__/$commit/g" -i ${packagename}.spec
+sed -e "s/__VERSION__/$version/g" -i ${packagename}.spec
+sed -e "s/__CURRENT_YEAR__/$year/g" -i ${packagename}.spec
+sed -e "s/__PATCHSOURCES__/$patchsources/g" -i ${packagename}.spec
+sed -e "s/__PATCHEXECS__/$patchexecs/g" -i ${packagename}.spec
+
+if [ -f ${packagename}.spec ];then
+  echo "Done!"
+  exit 0
+else
+  echo "A problem occured creating the spec file."
+  exit -1
+fi

--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -1,0 +1,122 @@
+#
+# spec file for package velum
+#
+# Copyright (c) __CURRENT_YEAR__ SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+Name:           velum
+
+# When you release a new version, set Version and branch accordingly.
+# For example:
+# Version:      1.0.0
+# %define branch 1.0.0
+
+Version:        __VERSION__
+%define branch __BRANCH__
+Release:        0.0.1
+License:        Apache-2.0
+Summary:        Dashboard for CaasP
+Url:            https://github.com/kubic-project/velum
+Source:         %{branch}.tar.gz
+__PATCHSOURCES__
+
+Group:          System/Management
+%define velumdir /srv/velum
+
+Requires:       ruby >= 2.1
+%if 0%{?suse_version} >= 1210
+BuildRequires: systemd-rpm-macros
+%endif
+BuildRequires:  fdupes
+BuildRequires:  gcc-c++
+BuildRequires:  ruby-macros >= 5
+%{?systemd_requires}
+Provides:       velum = %{version}
+Obsoletes:      velum < %{version}
+# javascript engine to build assets
+BuildRequires:  nodejs
+
+%define rb_build_versions %{rb_default_ruby}
+BuildRequires:  %{rubydevel}
+BuildRequires:  %{rubygem gem2rpm}
+BuildRequires:  %{rubygem bundler} >= 1.3.0
+
+__RUBYGEMS_BUILD_REQUIRES__
+
+
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+
+%description
+velum is the dashboard for CaasP to manage and deploy kubernetes clusters on top of MicroOS
+
+This package has been built with commit __COMMIT__ from branch __BRANCH__ on date __DATE__
+
+%prep
+%setup -q -n velum-%{branch}
+__PATCHEXECS__
+
+%build
+
+install -d vendor/cache
+cp %{_libdir}/ruby/gems/%{rb_ver}/cache/*.gem vendor/cache
+export NOKOGIRI_USE_SYSTEM_LIBRARIES=1
+export PACKAGING=yes
+SKIP_MIGRATION="yes" SECRET_KEY_BASE="assets_precompilation" RAILS_ENV=production bundle exec rake assets:precompile
+export IGNORE_ASSETS=yes
+
+# run bundle list to redo the Gemfile.lock
+bundle list
+
+# deploy gems
+bundle install --retry=3 --local --deployment
+
+# install bundler
+gem install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
+
+rm -rf vendor/cache
+
+%install
+install -d %{buildroot}/%{velumdir}
+
+cp -av . %{buildroot}/%{velumdir}
+
+rm -rf %{buildroot}/%{velumdir}/log
+mkdir %{buildroot}/%{velumdir}/log
+rm -rf %{buildroot}/%{velumdir}/tmp
+mkdir %{buildroot}/%{velumdir}/tmp
+
+%fdupes %{buildroot}/%{velumdir}
+
+%pre
+
+%post
+
+%preun
+
+%postun
+
+%files
+%defattr(-,root,root)
+%{velumdir}
+%exclude %{velumdir}/spec
+%doc %{velumdir}/README.md
+%doc %{velumdir}/LICENSE
+%defattr(0640, root, www)
+%config(noreplace) %{velumdir}/config/environment.rb
+%defattr(-, root, www, 1770)
+%{velumdir}/log/
+%{velumdir}/tmp/
+%{velumdir}/db/
+
+%changelog


### PR DESCRIPTION
It's still a bit bad to have the `make_spec.sh` script duplicated between here and `Portus`.
But there is some work on the way to fix that (see https://github.com/openSUSE/ruby-packaging/pull/6)