### PR TITLE
Add AutoYaST profile serving

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - bundle exec rspec spec
   - bundle exec rubocop -V
   - bundle exec rubocop -F
-  - bundle exec brakeman -z -A
+  - bundle exec brakeman -c config/brakeman.ignore -z -A
 
 addons:
   code_climate:

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 require "velum/kubernetes"
+require "velum/suse_connect"
 
 # DashboardController shows the main page.
 class DashboardController < ApplicationController
+  # TODO: move autoyast to its own controller (following a different logic flow). It would never get
+  # authenticated (as login/password -- since it's machines requesting this endpoint). It would
+  # never get redirected to setup the cluster, and it should actually read some security setting for
+  # only serving the autoyast profile to a set of IP ranges (provided by the customer).
+  skip_before_action :authenticate_user!, only: :autoyast
+  skip_before_action :redirect_to_setup, only: :autoyast
+
   def index
     @assigned_minions = Minion.assigned_role
     @unassigned_minions = Minion.unassigned_role
@@ -17,6 +25,39 @@ class DashboardController < ApplicationController
     end
   end
 
+  # Return the autoyast XML profile to bootstrap other worker nodes. They will read this response in
+  # order to start an unattended installation of CaaSP.
+  #
+  # It will return the content of the autoyast profile along with a 200 HTTP response code if the
+  # operation was successfull, or a 503 HTTP response code (service unavailable) if there was any
+  # problem while contacting to the subscription backend.
+  #
+  # This method skips authentication (workers won't authenticate using the typical username/password
+  # fields that customer uses) and also skips the redirection to the setup process (when a worker
+  # asks for the autoyast profile we will either serve it, or return an error).
+  def autoyast
+    @controller_node = Socket.gethostname
+    begin
+      suse_connect_config = Rails.cache.fetch("SUSEConnect_config") do
+        Velum::SUSEConnect.config
+      end
+      @suse_smt_url = suse_connect_config.smt_url
+      @suse_regcode = suse_connect_config.regcode
+      @do_registration = true
+    rescue Velum::SUSEConnect::MissingRegCodeException,
+           Velum::SUSEConnect::MissingCredentialsException
+      @do_registration = false
+    end
+    render "autoyast.xml.erb", layout: false, content_type: "text/xml"
+  rescue Velum::SUSEConnect::SCCConnectionException
+    head :service_unavailable
+  end
+
+  # Return the kubeconfig file that allows the customer to use the cluster using the kubectl tool.
+  #
+  # If everything is successfull, the kubeconfig file will be served. Otherwise (e.g. the cluster is
+  # not yet provisioned or is still being provisioned) it will redirect to the main page giving the
+  # user feedback about the current situation.
   def kubectl_config
     kubeconfig = Velum::Kubernetes.kubeconfig
     @apiserver_host = kubeconfig.host

