### PR TITLE
Retrieve host from request

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -36,7 +36,7 @@ class DashboardController < ApplicationController
   # fields that customer uses) and also skips the redirection to the setup process (when a worker
   # asks for the autoyast profile we will either serve it, or return an error).
   def autoyast
-    @controller_node = Socket.gethostname
+    @controller_node = request.host
     begin
       suse_connect_config = Rails.cache.fetch("SUSEConnect_config") do
         Velum::SUSEConnect.config


### PR DESCRIPTION
Since `Socket.gethostname` can be a purely internal hostname (not
exposed to other machines) and since the customer is in charge of
DNS itself, and since `@controller_node` here is going to be used
to provide a reachable salt master hostname for the rest of the
workers, it's better to just use the same hostname the customer used
when added the `autoyast=http://fancy-host.fancy-domain/autoyast`. In
this case we don't care about the internal name `Socket.gethostname`
but about the external name (the customer already used it on their own
request, so we just retrieve it).