### PR TITLE
Check retcode return value of the highstate

### DIFF
--- a/app/models/salt_handler/minion_highstate.rb
+++ b/app/models/salt_handler/minion_highstate.rb
@@ -34,7 +34,8 @@ class SaltHandler::MinionHighstate
 
     data = JSON.parse(salt_event.data)
 
-    new_highstate = Minion.highstates[data["success"] ? :applied : :failed]
+    highstate_succeeded = data["success"] && data["retcode"].zero?
+    new_highstate = Minion.highstates[highstate_succeeded ? :applied : :failed]
     # rubocop:disable SkipsModelValidations
     minion.update_column(:highstate, new_highstate)
     # rubocop:enable SkipsModelValidations


### PR DESCRIPTION
Not only the `success` field indicates a successfull highstate
execution, but also the `retcode` field being 0 as a result of the
execution.