### PR TITLE
Add an external pillar.

### DIFF
--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+# Pillar represents a pillar value on Salt.
+#
+# This can override already existing pillar values, or create completely new ones.
+#
+# For example, given that we have on our static pillar:
+#
+#   certificate_information:
+#     subject_properties:
+#       C: DE
+#       O: SUSE
+#
+# We could override them by creating the following Pillar records:
+#
+#   Pillar.create pillar: "certificate_information.subject_properties.C", value: "FR"
+#   Pillar.create pillar: "certificate_information.subject_properties.O", value: "My Company"
+#
+# Lists can be represented as collisions. So, creating the following Pillar records:
+#
+#   Pillar.create pillar: "my_service.extra_ips", value: "127.0.0.1"
+#   Pillar.create pillar: "my_service.extra_ips", value: "127.0.0.2"
+#
+# Would match the following YAML representation:
+#
+#   my_service:
+#     extra_ips:
+#       - 127.0.0.1
+#       - 127.0.0.2
+#
+# This is because how we configure our salt master using this table as an external pillar. For
+# further information you can visit:
+#   - https://github.com/kubic-project/velum/blob/master/docs/salt.md
+#   - https://github.com/kubic-project/velum/blob/master/kubernetes/salt/config/master.d/salt-master.conf
+class Pillar < ApplicationRecord
+  validates :pillar, presence: true
+  validates :value, presence: true
+
+  scope :global, -> { where minion_id: nil }
+end

--- a/db/migrate/20170227152008_create_pillars.rb
+++ b/db/migrate/20170227152008_create_pillars.rb
@@ -1,0 +1,10 @@
+class CreatePillars < ActiveRecord::Migration
+  def change
+    create_table :pillars do |t|
+      t.string :minion_id, index: true
+      t.string :pillar, index: true
+      t.string :value
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170201155426) do
+ActiveRecord::Schema.define(version: 20170227152008) do
 
   create_table "jids", id: false, force: :cascade do |t|
     t.string "jid",  limit: 255,      null: false
@@ -29,6 +29,17 @@ ActiveRecord::Schema.define(version: 20170201155426) do
   end
 
   add_index "minions", ["hostname"], name: "index_minions_on_hostname", unique: true, using: :btree
+
+  create_table "pillars", force: :cascade do |t|
+    t.string   "minion_id",  limit: 255
+    t.string   "pillar",     limit: 255
+    t.string   "value",      limit: 255
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "pillars", ["minion_id"], name: "index_pillars_on_minion_id", using: :btree
+  add_index "pillars", ["pillar"], name: "index_pillars_on_pillar", using: :btree
 
   create_table "salt_events", force: :cascade do |t|
     t.string   "tag",          limit: 255,      null: false

