### PR TITLE
Update manifests

### DIFF
--- a/kubernetes/manifest-templates/private.yaml
+++ b/kubernetes/manifest-templates/private.yaml
@@ -7,40 +7,6 @@ metadata:
 spec:
   hostNetwork: false
   containers:
-  - name: velum-event-processor
-    image: opensuse/velum:development
-    env:
-    - name: WORKER_ID
-      value: Worker_1
-    - name: RAILS_ENV
-      value: development
-    - name: VELUM_DB_HOST
-      value:
-    - name: VELUM_DB_USERNAME
-      value: "root"
-    - name: VELUM_DB_PASSWORD
-      value: "salt"
-    - name: VELUM_DB_SOCKET
-      value: /var/run/mysqld/mysqld.sock
-    - name: VELUM_SALT_HOST
-      value:
-    - name: VELUM_SALT_PORT
-      value:
-    - name: VELUM_SALT_USER
-      value:
-    - name: VELUM_KUBERNETES_HOST
-      value:
-    - name: VELUM_KUBERNETES_PORT
-      value:
-    - name: VELUM_KUBERNETES_CERT_DIRECTORY
-      value:
-    volumeMounts:
-      - mountPath: /usr/src/app
-        name: velum-source-code
-      - mountPath: /var/run/mysqld
-        name: mariadb-unix-socket
-    command: ["/bin/sh","-c"]
-    args: ["bundle exec bin/rake salt:process"]
   - name: velum-mariadb
     image: library/mariadb:10.0.29
     env:
@@ -52,36 +18,9 @@ spec:
       - mountPath: /etc/mysql/conf.d
         name: mariadb-config
   volumes:
-    - name: velum-source-code
-      hostPath:
-        path: ${project_dir}
     - name: mariadb-unix-socket
       hostPath:
         path: ${project_dir}/kubernetes/tmp/mariadb-socket
     - name: mariadb-config
       hostPath:
         path: ${project_dir}/kubernetes/mariadb
-    - name: salt-master-config
-      hostPath:
-        path: ${project_dir}/kubernetes/salt/config/master.d
-    - name: salt-master
-      hostPath:
-        path: ${salt_dir}/salt
-    - name: salt-pillar
-      hostPath:
-        path: ${salt_dir}/pillar
-    - name: salt-pillar-vars
-      hostPath:
-        path: ${project_dir}/kubernetes/salt/pillar/vars.sls
-    - name: salt-sock-dir
-      hostPath:
-        path: ${project_dir}/kubernetes/tmp/salt-sock-dir
-    - name: salt-minion-ca-grains
-      hostPath:
-        path: ${project_dir}/kubernetes/salt/grains/ca
-    - name: salt-minion-ca-config
-      hostPath:
-        path: ${project_dir}/kubernetes/salt/config/minion.d-ca/minion.conf
-    - name: salt-minion-ca-signing-policies
-      hostPath:
-        path: ${project_dir}/kubernetes/salt/config/minion.d-ca/signing_policies.conf

--- a/kubernetes/manifest-templates/public.yaml
+++ b/kubernetes/manifest-templates/public.yaml
@@ -77,6 +77,40 @@ spec:
       name: salt-minion-ca-signing-policies
     - mountPath: /etc/salt/grains
       name: salt-minion-ca-grains
+  - name: velum-event-processor
+    image: opensuse/velum:development
+    env:
+    - name: WORKER_ID
+      value: Worker_1
+    - name: RAILS_ENV
+      value: development
+    - name: VELUM_DB_HOST
+      value:
+    - name: VELUM_DB_USERNAME
+      value: "root"
+    - name: VELUM_DB_PASSWORD
+      value: "salt"
+    - name: VELUM_DB_SOCKET
+      value: /var/run/mysqld/mysqld.sock
+    - name: VELUM_SALT_HOST
+      value:
+    - name: VELUM_SALT_PORT
+      value:
+    - name: VELUM_SALT_USER
+      value:
+    - name: VELUM_KUBERNETES_HOST
+      value:
+    - name: VELUM_KUBERNETES_PORT
+      value:
+    - name: VELUM_KUBERNETES_CERT_DIRECTORY
+      value:
+    volumeMounts:
+      - mountPath: /usr/src/app
+        name: velum-source-code
+      - mountPath: /var/run/mysqld
+        name: mariadb-unix-socket
+    command: ["/bin/sh","-c"]
+    args: ["bundle exec bin/rake salt:process"]
   volumes:
     - name: velum-source-code
       hostPath:


### PR DESCRIPTION
Move the event processor to the `public` pod since it will very soon
require to connect to the `salt-api` service in order to fetch grains
from recently registered machines in order to retrieve number of CPUs,
memory, hard disk space...
    
Also cleanup the private manifest that did contain some host paths that
were used by containers that used to be on this private pod.