### PR TITLE
packaging: reference master instead of HEAD

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -20,6 +20,8 @@ if [ $TRAVIS_BRANCH ];then
   branch=$TRAVIS_BRANCH
 else
   branch=$(git rev-parse --abbrev-ref HEAD)
+  # the concourse git resource renders HEAD, but in this case we need master
+  [ $branch = "HEAD" ] && branch=master
 fi
 if [ $TRAVIS_COMMIT ];then
   commit=$TRAVIS_COMMIT


### PR DESCRIPTION
when we call make_spec.sh within a concourse git resource, the git
command renders HEAD instead of master.