--- a/docs/salt.md
+++ b/docs/salt.md
@@ -1,0 +1,58 @@
+# Salt usage
+
+This is a technical document explaining how we use and take advantage of `Salt`.
+
+Terminology:
+
+- We use the term *minion* to refer to the salt minions, because that is the way they are called in
+  Salt documentation.
+
+# Salt API
+
+We do use the [Salt API](https://docs.saltstack.com/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html)
+for almost all operations we perform on `Salt` from within `Velum`. There are some exceptions, that
+we will describe in this document.
+
+## Bootstrapping process
+
+During the bootstrapping process, we do several tasks with `Salt`. Mainly:
+
+1. Set grains on minions.
+2. Add information to the pillar.
+3. Run the orchestration.
+
+### Grains
+
+Grains are tiny amounts of information, automatically collected, or manually set.
+
+During the bootstrapping process, we will set `roles` for all minions. Right now, from the UI it
+will be possible to select which machine will take the kubernetes master role (that means, the
+machine that will run the `apiserver`, `controller-manager`...).
+
+This `role` is a grain, and is set through the `Salt API` from the `Velum` dashboard. The rest of
+discovered minions will be set the `kubernetes-minion` `role` (that means, the machines that will
+run the `kubelet`, `container runtime`...).
+
+### Pillar
+
+The pillar contains global information that is meant to be `static`. Some pillar settings are meant
+to never change, and some other pillar settings are meant to be set during the bootstrapping
+process, and never change again (at least in a long time).
+
+The pillar cannot be modified using the `Salt API`. For this reason, we are using an [external
+Pillar](https://docs.saltstack.com/en/latest/ref/pillar/all/salt.pillar.mysql.html), that
+complements the static Pillar that we already have. You can find more information about the `mysql`
+based external pillar [here](https://docs.saltstack.com/en/latest/ref/pillar/all/salt.pillar.sql_base.html).
+
+#### External Pillar
+
+Since SaltStack is highly modular, there are several ways to set up an external pillar. In our case,
+we are setting an external pillar that will rely on our `mysql` instance running on the controller
+node.
+
+This external pillar will be merged with the static Pillar, allowing for certain configurable
+settings to override the original ones, or to create completely new attributes that our salt states
+might or will read.
+
+This allows us to rely on our static Pillar with reasonable defaults, and choose what attributes
+will be configurable during the bootstrapping process that will override those defaults.

--- a/kubernetes/salt/config/master.d/salt-master.conf
+++ b/kubernetes/salt/config/master.d/salt-master.conf
@@ -3,8 +3,77 @@ auto_accept: True
 interface: 0.0.0.0
 
 event_return: mysql
-mysql.host: '127.0.0.1'
-mysql.user: 'root'
-mysql.pass: 'salt'
-mysql.db: 'velum_development'
-mysql.port: 3306
+
+mysql:
+  host: '127.0.0.1'
+  user: 'root'
+  pass: 'salt'
+  db: 'velum_development'
+  port: 3306
+
+ext_pillar:
+  - mysql:
+    # This queries allows us to override our pillar values up to a depth of 3.
+    #
+    # Considering we have on our static pillar:
+    #
+    #   certificate_information:
+    #     subject_properties:
+    #       C: DE
+    #       O: SUSE
+    #       ...
+    #
+    # We are able to prioritize pillar information overriding the default values.
+    #
+    # In this example, if we had a mysql row:
+    #   INSERT INTO pillars(pillar, value) VALUES ("certificate_information.subject_properties.O",
+    #                                              "My Company");
+    #
+    # We would see on the pillar:
+    #
+    #   certificate_information:
+    #     subject_properties:
+    #       C: DE
+    #       O: My Company
+    #       ...
+    #
+    # Please, note that this will only work until a depth of 3 properties. If we want to provide
+    # more depth, we would need to add more columns, as salt treats each column as a nested property
+    # inside the previous one. For further information, please visit:
+    #   https://docs.saltstack.com/en/latest/ref/pillar/all/salt.pillar.sql_base.html
+    #
+    # Lists can be represented as collisions:
+    #   INSERT INTO pillars(pillar, value) VALUES ("my_service.extra_ips", "127.0.0.1");
+    #   INSERT INTO pillars(pillar, value) VALUES ("my_service.extra_ips", "127.0.0.2");
+    #
+    # Will be represented as:
+    #
+    #   my_service:
+    #     extra_ips:
+    #       - 127.0.0.1
+    #       - 127.0.0.2
+    #
+    # Query for first level pillar values (no dots in `pillar` key)
+    - query: 'SELECT pillar,
+                     value
+                     FROM pillars WHERE
+                       (LENGTH(pillar) - LENGTH(REPLACE(pillar, ".", "")) = 0) AND
+                       (minion_id IS NULL OR minion_id = %s)'
+      as_list: True
+    # Query for second level pillar values (one dot in `pillar` key)
+    - query: 'SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ".", 1), ".", -1) AS key1,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ".", 2), ".", -1) AS key2,
+                     value
+                     FROM pillars WHERE
+                       (LENGTH(pillar) - LENGTH(REPLACE(pillar, ".", "")) = 1) AND
+                       (minion_id IS NULL OR minion_id = %s)'
+      as_list: True
+    # Query for third level pillar values (two dots in `pillar` key)
+    - query: 'SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ".", 1), ".", -1) AS key1,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ".", 2), ".", -1) AS key2,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ".", 3), ".", -1) AS key3,
+                     value
+                     FROM pillars WHERE
+                       (LENGTH(pillar) - LENGTH(REPLACE(pillar, ".", "")) = 2) AND
+                       (minion_id IS NULL OR minion_id = %s)'
+      as_list: True

--- a/spec/factories/pillar_factory.rb
+++ b/spec/factories/pillar_factory.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :pillar do
+    sequence(:pillar) { |n| "key#{n}" }
+    value "value"
+  end
+end

--- a/spec/models/pillar_spec.rb
+++ b/spec/models/pillar_spec.rb
@@ -1,0 +1,6 @@
+describe Pillar do
+  subject { create(:pillar) }
+
+  it { is_expected.to validate_presence_of(:pillar) }
+  it { is_expected.to validate_presence_of(:value) }
+end


### PR DESCRIPTION
The pillar is not programatically modifiable. Since we need to set
some pillar values during the bootstrapping process, we need to rely
on an external pillar that we can modify.

The original module requires a '%s' argument to be provided, or the
mysql python module will complain. We added a `minion_id` that can be
used for certain pillar key discovery. However, since we are going to
use this pillar information for global configuration, we can just let
`minion_id` be NULL, and that will be readable by all salt clients.

We also add a Pillar model that will be able to modify these Pillar
values.