### PR TITLE
Set salt master configuration on the minion on a script

### DIFF
--- a/app/views/dashboard/autoyast.xml.erb
+++ b/app/views/dashboard/autoyast.xml.erb
@@ -1,6 +1,20 @@
 <?xml version="1.0"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <scripts>
+    <chroot-scripts config:type="list">
+      <script>
+        <chrooted config:type="boolean">true</chrooted>
+        <filename>set_salt_master.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+        #!/bin/sh
+        echo "master: <%= @controller_node %>" > /etc/salt/minion.d/master.conf
+        ]]>
+        </source>
+      </script>
+    </chroot-scripts>
+  </scripts>
   <bootloader>
     <global>
       <generic_mbr>true</generic_mbr>
@@ -130,16 +144,4 @@
       <reg_server><%= @suse_smt_url %></reg_server>
     <% end %>
   </suse_register>
-  <files config:type="list">
-    <file>
-      <file_path>/etc/salt/minion.d/master.conf</file_path>
-      <file_contents>
-<![CDATA[
-master: <%= @controller_node %>
-]]>
-      </file_contents>
-      <file_owner>root.root</file_owner>
-      <file_permissions>640</file_permissions>
-    </file>
-  </files>
 </profile>


### PR DESCRIPTION
The files directive is executed on the 2nd YaST stage (which it's
skipped in CaaSP), so the `/etc/salt/minion.d/master.conf` was never
created on the worker nodes.

Let's do the same, but running a script that will create this
configuration file in the 1st YaST stage.