### PR TITLE
Use --non-interactive flag for non interactive mode in dev env start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ within the `kubernetes` folder. You will need a [standalone kubelet](https://kub
 
 This will start the velum container as well as other required containers.
 
+You can use the `--non-interactive` flag if you prefer to run in non interactive mode.
+In that case you will be asked before old containers are removed.
+
+E.g.
+
+`> ./start --non-interactive`
+
 If you want to use your own set of salt states you can provide `SALT_DIR` environment variable
 to the start script, so that directory will be used as salt root.
 

--- a/kubernetes/start
+++ b/kubernetes/start
@@ -4,14 +4,32 @@ log()   { echo ">>> $1" ; }
 
 [[ -d manifest-templates ]] || { echo >&2 "Please run this script from within the kubernetes folder"; exit 1; }
 
-while true; do
-    read -e -i "y" -p "Do you want to cleanup old containers? [Y/n] " yn
-    case $yn in
-        [Yy]* ) ./cleanup; break;;
-        [Nn]* ) exit 0;;
-        * ) echo "Please answer yes (y) or no (n).";;
-    esac
+# interactive by default
+interactive_mode=1
+
+while [ $# -gt 0 ] ; do
+  case $1 in
+    --non-interactive)
+      interactive_mode=0
+      ;;
+    *)
+      log "Unknown argument $1"
+      exit 1
+      ;;
+  esac
+  shift
 done
+
+while (( $interactive_mode == 1)) ; do
+  read -e -i "y" -p "Do you want to cleanup old containers? [Y/n] " yn
+  case $yn in
+      [Yy]* ) break;;
+      [Nn]* ) exit 0;;
+      * ) echo "Please answer yes (y) or no (n).";;
+  esac
+done
+
+./cleanup
 
 default_interface=$(awk '$2 == 00000000 { print $1 }' /proc/net/route)
 ip_address=$(ip addr show $default_interface | awk '$1 == "inet" {print $2}' | cut -f1 -d/)


### PR DESCRIPTION
We need the non interactive mode for the script to be used from other
scripts (e.g. in the e2e-tests project)