### PR TITLE
add init for containers

### DIFF
--- a/bin/check_db.rb
+++ b/bin/check_db.rb
@@ -1,0 +1,22 @@
+# This is a rails runner that will print the status of the database
+# Possible outcomes:
+#
+#   * `DB_READY`: the database has been created and initialized
+#   * `DB_EMPTY`: the database has been created but has not been initialized
+#   * `DB_MISSING`: the database has not been created
+#   * `DB_DOWN`: cannot connect to the database
+
+def database_exists?
+  ActiveRecord::Base.connection
+  if ActiveRecord::Base.connection.table_exists? 'schema_migrations'
+    puts "DB_READY"
+  else
+    puts "DB_EMPTY"
+  end
+rescue ActiveRecord::NoDatabaseError
+  puts "DB_MISSING"
+rescue Mysql2::Error
+  puts "DB_DOWN"
+end
+
+database_exists?

--- a/bin/init
+++ b/bin/init
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This script will setup the database and then start the rails application
+
+set -e
+
+setup_database() {
+  set +e
+
+  TIMEOUT=90
+  COUNT=0
+  RETRY=1
+
+  while [ $RETRY -ne 0 ]; do
+    case $(bundle exec rails r bin/check_db.rb | grep DB) in
+      "DB_DOWN")
+        if [ "$COUNT" -ge "$TIMEOUT" ]; then
+          printf " [FAIL]\n"
+          echo "Timeout reached, exiting with error"
+          exit 1
+        fi
+        echo "Waiting for mariadb to be ready in 5 seconds"
+        sleep 5
+        COUNT=$((COUNT+5))
+        ;;
+      "DB_EMPTY"|"DB_MISSING")
+        # create db, apply schema and seed
+        echo "Initializing database"
+        bundle exec rake db:create
+        bundle exec rake db:schema:load
+        if [ $? -ne 0 ]; then
+            echo "Error at setup time"
+            exit 1
+        fi
+        ;;
+      "DB_READY")
+        echo "Database ready"
+        break
+        ;;
+    esac
+  done
+  set -e
+}
+
+setup_database
+bundle exec rake db:migrate
+bundle exec "rails s -b 0.0.0.0 -p 80 Puma"


### PR DESCRIPTION
add a wrapper script called init that will check if the database has
been configured and, in that case, it will configure it before starting
the rails server.

This script calls db:migrate because this is meant to be run in a container.
When velum is updated, it will be by launching a new container, thus the new
container should run db:migrate.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>