--- a/app/views/dashboard/autoyast.xml.erb
+++ b/app/views/dashboard/autoyast.xml.erb
@@ -1,0 +1,145 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <global>
+      <generic_mbr>true</generic_mbr>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <terminal>gfxterm</terminal>
+      <timeout config:type="integer">8</timeout>
+      <suse_btrfs config:type="boolean">true</suse_btrfs>
+    </global>
+  </bootloader>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <second_stage config:type="boolean">false</second_stage>
+      <self_update config:type="boolean">false</self_update>
+    </mode>
+    <proposals config:type="list"/>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+   <partitioning config:type="list">
+    <drive>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <ssh_import>
+    <copy_config config:type="boolean">false</copy_config>
+    <import config:type="boolean">false</import>
+  </ssh_import>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Etc/GMT</timezone>
+  </timezone>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id/>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <setup_before_proposal config:type="boolean">true</setup_before_proposal>
+    <managed config:type="boolean">false</managed>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+  </networking>
+  <software>
+    <image/>
+    <install_recommended config:type="boolean">false</install_recommended>
+    <instsource/>
+    <patterns config:type="list">
+      <pattern>MicroOS</pattern>
+    </patterns>
+    <patterns config:type="list">
+      <pattern>Stack</pattern>
+    </patterns>
+  </software>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <disable config:type="list">
+        <service>purge-kernels</service>
+      </disable>
+      <enable config:type="list">
+        <service>sshd</service>
+        <service>cloud-init-local</service>
+        <service>cloud-init</service>
+        <service>cloud-config</service>
+        <service>cloud-final</service>
+        <service>issue-generator</service>
+        <service>issue-add-ssh-keys</service>
+        <service>salt-minion</service>
+      </enable>
+    </services>
+  </services-manager>
+  <users config:type="list">
+    <user>
+      <username>root</username>
+      <user_password>!</user_password>
+      <encrypted config:type="boolean">true</encrypted>
+    </user>
+  </users>
+  <suse_register>
+    <do_registration config:type="boolean"><%= @do_registration %></do_registration>
+    <% unless @suse_regcode.blank? %>
+      <reg_code><%= @suse_regcode %></reg_code>
+    <% end %>
+    <install_updates config:type="boolean">true</install_updates>
+    <slp_discovery config:type="boolean">false</slp_discovery>
+    <% unless @suse_smt_url.blank? %>
+      <reg_server><%= @suse_smt_url %></reg_server>
+    <% end %>
+  </suse_register>
+  <files config:type="list">
+    <file>
+      <file_path>/etc/salt/minion.d/master.conf</file_path>
+      <file_contents>
+<![CDATA[
+master: <%= @controller_node %>
+]]>
+      </file_contents>
+      <file_owner>root.root</file_owner>
+      <file_permissions>640</file_permissions>
+    </file>
+  </files>
+</profile>

--- a/app/views/setup/worker_bootstrap.html.slim
+++ b/app/views/setup/worker_bootstrap.html.slim
@@ -12,20 +12,20 @@ h1 Bootstrap your Container as a Service Platform
 p
   | In order to complete the installation, it is necessary to bootstrap a few additional nodes, those will be the Kubernetes Master and Workers.
   |  This process leverages AutoYaST and is (almost) fully automated.
-  |  In case you are not familiar with it, you can find more information about AutoYaST in the 
+  |  In case you are not familiar with it, you can find more information about AutoYaST in the&nbsp;
   a href="https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html" official documentation.
-  |  The automatic installation gets invoked by adding autoyast=&lt;URL_TO_PROFILE&gt; to the kernel parameter list.
+  |  The automatic installation gets invoked by adding autoyast=#{autoyast_url} to the kernel parameter list.
   |  As installation media, you can use the very same image you bootstrapped the admin node with.
 
   |  A ready to use AutoYaST profile has been already generated for you during the bootstrap of the admin node.
   |  Bootstrap all the nodes you want to make part of this platform by adding the following boot parameter
-  |  autoyast=http://myserver/myconfig.xml
+  |  autoyast=#{autoyast_url}
 
 h2 Tips
 p
-  | You don't need to boot each node by hand. More information on how to embed an AutoYaST profile in your PXE environment is available 
+  | You don't need to boot each node by hand. More information on how to embed an AutoYaST profile in your PXE environment is available&nbsp;
   a href="https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#bootmedium.pxe" here
-  | . Where http://myserver/myconfig.xml is the real, generated path to the AutoYaST profile served by the dashboard.
+  | . Where #{autoyast_url} is the real, generated path to the AutoYaST profile served by the dashboard.
 
 .clearfix.text-right.steps-container
   = link_to "Back", setup_path, class: "btn btn-danger"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "SSL Verification Bypass",
+      "warning_code": 71,
+      "fingerprint": "fcd6d876d77ab745b6d968b6e91bd07a4390469664220843227a10672aad89f4",
+      "check_name": "SSLVerify",
+      "message": "SSL certificate verification was bypassed",
+      "file": "lib/velum/suse_connect.rb",
+      "line": 113,
+      "link": "http://brakemanscanner.org/docs/warning_types/ssl_verification_bypass/",
+      "code": "Net::HTTP.start(URI.join(@smt_url, endpoint).hostname, URI.join(@smt_url, endpoint).port, :open_timeout => 2, :use_ssl => (URI.join(@smt_url, endpoint).scheme == \"https\"), :verify_mode => (OpenSSL::SSL::VERIFY_NONE))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Velum::SUSEConnect",
+        "method": "perform_request"
+      },
+      "user_input": null,
+      "confidence": "High",
+      "note": ""
+    }
+  ],
+  "updated": "2017-03-22 17:44:12 +0000",
+  "brakeman_version": "3.5.0"
+}

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,6 +13,9 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
+  # Disable cache
+  config.cache_store = :null_store
+
   # Configure static file server for tests with Cache-Control for performance.
   config.serve_static_files   = true
   config.static_cache_control = "public, max-age=3600"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     root to: "auth/sessions#new"
   end
 
