### PR TITLE
Remove port from puma configuration

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,10 +8,6 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
 threads threads_count, threads_count
 
-# Specifies the `port` that Puma will listen on to receive requests, default is 3000.
-#
-port        ENV.fetch("PORT") { 3000 }
-
 # Specifies the `environment` that Puma will run in.
 #
 environment ENV.fetch("RAILS_ENV") { "development" }


### PR DESCRIPTION
We are firing puma up with something along the lines:
`bundle exec rails s -b 0.0.0.0 -p 80 --pid /tmp/puma.pid Puma`

In this case, the port is set through an argument to the rails server
command, but with this change on our puma configuration, we override
it, only honoring the `PORT` envvar, or falling back to 3000
otherwise.

Remove this bit from the Puma configuration, since our manifests
include the port as an argument to the rails server command.