### PR TITLE
Set dashboard location on the pillar.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@
 .rspec
 /kubernetes/tmp
 /kubernetes/manifests
+/kubernetes/salt/pillar
 /kubernetes/salt/config/minion.d/_schedule.conf
 /.vagrant

--- a/kubernetes/manifest-templates/salt.yaml
+++ b/kubernetes/manifest-templates/salt.yaml
@@ -16,6 +16,8 @@ spec:
       name: salt-master
     - mountPath: /srv/pillar
       name: salt-pillar
+    - mountPath: /srv/pillar/vars.sls
+      name: salt-pillar-vars
     - mountPath: /var/run/salt/master
       name: salt-sock-dir
   - name: salt-api
@@ -44,6 +46,9 @@ spec:
     - name: salt-pillar
       hostPath:
         path: ${salt_dir}/pillar
+    - name: salt-pillar-vars
+      hostPath:
+        path: ${project_dir}/kubernetes/salt/pillar/vars.sls
     - name: salt-sock-dir
       hostPath:
         path: ${project_dir}/kubernetes/tmp/salt-sock-dir

--- a/kubernetes/salt-templates/pillar/vars.sls
+++ b/kubernetes/salt-templates/pillar/vars.sls
@@ -1,0 +1,4 @@
+# some global variables that will be set dynamically
+
+# a distinguishable name/IP for the dashboard
+dashboard:     '${ip_address}'

--- a/kubernetes/start
+++ b/kubernetes/start
@@ -34,24 +34,31 @@ done
 default_interface=$(awk '$2 == 00000000 { print $1 }' /proc/net/route)
 ip_address=$(ip addr show $default_interface | awk '$1 == "inet" {print $2}' | cut -f1 -d/)
 
+# Use SALT_DIR is set and not empty else use our default directory
+# This can be used to point to different state files for orchestration.
+if [ -z ${SALT_DIR+x} ]
+then
+    log "You did not provide a SALT_DIR. $(dirname $PWD)/kubernetes/salt will be used..."
+    salt_dir="$(dirname $PWD)/kubernetes/salt"
+    sleep 5
+else
+    salt_dir=$SALT_DIR
+fi
+
 for template in $(ls manifest-templates)
 do
     log "Processing template $template..."
     sed -e "s#\${project_dir}#$(dirname $PWD)#" \
-        -e "s#\${ip_address}#$ip_address#" manifest-templates/$template > manifests/$template
+        -e "s#\${ip_address}#$ip_address#" \
+        -e "s#\${salt_dir}#$salt_dir#" manifest-templates/$template > manifests/$template
+done
 
-    # Use SALT_DIR is set and not empty else use our default directory
-    # This can be used to point to different state files for orchestration.
-    if [ -z ${SALT_DIR+x} ]
-    then
-      log "You did not provide a SALT_DIR. $(dirname $PWD)/kubernetes/salt will be used..."
-      salt_dir="$(dirname $PWD)/kubernetes/salt"
-      sleep 5
-    else
-      salt_dir=$SALT_DIR
-    fi
-
-    sed -i -e "s#\${salt_dir}#$salt_dir#" manifests/$template
+for template in $(find salt-templates -type f | cut -d'/' -f2-)
+do
+    log "Processing template $template..."
+    sed -e "s#\${project_dir}#$(dirname $PWD)#" \
+        -e "s#\${ip_address}#$ip_address#" \
+        -e "s#\${salt_dir}#$salt_dir#" salt-templates/$template > salt/$template
 done
 
 if $(which kubelet >&/dev/null); then


### PR DESCRIPTION
When starting the development environment, we can take the vars.sls
from the pillar, and mount it on the salt-master, so we can add some
variables without having to modify the original salt states.