### PR TITLE
packaging: make sure build is running, obs is slow

### DIFF
--- a/packaging/suse/concourse/wait_for_build.sh
+++ b/packaging/suse/concourse/wait_for_build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+sed -i "s|<username>|$OSC_USERNAME|g" /root/.oscrc
+sed -i "s|<password>|$OSC_PASSWORD|g" /root/.oscrc
+
+log() { echo ">>> $1" ; }
+get_result() { osc results Virtualization:containers:Velum velum ; }
+
+until get_result | grep -q "building"
+do
+    log "Waiting for build to start"
+    sleep 5
+done
+
+exit 0


### PR DESCRIPTION
as obs is a bit slow picking up a new build once a new change has
been submitted, we need an intermediate step to make sure the build
has begun, before checking for success/failure