### PR TITLE
packaging: enhancements and fixes

### DIFF
--- a/packaging/suse/concourse/copypac.sh
+++ b/packaging/suse/concourse/copypac.sh
@@ -20,6 +20,9 @@ if [ -z "$4" ]; then
   apiurl=https://api.opensuse.org
 else
   apiurl=$4
+  if ! [[ $apiurl =~ "https://api.opensuse.org" ]]; then
+    sed -i "s|https://api.opensuse.org|$apiurl|g" /root/.oscrc
+  fi
 fi
 
 log() { echo ">>> $1" ; }

--- a/packaging/suse/concourse/wait_for_build.sh
+++ b/packaging/suse/concourse/wait_for_build.sh
@@ -19,14 +19,18 @@ if [ -z "$3" ]; then
   apiurl=https://api.opensuse.org
 else
   apiurl=$3
+  if ! [[ "$apiurl" =~ "https://api.opensuse.org" ]]; then
+    sed -i "s|https://api.opensuse.org|$apiurl|g" /root/.oscrc
+  fi
 fi
 
 log() { echo ">>> $1" ; }
 get_result() { osc -A $apiurl results $project $package ; }
 
+log "Waiting for build to start on $apiurl/package/show/$project/$package"
 until get_result | grep -q "building"
 do
-    log "Waiting for build to start"
+    log "Waiting for $project $package build to start"
     sleep 5
 done
 


### PR DESCRIPTION
* make sure to write .oscrc
* enhance logging
* cache result after success
  otherwise we will always fail, due to an outdated result
  if the apiurl is different than https://api.opensuse.org

Signed-off-by: Maximilian Meister <mmeister@suse.de>