### PR TITLE
packaging: adapt regex to obs output

### DIFF
--- a/packaging/suse/concourse/buildresult.sh
+++ b/packaging/suse/concourse/buildresult.sh
@@ -21,7 +21,7 @@ arch=$2
 result=$(get_result | grep "$repository.*$arch")
 
 log "fetching build results"
-until get_result | grep -Eq "^$repository.*$arch.*(succeeded|failed|excluded|unresolvable)$";
+until get_result | grep -Eq "^$repository.*$arch.*(succeeded|failed|excluded|unresolvable)(\*|)$";
 do
     result=$(get_result | grep "$repository.*$arch")
     log "Waiting for $repository $arch build to finish"


### PR DESCRIPTION
in the case that build jobs have been processed, but new repository
is not yet created (meaning the package hasn't been published yet), the output of the query will look like:
  SLE_12_SP2 x86_64 succeeded*

so we need to adapt the regex to that case as it can take up quite some time to get published