+  get "/autoyast", to: "dashboard#autoyast"
   get "/kubectl-config", to: "dashboard#kubectl_config"
 
   namespace :setup do

--- a/lib/velum/http_exceptions.rb
+++ b/lib/velum/http_exceptions.rb
@@ -1,0 +1,19 @@
+module Velum
+  module HTTPExceptions
+    EXCEPTIONS = [
+      SocketError,
+      Errno::ETIMEDOUT,
+      Net::ReadTimeout,
+      Net::OpenTimeout,
+      Net::ProtocolError,
+      Errno::ECONNREFUSED,
+      Errno::EHOSTDOWN,
+      Errno::ECONNRESET,
+      Errno::ENETUNREACH,
+      Errno::EHOSTUNREACH,
+      Errno::ECONNABORTED,
+      OpenSSL::SSL::SSLError,
+      EOFError
+    ].freeze
+  end
+end

--- a/lib/velum/salt_api.rb
+++ b/lib/velum/salt_api.rb
@@ -1,26 +1,11 @@
 # frozen_string_literal: true
 require "net/http"
+require "velum/http_exceptions"
 
 module Velum
   # This class offers the integration between ruby and the Saltstack API.
   module SaltApi
     class SaltConnectionException < StandardError; end
-
-    HTTP_EXCEPTIONS = [
-      SocketError,
-      Errno::ETIMEDOUT,
-      Net::ReadTimeout,
-      Net::OpenTimeout,
-      Net::ProtocolError,
-      Errno::ECONNREFUSED,
-      Errno::EHOSTDOWN,
-      Errno::ECONNRESET,
-      Errno::ENETUNREACH,
-      Errno::EHOSTUNREACH,
-      Errno::ECONNABORTED,
-      OpenSSL::SSL::SSLError,
-      EOFError
-    ].freeze
 
     def self.included(base)
       base.extend(ClassMethods)
@@ -95,7 +80,7 @@ module Velum
 
         opts = { use_ssl: false, open_timeout: 2 }
         Net::HTTP.start(uri.hostname, uri.port, opts) { |http| http.request(req) }
-      rescue *HTTP_EXCEPTIONS => e
+      rescue *HTTPExceptions::EXCEPTIONS => e
         raise SaltConnectionException, e
       end
     end

