### PR TITLE
Request the ca certificate directly to the CA machine (container)

### DIFF
--- a/lib/velum/kubernetes.rb
+++ b/lib/velum/kubernetes.rb
@@ -11,9 +11,9 @@ module Velum
 
     # Returns the Kubernetes apiserver configuration. It returns a KubeConfig struct.
     def self.kubeconfig
-      _, ca = Velum::Salt.call action:  "mine.get",
-                               targets: "ca",
-                               arg:     ["ca", "x509.get_pem_entries"]
+      _, ca_crt = Velum::Salt.call action:  "cmd.run",
+                                   targets: "ca",
+                                   arg:     "cat /etc/pki/ca.crt"
       _, apiserver_crt = Velum::Salt.call action:      "cmd.run",
                                           targets:     "roles:kube-master",
                                           target_type: "grain",
@@ -24,7 +24,7 @@ module Velum
                                           arg:         "cat /etc/pki/minion.key"
       host = Minion.master.applied.pluck(:hostname).first
       # rubocop:disable Style/RescueModifier
-      ca_crt = ca["return"].first["ca"]["ca"]["/etc/pki/ca.crt"] rescue nil
+      ca_crt = ca_crt["return"].first.values.first rescue nil
       client_crt = apiserver_crt["return"].first.values.first rescue nil
       client_key = apiserver_key["return"].first.values.first rescue nil
       # rubocop:enable Style/RescueModifier


### PR DESCRIPTION
The ca certificate was retrieved from the mine. The mine gets wiped
when the admin node gets rebooted (the salt-master container gets
rebooted). We don't want to wait for the mine to be populated if we
actually have this information in the filesystem.

If an orchestration is run, this information will be automatically
populated on the mine (but we don't want to force that), so we
directly use salt to cat the ca certificate from the ca machine (it's
a container at the moment).