### PR TITLE
Add an etcd instance to the development environment.

### DIFF
--- a/kubernetes/manifest-templates/etcd.yaml
+++ b/kubernetes/manifest-templates/etcd.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd
+  labels:
+    name: etcd
+spec:
+  hostNetwork: true
+  containers:
+  - name: etcd
+    image: ereslibre/etcd:latest
+    env:
+    - name: ETCD_NAME
+      value: default
+    - name: ETCD_DATA_DIR
+      value: /var/lib/etcd/default.etcd
+    - name: ETCD_LISTEN_PEER_URLS
+      value: http://0.0.0.0:2380
+    - name: ETCD_LISTEN_CLIENT_URLS
+      value: http://0.0.0.0:2379
+    - name: ETCD_ADVERTISE_CLIENT_URLS
+      value: http://${ip_address}:2379

--- a/kubernetes/start
+++ b/kubernetes/start
@@ -13,11 +13,14 @@ while true; do
     esac
 done
 
+default_interface=$(awk '$2 == 00000000 { print $1 }' /proc/net/route)
+ip_address=$(ip addr show $default_interface | awk '$1 == "inet" {print $2}' | cut -f1 -d/)
+
 for template in $(ls manifest-templates)
 do
     log "Processing template $template..."
-    sed -e "s#\${project_dir}#$(dirname $PWD)#" manifest-templates/$template > manifests/$template
-
+    sed -e "s#\${project_dir}#$(dirname $PWD)#" \
+        -e "s#\${ip_address}#$ip_address#" manifest-templates/$template > manifests/$template
 
     # Use SALT_DIR is set and not empty else use our default directory
     # This can be used to point to different state files for orchestration.

--- a/lib/velum/salt_minion.rb
+++ b/lib/velum/salt_minion.rb
@@ -9,7 +9,7 @@ module Velum
     attr_accessor :minion_id
 
     ROLES_MAP = {
-      master: ["kube-master", "etcd"],
+      master: ["kube-master"],
       minion: ["kube-minion"]
     }.freeze
 


### PR DESCRIPTION
When there is no dashboard, the development environment is the
dashboard itself. Add an etcd instance that the rest of the cluster
can use.