### PR TITLE
packaging: remove .orig files

### DIFF
--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -96,6 +96,10 @@ mkdir %{buildroot}/%{velumdir}/log
 rm -rf %{buildroot}/%{velumdir}/tmp
 mkdir %{buildroot}/%{velumdir}/tmp
 
+# remove any .orig files that might have been created by a successful patch with an offset
+# unfortunately there is no option to patch that prevents that
+rm -rf %{buildroot}/%{velumdir}/Gemfile.lock.orig
+
 %fdupes %{buildroot}/%{velumdir}
 
 %pre


### PR DESCRIPTION
unfortunately there is no option to patch that prevents this
it seems that patch creates an .orig file in some cases even
when it was successful, e.g. when the patch has an offset

Signed-off-by: Maximilian Meister <mmeister@suse.de>