### PR TITLE
packaging: add a script to prepare obs submission

### DIFF
--- a/packaging/suse/concourse/README.md
+++ b/packaging/suse/concourse/README.md
@@ -1,0 +1,4 @@
+### concourse ci
+
+this scripts are called only through a concourse pipeline
+**NOT** meant to be called manually

--- a/packaging/suse/concourse/package.sh
+++ b/packaging/suse/concourse/package.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+log()   { echo ">>> $1" ; }
+
+sed -i "s|<username>|$OSC_USERNAME|g" /root/.oscrc
+sed -i "s|<password>|$OSC_PASSWORD|g" /root/.oscrc
+
+# build the spec file
+log "building the spec file"
+velum-git-resource/packaging/suse/make_spec.sh velum
+
+pushd velum-osc-resource/Virtualization:containers:Velum/velum 1> /dev/null
+  log "updating osc checkout to newest revision"
+  osc up
+  log "removing old specfile"
+  osc rm velum.spec
+  log "adding new specfile"
+  cp ../../../velum-git-resource/packaging/suse/velum.spec .
+popd 1> /dev/null
+
+cp -a velum-osc-resource/Virtualization:containers:Velum/velum/. velum-osc-updated-resource/


### PR DESCRIPTION
this will be called by a concourse task during execution of the
pipeline, and prepares an osc-resource to be submitted to obs

![concourse-velum](https://cloud.githubusercontent.com/assets/5364817/23056485/f5674562-f4eb-11e6-8854-213b88edbc37.png)