--- a/lib/velum/suse_connect.rb
+++ b/lib/velum/suse_connect.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+require "net/http"
+require "velum/http_exceptions"
+
+module Velum
+  # This class handles interaction with the SUSE Connect service (whether is the SCC or SMT).
+  class SUSEConnect
+    # Raised when there is a connection exception with the SMT/SCC service
+    class SCCConnectionException < StandardError; end
+    # Raised when an active registration code for CaaSP is missing
+    class MissingRegCodeException < StandardError; end
+    # Raised when no credentials were found for SCC service
+    class MissingCredentialsException < StandardError; end
+
+    DEFAULT_SMT_URL = "https://scc.suse.com".freeze
+
+    SUSEConnectConfig = Struct.new :smt_url, :regcode
+
+    class << self
+      def config
+        if smt_url == DEFAULT_SMT_URL
+          SUSEConnectConfig.new smt_url, regcode
+        else
+          SUSEConnectConfig.new smt_url
+        end
+      end
+
+      def smt_url_prefixes
+        ["/run/secrets", "/etc"]
+      end
+
+      def smt_config_file_contents(prefix:)
+        YAML.load_file File.join(prefix, "SUSEConnect")
+      rescue
+        nil
+      end
+
+      def smt_config
+        smt_config = nil
+        smt_url_prefixes.each do |prefix|
+          smt_config ||= smt_config_file_contents prefix: prefix
+        end
+        smt_config || {}
+      end
+
+      def smt_url
+        smt_config["url"] || DEFAULT_SMT_URL
+      end
+
+      def smt_insecure
+        smt_config["insecure"] || false
+      end
+
+      def credentials_prefixes
+        ["/run/secrets", "/etc/zypp"]
+      end
+
+      def credentials_file_contents(prefix:)
+        File.read File.join(prefix, "credentials.d", "SCCcredentials")
+      rescue
+        nil
+      end
+
+      def credentials
+        credentials_config = nil
+        credentials_prefixes.each do |prefix|
+          credentials_config ||= credentials_file_contents prefix: prefix
+        end
+        raise MissingCredentialsException if credentials_config.nil?
+        {
+          username: /^username=(.+)$/.match(credentials_config)[1],
+          password: /^password=(.+)$/.match(credentials_config)[1]
+        }
+      end
+
+      def regcode
+        SUSEConnect.new(smt_url:      smt_url,
+                        smt_insecure: smt_insecure,
+                        credentials:  credentials).regcode
+      end
+    end
+
+    # Initializes a SUSEConnect client.
+    #
+    # It takes `smt_url` which links to the SMT service to be used (by default is DEFAULT_SMT_URL),
+    # smt_insecure (that allows for this connection to be insecure), and a credentials hash
+    # including `:username` and `:password` keys.
+    def initialize(smt_url: SUSEConnect::DEFAULT_SMT_URL, smt_insecure: false, credentials:)
+      @smt_url = smt_url
+      @smt_insecure = smt_insecure
+      @credentials = credentials
+    end
+
+    # Obtains an active regcode for CaaSP.
+    #
+    # This method will retrieve an active and valid regcode for CaaSP using the credentials
+    # provided when this instance was created.
+    #
+    # If no valid active regcode is found for CaaSP, `MissingRegCodeException` will be raised.
+    #
+    # If there is any kind of connectivity problem with SMT/SCC, `SCCConnectionException` will be
+    # raised.
+    def regcode
+      result, all_regcodes = perform_request endpoint: "/connect/systems/subscriptions",
+                                             method:   "get"
+      case result
+      when Net::HTTPSuccess
+        activated_caasp_regcodes = all_regcodes.select do |regcode|
+          regcode["name"] =~ /^SUSE Container as a Service Platform/ &&
+            regcode["status"] == "ACTIVE"
+        end
+        # rubocop:disable Style/RescueModifier
+        regcode = activated_caasp_regcodes.first["regcode"] rescue nil
+        # rubocop:enable Style/RescueModifier
+        regcode || raise(MissingRegCodeException)
+      else
+        raise SCCConnectionException
+      end
+    end
+
+    # Performs an HTTP request to the SCC server.
+    #
+    # Returns the response object.
+    def perform_request(endpoint:, method:, data: {})
+      uri = URI.join @smt_url, endpoint
+      req = Net::HTTP.const_get(method.capitalize).new uri
+      req.basic_auth @credentials[:username], @credentials[:password]
+      req["Accept"]       = "application/json; charset=utf-8"
+      req["Content-Type"] = "application/json; charset=utf-8"
+      req.body = data.to_json unless data.blank?
+
+      opts = { open_timeout: 2, use_ssl: uri.scheme == "https" }
+      opts[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if opts[:use_ssl] && @smt_insecure
+      response = Net::HTTP.start(uri.hostname, uri.port, opts) { |http| http.request req }
+      case response
+      when Net::HTTPSuccess
+        return response, JSON.parse(response.body)
+      else
+        return response, nil
+      end
+    rescue *HTTPExceptions::EXCEPTIONS => e
+      raise SCCConnectionException, e
+    end
+  end
+end

--- a/spec/lib/velum/salt_api_spec.rb
+++ b/spec/lib/velum/salt_api_spec.rb
@@ -29,7 +29,7 @@ describe Velum::SaltApi do
   end
 
   context "when a HTTP/socket error happens" do
-    before { allow(Net::HTTP).to receive(:start) { raise Errno::ECONNREFUSED } }
+    before { allow(Net::HTTP).to receive(:start).and_raise(Errno::ECONNREFUSED) }
 
     it "raises SaltConnectionException" do
       expect do

--- a/spec/lib/velum/suse_connect_spec.rb
+++ b/spec/lib/velum/suse_connect_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+require "rails_helper"
+require "velum/suse_connect"
+
+describe Velum::SUSEConnect do
+
+  context "when loading SUSEConnect settings" do
+    context "when the file exists" do
+      before do
+        allow(YAML).to receive(:load_file).with("/run/secrets/SUSEConnect")
+          .and_return("url" => "https://smt.mycompany.com")
+      end
+
+      it "returns the contents unmarshalled" do
+        expect(described_class.smt_config_file_contents(prefix: "/run/secrets")).to(
+          eq("url" => "https://smt.mycompany.com")
+        )
+      end
+    end
+    context "when the file does not exist" do
+      before do
+        allow(YAML).to receive(:load_file).with("/run/secrets/SUSEConnect")
+          .and_raise(Errno::ENOENT)
+      end
+
+      it "returns nil" do
+        expect(described_class.smt_config_file_contents(prefix: "/run/secrets")).to be_nil
+      end
+    end
+  end
+
+  context "smt server set as https://smt.mycompany.com" do
+    before do
+      allow(described_class).to receive(:smt_config_file_contents)
+        .and_return("url" => "https://smt.mycompany.com")
+    end
+
+    it "returns a SUSEConnectConfig with https://smt.mycompany.com as smt_url" do
+      expect(described_class.config.smt_url).to eq("https://smt.mycompany.com")
+    end
+
+    it "returns a SUSEConnectConfig without regcode" do
+      expect(described_class.config.regcode).to be_nil
+    end
+
+    it "returns https://smt.mycompany.com as smt_url" do
+      expect(described_class.smt_url).to eq("https://smt.mycompany.com")
+    end
+
+    it "raises an exception about missing credentials" do
+      expect do
+        described_class.credentials
+      end.to raise_error(Velum::SUSEConnect::MissingCredentialsException)
+    end
+  end
+
+  context "smt server not set (defaults to https://scc.suse.com)" do
+    before do
+      allow(described_class).to receive(:smt_config_file_contents).and_return({})
+    end
+
+    it "returns the SCC server" do
+      expect(described_class.smt_url).to eq("https://scc.suse.com")
+    end
+
+    context "when credentials exist" do
+      before do
+        allow(described_class).to receive(:credentials_file_contents)
+          .and_return("username=username\npassword=password")
+      end
+
+      it "returns a SUSEConnectConfig with https://scc.suse.com as smt_url" do
+        VCR.use_cassette("suse_connect/caasp_registration_active", record: :none) do
+          expect(described_class.config.smt_url).to eq("https://scc.suse.com")
+        end
+      end
+
+      it "returns a SUSEConnectConfig with regcode" do
+        VCR.use_cassette("suse_connect/caasp_registration_active", record: :none) do
+          expect(described_class.config.regcode).not_to be_nil
+        end
+      end
+
+      it "does return SCC credentials" do
+        expect(described_class.credentials).to eq(username: "username",
+                                                  password: "password")
+      end
+    end
+    context "when credentials are missing" do
+      before do
+        allow(described_class).to receive(:credentials_file_contents).and_return(nil)
+      end
+
+      it "asking for config should raise an exception" do
+        expect do
+          described_class.config
+        end.to raise_error(Velum::SUSEConnect::MissingCredentialsException)
+      end
+
+      it "raises an exception about missing credentials" do
+        expect do
+          described_class.credentials
+        end.to raise_error(Velum::SUSEConnect::MissingCredentialsException)
+      end
+    end
+  end
+
+  context "when requesting the regcode for CaaSP product" do
+    let(:suse_connect_client) do
+      described_class.new credentials: {
+        username: "valid_username",
+        password: "valid_password"
+      }
+    end
+
+    context "with connectivity problems with smt service" do
+      before { allow(Net::HTTP).to receive(:start).and_raise(Errno::ECONNREFUSED) }
+
+      it "raises SCCConnectionException" do
+        expect do
+          suse_connect_client.regcode
+        end.to raise_error(Velum::SUSEConnect::SCCConnectionException)
+      end
+    end
+
+    context "with an unexpected response from the SCC service" do
+      before { allow(Net::HTTP).to receive(:start).and_return(Net::HTTPInternalServerError) }
+
+      it "raises SCCConnectionException" do
+        expect do
+          suse_connect_client.regcode
+        end.to raise_error(Velum::SUSEConnect::SCCConnectionException)
+      end
+    end
+
+    context "with valid login information if there a CaaSP registration active" do
+      it "returns the regcode for the product" do
+        VCR.use_cassette("suse_connect/caasp_registration_active", record: :none) do
+          suse_connect_client.regcode
+        end
+      end
+    end
+
+    context "with valid login information if there is no such product" do
+      it "does raise an exception" do
+        VCR.use_cassette("suse_connect/no_caasp_registration_active", record: :none) do
+          expect do
+            suse_connect_client.regcode
+          end.to raise_error(Velum::SUSEConnect::MissingRegCodeException)
+        end
+      end
+    end
+
+    context "with invalid login information" do
+      let(:suse_connect_client) do
+        described_class.new credentials: {
+          username: "invalid_username",
+          password: "invalid_password"
+        }
+      end
+
+      it "does raise an exception" do
+        VCR.use_cassette("suse_connect/invalid_credentials", record: :none) do
+          expect do
+            suse_connect_client.regcode
+          end.to raise_error(Velum::SUSEConnect::SCCConnectionException)
+        end
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/suse_connect/caasp_registration_active.yml
+++ b/spec/vcr_cassettes/suse_connect/caasp_registration_active.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://scc.suse.com/connect/systems/subscriptions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - scc.suse.com
+      Authorization:
+      - Basic U0NDXzJjOTRiOThlM2RiMzQ1MzhhMmNjOGRkZWRlOTQ2MTcxOjJiN2MxOGYyYmE0NzRmYmE=
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 22 Mar 2017 15:46:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Scc-Api-Version:
+      - v4
+      Etag:
+      - W/"6171e1469996c90bd19cd803fe26ccb7"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - XSRF-TOKEN=AYJuU395orJ7i%2BfDK%2BPCOyXpxmQJNmxsgcWCFqUJHDvIIcRPjpCNblBVc8CQPoqEjXjxUf3i7pPjgV0cvMZS0g%3D%3D;
+        path=/; secure
+      - lb_scc=ICPJEBIJ; Expires=Sat, 20-Mar-2027 15:46:53 GMT; Path=/
+      - lb_scc=ICPJEBIJ; Expires=Sat, 20-Mar-2027 15:46:53 GMT; Path=/
+      X-Request-Id:
+      - d66c890a-8fc0-4408-bbd5-429a51829ab8
+      X-Runtime:
+      - '0.086023'
+      Strict-Transport-Security:
+      - max-age=300
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '[{"id":1,"regcode":"thisisavalidregcode","name":"SUSE Container
+        as a Service Platform 1.0 x86_64 subscription","status":"ACTIVE","starts_at":"2017-03-16T14:19:06.641Z","expires_at":"2018-03-11T14:19:06.641Z","system_limit":-1,"systems_count":7,"virtual_count":null,"product_classes":["CAASP_X86"],"systems":[{"id":1,"login":"valid_username","password":"valid_password"},{"id":2,"login":"valid_username","password":"valid_password"},{"id":3,"login":"valid_username","password":"valid_password"},{"id":4,"login":"valid_username","password":"valid_password"},{"id":5,"login":"valid_username","password":"valid_password"},{"id":6,"login":"valid_username","password":"valid_password"},{"id":7,"login":"valid_username","password":"valid_password"}],"product_ids":[1484]}]'
+    http_version:
+  recorded_at: Wed, 22 Mar 2017 15:46:54 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/suse_connect/invalid_credentials.yml
+++ b/spec/vcr_cassettes/suse_connect/invalid_credentials.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://scc.suse.com/connect/systems/subscriptions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - scc.suse.com
+      Authorization:
+      - Basic aW52YWxpZF91c2VybmFtZTppbnZhbGlkX3Bhc3N3b3Jk
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 22 Mar 2017 15:46:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 0d0a6973-af77-4512-893d-06d0f97ccef9
+      X-Runtime:
+      - '0.013165'
+      Strict-Transport-Security:
+      - max-age=300
+      - max-age=31536000
+      Vary:
+      - Accept-encoding
+      Set-Cookie:
+      - lb_scc=ICPJEBIJ; Expires=Sat, 20-Mar-2027 15:46:52 GMT; Path=/
+      - lb_scc=ICPJEBIJ; Expires=Sat, 20-Mar-2027 15:46:52 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"type":"error","error":"Invalid system credentials","localized_error":"Invalid
+        system credentials"}'
+    http_version: 
+  recorded_at: Wed, 22 Mar 2017 15:46:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/suse_connect/no_caasp_registration_active.yml
+++ b/spec/vcr_cassettes/suse_connect/no_caasp_registration_active.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://scc.suse.com/connect/systems/subscriptions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - scc.suse.com
+      Authorization:
+      - Basic U0NDXzJjOTRiOThlM2RiMzQ1MzhhMmNjOGRkZWRlOTQ2MTcxOjJiN2MxOGYyYmE0NzRmYmE=
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 22 Mar 2017 15:46:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Scc-Api-Version:
+      - v4
+      Etag:
+      - W/"6171e1469996c90bd19cd803fe26ccb7"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - XSRF-TOKEN=AYJuU395orJ7i%2BfDK%2BPCOyXpxmQJNmxsgcWCFqUJHDvIIcRPjpCNblBVc8CQPoqEjXjxUf3i7pPjgV0cvMZS0g%3D%3D;
+        path=/; secure
+      - lb_scc=ICPJEBIJ; Expires=Sat, 20-Mar-2027 15:46:53 GMT; Path=/
+      - lb_scc=ICPJEBIJ; Expires=Sat, 20-Mar-2027 15:46:53 GMT; Path=/
+      X-Request-Id:
+      - d66c890a-8fc0-4408-bbd5-429a51829ab8
+      X-Runtime:
+      - '0.086023'
+      Strict-Transport-Security:
+      - max-age=300
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '[{"id":1,"regcode":"thisisavalidregcode","name":"Other x86_64 subscription","status":"ACTIVE","starts_at":"2017-03-16T14:19:06.641Z","expires_at":"2018-03-11T14:19:06.641Z","system_limit":-1,"systems_count":7,"virtual_count":null,"product_classes":["OTHERPRODUCT_X86"],"systems":[{"id":1,"login":"valid_username","password":"valid_password"},{"id":2,"login":"valid_username","password":"valid_password"},{"id":3,"login":"valid_username","password":"valid_password"},{"id":4,"login":"valid_username","password":"valid_password"},{"id":5,"login":"valid_username","password":"valid_password"},{"id":6,"login":"valid_username","password":"valid_password"},{"id":7,"login":"valid_username","password":"valid_password"}],"product_ids":[1484]}]'
+    http_version:
+  recorded_at: Wed, 22 Mar 2017 15:46:54 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This profile will be read by workers during the bootstrapping process
and when adding new workers to the cluster. It will provide the
subscription details of the main installation to the workers.

Here we take into account that we are using our SUSE Secrets fork of
Docker, that mounts `/run/secrets` on every container. This directory
will include `/etc/SUSEConnect` and `/etc/zypp/credentials.d` from the
host mounted inside the container.

- `/run/secrets/SUSEConnect` includes the SMT if any (the default is SCC
  if not provided). If there is a SMT present, the regcode will be empty.

- If we are using SUSE's Customer Center (SCC), we need a regcode, that
  is obtained using the credentials in
  `/run/secrets/credentials.d/SCCcredentials` file, accessing the SCC API
   and checking for an active subscription. Filtering the CaaSP active
   subscription we can fetch the registration code for the subscription
   and serve it.