### PR TITLE
Generate application base secrets upon startup, and use previously generated base secrets if they exist.

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+ENV["VELUM_SECRETS_DIR"] ||= File.join(Dir.tmpdir, "test_velum_secrets_dir")
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/initializers/file_secrets.rb
+++ b/config/initializers/file_secrets.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# Be sure to restart your server when you modify this file.
+require "velum/file_config"
+app_secrets = Velum::AppSecrets.new(ENV.fetch("VELUM_SECRETS_DIR"))
+Rails.application.secrets.secret_key_base = app_secrets.generate_secret_key_base

--- a/kubernetes/manifest-templates/velum.yaml
+++ b/kubernetes/manifest-templates/velum.yaml
@@ -12,10 +12,10 @@ spec:
     env:
     - name: RAILS_ENV
       value: development
-    - name: SECRET_KEY_BASE
-      value: fc0ece3811c0b1e0118dd7d619b385955e3ed146b37315d67d1c2d201c42531da398941ef27aab42493fff23afcba540390a26db51b5889e96d850a14178aabdc1926c013936a3c41abdbeb696ce440685c5d7be3a6c548434699d526a9e37657a76a43ca975b824905fd949f7e8d50aa1196a58e7e79dcfb08e2e397ee4f7b7
     - name: RAILS_SERVE_STATIC_FILES
       value: "true"
+    - name: VELUM_SECRETS_DIR
+      value: /tmp/velum-secrets
     - name: VELUM_DB_HOST
       value: "127.0.0.1"
     - name: VELUM_DB_PORT
@@ -41,6 +41,8 @@ spec:
     volumeMounts:
       - mountPath: /usr/src/app
         name: velum-source-code
+      - mountPath: /tmp/velum-secrets
+        name: velum-secrets
     command: ["/bin/sh","-c"]
     args: ["bundle exec rails s -b 0.0.0.0 -p 3000 --pid /tmp/puma.pid Puma"]
   - name: velum-event-processor
@@ -50,8 +52,8 @@ spec:
       value: Worker_1
     - name: RAILS_ENV
       value: development
-    - name: SECRET_KEY_BASE
-      value: fc0ece3811c0b1e0118dd7d619b385955e3ed146b37315d67d1c2d201c42531da398941ef27aab42493fff23afcba540390a26db51b5889e96d850a14178aabdc1926c013936a3c41abdbeb696ce440685c5d7be3a6c548434699d526a9e37657a76a43ca975b824905fd949f7e8d50aa1196a58e7e79dcfb08e2e397ee4f7b7
+    - name: VELUM_SECRETS_DIR
+      value: /tmp/velum-secrets
     - name: VELUM_DB_HOST
       value: "127.0.0.1"
     - name: VELUM_DB_PORT
@@ -75,6 +77,8 @@ spec:
     volumeMounts:
       - mountPath: /usr/src/app
         name: velum-source-code
+      - mountPath: /tmp/velum-secrets
+        name: velum-secrets
     command: ["/bin/sh","-c"]
     args: ["bundle exec bin/rake salt:process"]
   - name: velum-mariadb
@@ -86,3 +90,6 @@ spec:
     - name: velum-source-code
       hostPath:
         path: ${project_dir}
+    - name: velum-secrets
+      hostPath:
+        path: "/tmp/velum-secrets"

--- a/lib/velum/file_config.rb
+++ b/lib/velum/file_config.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require "json"
+require "fileutils"
+require "securerandom"
+
+module Velum
+  # Handle IO operations and data serialisation for configuration files under a specific directory.
+  class FileConfig
+    def initialize(base_dir)
+      @base_dir = base_dir
+    end
+
+    # Return true only if the specified file name exists in the configuration base directory.
+    def exist?(file_name)
+      File.exist?(File.join(@base_dir, file_name))
+    end
+
+    # Deserialise JSON text from the specified file into a hash structure and return.
+    def read_hash(file_name)
+      JSON.parse(IO.read(File.join(@base_dir, file_name)))
+    end
+
+    # Serialise the hash structure into JSON text and overwrite the specified file with it.
+    def write_hash(file_name, hash)
+      FileUtils.mkdir_p(@base_dir)
+      IO.write(File.join(@base_dir, file_name), JSON.dump(hash))
+    end
+  end
+
+  # Manage persistent application-wide secret data.
+  class AppSecrets
+    def initialize(base_dir)
+      @files = FileConfig.new(base_dir)
+    end
+
+    # Generate a new random "secret_key_base" value and return.
+    def new_secret_key_base
+      SecureRandom.hex(64)
+    end
+
+    # Return persisted "secret_key_base", or save a new one if persistent value does not exist.
+    def generate_secret_key_base
+      name = "app_secrets.json"
+      return @files.read_hash(name)["base"] if @files.exist?(name)
+      new_base = new_secret_key_base
+      @files.write_hash(name, "base" => new_base)
+      new_base
+    end
+  end
+end

--- a/spec/lib/velum/file_config_spec.rb
+++ b/spec/lib/velum/file_config_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "tempfile"
+require 'fileutils'
+require "velum/file_config"
+
+describe Velum::FileConfig do
+  conf_dir = File.join(Dir.tmpdir, "velum_config_test")
+
+  before do
+    FileUtils::rm_r(conf_dir, :force => true)
+  end
+
+  after do
+    FileUtils::rm_r(conf_dir, :force => true)
+  end
+
+  it "reads and writes hash structures" do
+    conf = Velum::FileConfig.new(conf_dir)
+    expect(conf.exist?("hash")).to eq false
+
+    conf.write_hash("hash", "a"=>1)
+    expect(conf.exist?("hash")).to eq true
+    expect(conf.read_hash("hash")).to eq("a"=>1)
+  end
+end
+
+describe Velum::AppSecrets do
+  conf_dir = File.join(Dir.tmpdir, "velum_app_secrets_test")
+
+  before do
+    FileUtils::rm_r(conf_dir, :force => true)
+  end
+
+  after do
+    FileUtils::rm_r(conf_dir, :force => true)
+  end
+
+  it "generates a unique secret" do
+    app_secrets = Velum::AppSecrets.new(conf_dir)
+    secret1 = app_secrets.new_secret_key_base
+    secret2 = app_secrets.new_secret_key_base
+    expect(secret1).not_to eq secret2
+  end
+
+  it "persist generated application key hex string" do
+    app_secrets = Velum::AppSecrets.new(conf_dir)
+    new_secret = app_secrets.generate_secret_key_base
+    expect(new_secret).not_to eq ""
+    retrieved_secret = app_secrets.generate_secret_key_base
+    expect(retrieved_secret).to eq new_secret
+  end
+end


### PR DESCRIPTION
The following comments from Rafael are addressed:
- "We have inconsistent quotes overall our manifests, but I think absolute paths are always unquoted. Still we would need to improve consistency overall."
- "Here I'd say it's better to use SecureRandom (you need to require it at the top). SecureRandom.hex 64 would do the trick and it's recommended for this kind of purposes."

One comment from Rafael is to be discussed: `test.rb`

"If the `RAILS_ENV` is `test`, we do want to set this envvar? Will there be anything to read at all?"