### PR TITLE
Do not assume minion_id is hostname/fqdn

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -84,7 +84,7 @@ MinionPoller = {
       <tr> \
         <th>" + minion.id +  "</th>\
         <td class='text-center'>" + statusHtml +  "</td>\
-        <td>" + minion.hostname +  "</td>\
+        <td>" + minion.fqdn +  "</td>\
         <td>" + (minion.role || '') +  "</td>\
         <td class='text-center'>" + masterHtml + "</td>\
       </tr>";
@@ -105,7 +105,7 @@ MinionPoller = {
     return "\
       <tr> \
         <th>" + minion.id +  "</th>\
-        <td>" + minion.hostname +  "</td>\
+        <td>" + minion.fqdn +  "</td>\
         <td class='text-center'>" + masterHtml + "</td>\
       </tr>";
   }

--- a/app/models/salt_handler/minion_highstate.rb
+++ b/app/models/salt_handler/minion_highstate.rb
@@ -27,7 +27,7 @@ class SaltHandler::MinionHighstate
     # Salt probably tries to make sure it stays applied. We don't need to process
     # those events. We only need to process a highstate if one is pending.
     minion = Minion.find_by(
-      hostname:  minion_id,
+      minion_id: minion_id,
       highstate: Minion.highstates[:pending]
     )
     return false unless minion

--- a/app/models/salt_handler/minion_start.rb
+++ b/app/models/salt_handler/minion_start.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "velum/salt"
 
 # This class is responsible to handle the salt events with tag "minion_start".
 # When such an event occurs, we want the minion to be saved in our database
@@ -22,7 +23,9 @@ class SaltHandler::MinionStart
     # Ignore the ca minion. It shouldn't be used as part of the k8s cluster.
     return false if parsed_data["id"] == "ca"
 
-    # false if a minion with this hostname already exists (uniqueness validation)
-    Minion.new(hostname: parsed_data["id"]).save
+    minion_info = Velum::Salt.minions[parsed_data["id"]]
+
+    # false if a minion with this minion_id or fqdn already exists (uniqueness validation)
+    Minion.new(minion_id: parsed_data["id"], fqdn: minion_info["fqdn"]).save
   end
 end

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -26,7 +26,7 @@ h1 Nodes
             th
               | #{m.id}
             td
-              | #{m.hostname}
+              | #{m.fqdn}
             td.text-center
               = radio_button_tag "roles[master]", m.id
     .clearfix.text-right.steps-container

--- a/db/migrate/20170111154919_create_minions.rb
+++ b/db/migrate/20170111154919_create_minions.rb
@@ -1,9 +1,11 @@
 class CreateMinions < ActiveRecord::Migration
   def change
     create_table :minions do |t|
-      t.string :hostname
+      t.string :minion_id
+      t.string :fqdn
       t.timestamps
     end
-    add_index :minions, :hostname
+    add_index :minions, :minion_id
+    add_index :minions, :fqdn
   end
 end

--- a/db/migrate/20170124141701_add_uniq_index_on_minions_id.rb
+++ b/db/migrate/20170124141701_add_uniq_index_on_minions_id.rb
@@ -1,11 +1,15 @@
 class AddUniqIndexOnMinionsId < ActiveRecord::Migration
   def up
-    remove_index :minions, :hostname
-    add_index :minions, :hostname, unique: true
+    remove_index :minions, :minion_id
+    remove_index :minions, :fqdn
+    add_index :minions, :minion_id, unique: true
+    add_index :minions, :fqdn, unique: true
   end
 
   def down
-    remove_index :minions, :hostname
-    add_index :minions, :hostname
+    remove_index :minions, :minion_id
+    remove_index :minions, :fqdn
+    add_index :minions, :minion_id
+    add_index :minions, :fqdn
   end
 end

--- a/db/migrate/20170124170136_add_role_to_minions.rb
+++ b/db/migrate/20170124170136_add_role_to_minions.rb
@@ -1,5 +1,5 @@
 class AddRoleToMinions < ActiveRecord::Migration
   def change
-    add_column :minions, :role, :integer, index: true, after: :hostname
+    add_column :minions, :role, :integer, index: true, after: :fqdn
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,14 +21,16 @@ ActiveRecord::Schema.define(version: 20170227152008) do
   add_index "jids", ["jid"], name: "jid", unique: true, using: :btree
 
   create_table "minions", force: :cascade do |t|
-    t.string   "hostname",   limit: 255
+    t.string   "minion_id",  limit: 255
+    t.string   "fqdn",       limit: 255
     t.integer  "role",       limit: 4
     t.integer  "highstate",  limit: 4,   default: 0
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "minions", ["hostname"], name: "index_minions_on_hostname", unique: true, using: :btree
+  add_index "minions", ["fqdn"], name: "index_minions_on_fqdn", unique: true, using: :btree
+  add_index "minions", ["minion_id"], name: "index_minions_on_minion_id", unique: true, using: :btree
 
   create_table "pillars", force: :cascade do |t|
     t.string   "minion_id",  limit: 255

--- a/kubernetes/manifest-templates/public.yaml
+++ b/kubernetes/manifest-templates/public.yaml
@@ -95,11 +95,13 @@ spec:
     - name: VELUM_DB_SOCKET
       value: /var/run/mysqld/mysqld.sock
     - name: VELUM_SALT_HOST
-      value:
+      value: "127.0.0.1"
     - name: VELUM_SALT_PORT
-      value:
+      value: "8000"
     - name: VELUM_SALT_USER
-      value:
+      value: saltapi
+    - name: VELUM_SALT_PASSWORD
+      value: saltapi
     - name: VELUM_KUBERNETES_HOST
       value:
     - name: VELUM_KUBERNETES_PORT

--- a/lib/velum/kubernetes.rb
+++ b/lib/velum/kubernetes.rb
@@ -22,7 +22,7 @@ module Velum
                                           targets:     "roles:kube-master",
                                           target_type: "grain",
                                           arg:         "cat /etc/pki/minion.key"
-      host = Minion.master.applied.pluck(:hostname).first
+      host = Minion.master.applied.pluck(:fqdn).first
       # rubocop:disable Style/RescueModifier
       ca_crt = ca_crt["return"].first.values.first rescue nil
       client_crt = apiserver_crt["return"].first.values.first rescue nil

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe SetupController, type: :controller do
     let(:salt) { Velum::Salt }
     before do
       sign_in user
-      Minion.create! [{ hostname: "master" }, { hostname: "minion0" }]
+      Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "master" },
+                      { minion_id: SecureRandom.hex, fqdn: "minion0" }]
     end
 
     context "when the minion doesn't exist" do
@@ -62,7 +63,7 @@ RSpec.describe SetupController, type: :controller do
       it "sets the other roles to minions" do
         post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
         # check that all minions are set to minion role
-        expect(Minion.where("hostname REGEXP ?", "minion*").map(&:role).uniq).to eq ["minion"]
+        expect(Minion.where("fqdn REGEXP ?", "minion*").map(&:role).uniq).to eq ["minion"]
       end
 
       it "calls the orchestration" do
@@ -115,7 +116,8 @@ RSpec.describe SetupController, type: :controller do
     let(:salt) { Velum::Salt }
     before do
       sign_in user
-      Minion.create! [{ hostname: "master" }, { hostname: "minion0" }]
+      Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "master" },
+                      { minion_id: SecureRandom.hex, fqdn: "minion0" }]
       request.accept = "application/json"
     end
 
@@ -144,7 +146,7 @@ RSpec.describe SetupController, type: :controller do
       it "sets the other roles to minions" do
         post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
         # check that all minions are set to minion role
-        expect(Minion.where("hostname REGEXP ?", "minion*").map(&:role).uniq).to eq ["minion"]
+        expect(Minion.where("fqdn REGEXP ?", "minion*").map(&:role).uniq).to eq ["minion"]
       end
 
       it "calls the orchestration" do

--- a/spec/factories/minions_factory.rb
+++ b/spec/factories/minions_factory.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :minion do
-    sequence(:hostname) { |n| "hostname#{n}.domain.com" }
+    sequence(:minion_id) { SecureRandom.hex }
+    sequence(:fqdn)      { |n| "hostname#{n}.domain.com" }
   end
   factory :master_minion, parent: :minion do
     role :master

--- a/spec/factories/salt_event_factory.rb
+++ b/spec/factories/salt_event_factory.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :salt_event do
-    tag "salt/minion/MyMinion/start"
+    tag "salt/minion/3bcb66a2e50646dcabf779e50c6f3232/start"
     data({ "_stamp" => "2017-01-23T15:32:32.913621", "pretag" => nil,
-          "cmd" => "_minion_event", "tag" => "salt/minion/MyMinion/start",
-          "data" => "Minion MyMinion started at Mon Jan 23 15:32:32 2017",
-          "id" => "MyMinion" }.to_json)
+          "cmd" => "_minion_event", "tag" => "salt/minion/3bcb66a2e50646dcabf779e50c6f3232/start",
+          "data" => "Minion 3bcb66a2e50646dcabf779e50c6f3232 started at Mon Jan 23 15:32:32 2017",
+          "id" => "3bcb66a2e50646dcabf779e50c6f3232" }.to_json)
     master_id "TheMaster"
     alter_time Time.current
   end

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -11,7 +11,7 @@ feature "Bootstrap cluster feature" do
 
   scenario "It shows the minions as soon as they register", js: true do
     expect(page).not_to have_content("minion0.k8s.local")
-    Minion.create!(hostname: "minion0.k8s.local")
+    Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local")
     using_wait_time 10 do
       expect(page).to have_content("minion0.k8s.local")
     end

--- a/spec/features/monitoring_feature_spec.rb
+++ b/spec/features/monitoring_feature_spec.rb
@@ -6,7 +6,7 @@ feature "Monitoring feature" do
 
   before do
     login_as user, scope: :user
-    Minion.create!(hostname: "minion0.k8s.local", role: "master")
+    Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master")
     visit authenticated_root_path
   end
 
@@ -27,7 +27,7 @@ feature "Monitoring feature" do
       expect(page).not_to have_content(
         "nodes are available but have not been added to the cluster yet"
       )
-      Minion.create!(hostname: "minion1.k8s.local", role: nil)
+      Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local", role: nil)
       expect(page).to have_content(
         "1 new nodes are available but have not been added to the cluster yet"
       )

--- a/spec/models/minion_spec.rb
+++ b/spec/models/minion_spec.rb
@@ -2,15 +2,15 @@
 require "rails_helper"
 
 describe Minion do
-  it { is_expected.to validate_uniqueness_of(:hostname) }
+  it { is_expected.to validate_uniqueness_of(:fqdn) }
 
   # rubocop:disable RSpec/ExampleLength
   describe ".assign_roles!" do
     let(:minions) do
       described_class.create! [
-        { hostname: "master.example.com" },
-        { hostname: "minion0.example.com" },
-        { hostname: "minion1.example.com" }
+        { minion_id: SecureRandom.hex, fqdn: "master.example.com" },
+        { minion_id: SecureRandom.hex, fqdn: "minion0.example.com" },
+        { minion_id: SecureRandom.hex, fqdn: "minion1.example.com" }
       ]
     end
 
@@ -19,7 +19,7 @@ describe Minion do
         minions
       end
 
-      it "returns a hash with the master hostname false" do
+      it "returns a hash with the master fqdn false" do
         # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
           .with(:master).and_return(false)
@@ -34,9 +34,9 @@ describe Minion do
             }
           )
         ).to eq(
-          minions[0].hostname => false,
-          minions[1].hostname => true,
-          minions[2].hostname => true
+          minions[0].minion_id => false,
+          minions[1].minion_id => true,
+          minions[2].minion_id => true
         )
       end
     end
@@ -46,7 +46,7 @@ describe Minion do
         minions
       end
 
-      it "returns a hash with the minion hostnames false" do
+      it "returns a hash with the minion fqdns false" do
         # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
           .with(:master).and_return(true)
@@ -61,9 +61,9 @@ describe Minion do
             }
           )
         ).to eq(
-          minions[0].hostname => true,
-          minions[1].hostname => false,
-          minions[2].hostname => false
+          minions[0].minion_id => true,
+          minions[1].minion_id => false,
+          minions[2].minion_id => false
         )
       end
     end
@@ -73,7 +73,7 @@ describe Minion do
         minions
       end
 
-      it "returns a hash with the default_role hostname false" do
+      it "returns a hash with the default_role fqdn false" do
         # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(:master)
           .and_return(true)
@@ -90,9 +90,9 @@ describe Minion do
             }, default_role: :another_role
           )
         ).to eq(
-          minions[0].hostname => true,
-          minions[1].hostname => true,
-          minions[2].hostname => false
+          minions[0].minion_id => true,
+          minions[1].minion_id => true,
+          minions[2].minion_id => false
         )
       end
     end
@@ -162,9 +162,9 @@ describe Minion do
       )
 
       expect(roles).to eq(
-        minions[0].hostname => true,
-        minions[1].hostname => true,
-        minions[2].hostname => true
+        minions[0].minion_id => true,
+        minions[1].minion_id => true,
+        minions[2].minion_id => true
       )
     end
   end

--- a/spec/models/salt_event_spec.rb
+++ b/spec/models/salt_event_spec.rb
@@ -22,20 +22,24 @@ describe SaltEvent do
       event_data = {
         "_stamp" => "2017-01-24T13:30:20.794326",
         "pretag" => nil, "cmd" => "_minion_event", "tag" => "minion_start",
-        "data" => "Minion MyMinion started at Tue Jan 24 13:30:20 2017",
-        "id" => "MyMinion"
+        "data" => "Minion 3bcb66a2e50646dcabf779e50c6f3232 started at Tue Jan 24 13:30:20 2017",
+        "id" => "3bcb66a2e50646dcabf779e50c6f3232"
       }.to_json
 
       FactoryGirl.create(:salt_event, tag: "minion_start", data: event_data)
     end
 
+    # rubocop:disable RSpec/ExampleLength
     it "processes new-minion events" do
       new_minion_event
 
-      expect do
-        described_class.process_next_event(worker_id: "MyWorker")
-      end.to change { Minion.where(hostname: "MyMinion").count }.by(1)
+      VCR.use_cassette("salt/process_event", record: :none) do
+        expect do
+          described_class.process_next_event(worker_id: "MyWorker")
+        end.to change { Minion.where(minion_id: "3bcb66a2e50646dcabf779e50c6f3232").count }.by(1)
+      end
     end
+    # rubocop:enable RSpec/ExampleLength
 
     it "processes irrelevant events" do
       FactoryGirl.create(:salt_event, tag: "nobody_cares_about_this_event")

--- a/spec/models/salt_handler/minion_highstate_spec.rb
+++ b/spec/models/salt_handler/minion_highstate_spec.rb
@@ -12,12 +12,12 @@ describe SaltHandler::MinionHighstate do
       "cmd"      => "_return",
       "_stamp"   => "2017-02-01T13:43:00.348440",
       "fun"      => "state.highstate",
-      "id"       => "minion0.k8s.local",
+      "id"       => "3bcb66a2e50646dcabf779e50c6f3232",
       "out"      => "highstate"
     }.to_json
 
     FactoryGirl.create(:salt_event,
-      tag:  "salt/job/20170201134101334637/ret/minion0.k8s.local",
+      tag:  "salt/job/20170201134101334637/ret/3bcb66a2e50646dcabf779e50c6f3232",
       data: event_data)
   end
 
@@ -25,37 +25,46 @@ describe SaltHandler::MinionHighstate do
     let(:handler) { described_class.new(salt_event) }
     let(:matching_minion) do
       FactoryGirl.create(:minion,
-                         hostname:  "minion0.k8s.local",
+                         minion_id: "3bcb66a2e50646dcabf779e50c6f3232",
+                         fqdn:      "minion0.k8s.local",
                          highstate: :pending)
     end
     let(:matching_minion_with_no_pending_highstate) do
       FactoryGirl.create(:minion,
-                         hostname:  "minion0.k8s.local",
+                         minion_id: "18e57e95171048bfbd6346a22d4bbb2a",
+                         fqdn:      "minion1.k8s.local",
                          highstate: :failed)
     end
 
     it "returns false if no matching Minion exists" do
-      expect(handler.process_event).to be(false)
+      VCR.use_cassette("salt/process_event", record: :none) do
+        expect(handler.process_event).to be(false)
+      end
     end
 
     it "returns false if a matching Minion exists but has no pending highstate" do
       matching_minion_with_no_pending_highstate
 
-      expect(handler.process_event).to be(false)
+      VCR.use_cassette("salt/process_event", record: :none) do
+        expect(handler.process_event).to be(false)
+      end
     end
 
     it "return true if a matching Minion with pending highstate exists" do
       matching_minion
 
-      expect(handler.process_event).to be(true)
+      VCR.use_cassette("salt/process_event", record: :none) do
+        expect(handler.process_event).to be(true)
+      end
     end
 
     it "updates the matching Minion's highstate column" do
       matching_minion
 
-      expect { handler.process_event }
-        .to change { matching_minion.reload.highstate }.from("pending")
-        .to("applied")
+      VCR.use_cassette("salt/process_event", record: :none) do
+        expect { handler.process_event }
+          .to change { matching_minion.reload.highstate }.from("pending").to("applied")
+      end
     end
   end
 end

--- a/spec/vcr_cassettes/salt/process_event.yml
+++ b/spec/vcr_cassettes/salt/process_event.yml
@@ -1,0 +1,231 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"saltapi","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '217'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Tue, 18 Apr 2017 18:01:02 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Auth-Token:
+      - 049022ab20df203870eb7dc01a9abd3d41ea18fc
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=049022ab20df203870eb7dc01a9abd3d41ea18fc; expires=Wed, 19 Apr 2017
+        04:01:02 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
+        "start": 1492538462.490156, "token": "049022ab20df203870eb7dc01a9abd3d41ea18fc",
+        "expire": 1492581662.490157, "user": "saltapi", "eauth": "pam"}]}'
+    http_version: 
+  recorded_at: Tue, 18 Apr 2017 18:01:02 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:8000/minions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Auth-Token:
+      - 049022ab20df203870eb7dc01a9abd3d41ea18fc
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '10245'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Cache-Control:
+      - private
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Tue, 18 Apr 2017 18:01:02 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=049022ab20df203870eb7dc01a9abd3d41ea18fc; expires=Wed, 19 Apr 2017
+        04:01:02 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"ca": {"kernel": "Linux", "domain": "k8s.local", "uid":
+        0, "zmqversion": "4.1.2", "kernelrelease": "4.10.8-1-default", "pythonpath":
+        ["/usr/bin", "/usr/lib/python27.zip", "/usr/lib64/python2.7", "/usr/lib64/python2.7/plat-linux2",
+        "/usr/lib64/python2.7/lib-tk", "/usr/lib64/python2.7/lib-old", "/usr/lib64/python2.7/lib-dynload",
+        "/usr/lib64/python2.7/site-packages", "/usr/local/lib64/python2.7/site-packages",
+        "/usr/local/lib/python2.7/site-packages", "/usr/lib/python2.7/site-packages"],
+        "pid": 12, "ip_interfaces": {"docker0": ["172.17.0.1"], "lo": ["127.0.0.1"],
+        "tun0": ["10.163.1.166"], "virbr0-ni": [], "veth9c957": [], "virbr0": ["192.168.122.1"],
+        "enp0s31f6": ["192.168.1.106"], "wlp1s0": ["192.168.1.108", "fe80::4cab:8580:fb16:905e"]},
+        "groupname": "root", "shell": "/bin/sh", "mem_total": 7866, "saltversioninfo":
+        [2016, 3, 4, 0], "host": "freedom", "SSDs": ["sda"], "id": "ca", "osrelease":
+        "42.2", "ps": "ps -efH", "server_id": 610049290, "ip6_interfaces": {"docker0":
+        [], "lo": [], "tun0": [], "virbr0-ni": [], "veth9c957": [], "virbr0": [],
+        "enp0s31f6": [], "wlp1s0": ["fe80::4cab:8580:fb16:905e"]}, "num_cpus": 4,
+        "hwaddr_interfaces": {"docker0": "02:42:2A:B5:6B:7E", "veth9c957": "D6:16:09:A5:97:52",
+        "tun0": "00", "virbr0-ni": "52:54:00:F7:A3:90", "virbr0": "52:54:00:F7:A3:90",
+        "enp0s31f6": "28:F1:0E:45:3A:45", "wlp1s0": "E4:A7:A0:01:44:B0"}, "init":
+        "unknown", "ip4_interfaces": {"docker0": ["172.17.0.1"], "lo": ["127.0.0.1"],
+        "tun0": ["10.163.1.166"], "virbr0-ni": [], "veth9c957": [], "virbr0": ["192.168.122.1"],
+        "enp0s31f6": ["192.168.1.106"], "wlp1s0": ["192.168.1.108"]}, "osfullname":
+        "Leap", "gid": 0, "master": "localhost", "ipv4": ["10.163.1.166", "127.0.0.1",
+        "172.17.0.1", "192.168.1.106", "192.168.1.108", "192.168.122.1"], "dns": {"nameservers":
+        ["10.160.2.88", "10.160.0.1"], "domain": "", "ip4_nameservers": ["10.160.2.88",
+        "10.160.0.1"], "search": [], "ip6_nameservers": []}, "ipv6": ["fe80::4cab:8580:fb16:905e"],
+        "cpu_flags": ["fpu", "vme", "de", "pse", "tsc", "msr", "pae", "mce", "cx8",
+        "apic", "sep", "mtrr", "pge", "mca", "cmov", "pat", "pse36", "clflush", "dts",
+        "acpi", "mmx", "fxsr", "sse", "sse2", "ss", "ht", "tm", "pbe", "syscall",
+        "nx", "pdpe1gb", "rdtscp", "lm", "constant_tsc", "art", "arch_perfmon", "pebs",
+        "bts", "rep_good", "nopl", "xtopology", "nonstop_tsc", "aperfmperf", "tsc_known_freq",
+        "pni", "pclmulqdq", "dtes64", "monitor", "ds_cpl", "vmx", "smx", "est", "tm2",
+        "ssse3", "sdbg", "fma", "cx16", "xtpr", "pdcm", "pcid", "sse4_1", "sse4_2",
+        "x2apic", "movbe", "popcnt", "tsc_deadline_timer", "aes", "xsave", "avx",
+        "f16c", "rdrand", "lahf_lm", "abm", "3dnowprefetch", "epb", "intel_pt", "tpr_shadow",
+        "vnmi", "flexpriority", "ept", "vpid", "fsgsbase", "tsc_adjust", "bmi1", "hle",
+        "avx2", "smep", "bmi2", "erms", "invpcid", "rtm", "mpx", "rdseed", "adx",
+        "smap", "clflushopt", "xsaveopt", "xsavec", "xgetbv1", "xsaves", "dtherm",
+        "ida", "arat", "pln", "pts", "hwp", "hwp_notify", "hwp_act_window", "hwp_epp"],
+        "localhost": "freedom", "lsb_distrib_id": "openSUSE Leap", "username": "root",
+        "fqdn_ip4": [], "fqdn_ip6": [], "nodename": "freedom", "saltversion": "2016.3.4",
+        "lsb_distrib_release": "42.2", "systemd": {"version": "228", "features": "+PAM
+        -AUDIT +SELINUX -IMA +APPARMOR -SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT
+        -GNUTLS +ACL +XZ -LZ4 +SECCOMP +BLKID -ELFUTILS +KMOD -IDN"}, "saltpath":
+        "/usr/lib/python2.7/site-packages/salt", "osmajorrelease": "42", "os_family":
+        "Suse", "oscodename": "openSUSE Leap 42.2", "osfinger": "Leap-42", "pythonversion":
+        [2, 7, 12, "final", 0], "roles": ["ca"], "num_gpus": 0, "virtual": "physical",
+        "disks": [], "cpu_model": "Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz", "fqdn":
+        "freedom", "pythonexecutable": "/usr/bin/python", "osarch": "x86_64", "cpuarch":
+        "x86_64", "lsb_distrib_codename": "openSUSE Leap 42.2", "osrelease_info":
+        [42, 2], "locale_info": {"detectedencoding": "ascii", "defaultlanguage": null,
+        "defaultencoding": null}, "gpus": [], "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "machine_id": "f17d6d03329ac77ed5a2364858da1d46", "os": "SUSE"}, "18e57e95171048bfbd6346a22d4bbb2a":
+        {"biosversion": "1.0.0-prebuilt.qemu-project.org", "kernel": "Linux", "domain":
+        "k8s.local", "uid": 0, "zmqversion": "4.0.4", "kernelrelease": "4.4.52-1-default",
+        "pythonpath": ["/usr/bin", "/usr/lib/python27.zip", "/usr/lib64/python2.7",
+        "/usr/lib64/python2.7/plat-linux2", "/usr/lib64/python2.7/lib-tk", "/usr/lib64/python2.7/lib-old",
+        "/usr/lib64/python2.7/lib-dynload", "/usr/lib64/python2.7/site-packages",
+        "/usr/local/lib64/python2.7/site-packages", "/usr/local/lib/python2.7/site-packages",
+        "/usr/lib/python2.7/site-packages"], "pid": 2061, "ip_interfaces": {"lo":
+        ["127.0.0.1", "::1"], "eth0": ["10.17.3.252", "fe80::b8a3:d1ff:fe51:522b"]},
+        "groupname": "root", "shell": "/bin/sh", "mem_total": 1999, "saltversioninfo":
+        [2016, 11, 3, 0], "osmajorrelease": "1", "SSDs": [], "id": "18e57e95171048bfbd6346a22d4bbb2a",
+        "osrelease": "1.0", "ps": "ps -efH", "server_id": 1191278123, "uuid": "18e57e95-1710-48bf-bd63-46a22d4bbb2a",
+        "ip6_interfaces": {"lo": ["::1"], "eth0": ["fe80::b8a3:d1ff:fe51:522b"]},
+        "num_cpus": 1, "hwaddr_interfaces": {"lo": "00:00:00:00:00:00", "eth0": "ba:a3:d1:51:52:2b"},
+        "init": "systemd", "ip4_interfaces": {"lo": ["127.0.0.1"], "eth0": ["10.17.3.252"]},
+        "osfullname": "CAASP", "gid": 0, "master": "192.168.1.106", "ipv4": ["10.17.3.252",
+        "127.0.0.1"], "dns": {"domain": "", "sortlist": [], "nameservers": ["10.17.3.1"],
+        "ip4_nameservers": ["10.17.3.1"], "search": ["k8s.local"], "ip6_nameservers":
+        [], "options": []}, "ipv6": ["::1", "fe80::b8a3:d1ff:fe51:522b"], "cpu_flags":
+        ["fpu", "de", "pse", "tsc", "msr", "pae", "mce", "cx8", "apic", "sep", "mtrr",
+        "pge", "mca", "cmov", "pse36", "clflush", "mmx", "fxsr", "sse", "sse2", "syscall",
+        "nx", "lm", "rep_good", "nopl", "xtopology", "pni", "cx16", "x2apic", "hypervisor",
+        "lahf_lm"], "localhost": "minion1", "lsb_distrib_id": "CAASP", "username":
+        "root", "fqdn_ip4": ["10.17.3.252"], "saltpath": "/usr/lib/python2.7/site-packages/salt",
+        "fqdn_ip6": [], "nodename": "minion1", "saltversion": "2016.11.3", "lsb_distrib_release":
+        "1.0", "systemd": {"version": "228", "features": "+PAM -AUDIT +SELINUX -IMA
+        +APPARMOR -SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT -GNUTLS +ACL +XZ -LZ4
+        +SECCOMP +BLKID -ELFUTILS +KMOD -IDN"}, "biosreleasedate": "04/01/2014", "host":
+        "minion1", "os_family": "Suse", "oscodename": "SUSE Container as a Service
+        Platform 1.0", "osfinger": "CAASP-1", "pythonversion": [2, 7, 13, "final",
+        0], "manufacturer": "QEMU", "num_gpus": 0, "virtual": "kvm", "disks": ["sr0",
+        "vda"], "cpu_model": "QEMU Virtual CPU version 2.5+", "fqdn": "minion1.k8s.local",
+        "pythonexecutable": "/usr/bin/python", "productname": "Standard PC (i440FX
+        + PIIX, 1996)", "osarch": "x86_64", "cpuarch": "x86_64", "lsb_distrib_codename":
+        "SUSE Container as a Service Platform 1.0", "osrelease_info": [1, 0], "locale_info":
+        {"detectedencoding": "UTF-8", "defaultlanguage": "en_US", "defaultencoding":
+        "UTF-8"}, "gpus": [], "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "machine_id": "18e57e95171048bfbd6346a22d4bbb2a", "os": "SUSE"}, "3bcb66a2e50646dcabf779e50c6f3232":
+        {"biosversion": "1.0.0-prebuilt.qemu-project.org", "kernel": "Linux", "domain":
+        "k8s.local", "uid": 0, "zmqversion": "4.0.4", "kernelrelease": "4.4.52-1-default",
+        "pythonpath": ["/usr/bin", "/usr/lib/python27.zip", "/usr/lib64/python2.7",
+        "/usr/lib64/python2.7/plat-linux2", "/usr/lib64/python2.7/lib-tk", "/usr/lib64/python2.7/lib-old",
+        "/usr/lib64/python2.7/lib-dynload", "/usr/lib64/python2.7/site-packages",
+        "/usr/local/lib64/python2.7/site-packages", "/usr/local/lib/python2.7/site-packages",
+        "/usr/lib/python2.7/site-packages"], "pid": 2082, "ip_interfaces": {"lo":
+        ["127.0.0.1", "::1"], "eth0": ["10.17.3.221", "fe80::1835:caff:fe0c:aca8"]},
+        "groupname": "root", "shell": "/bin/sh", "mem_total": 1999, "saltversioninfo":
+        [2016, 11, 3, 0], "osmajorrelease": "1", "SSDs": [], "id": "3bcb66a2e50646dcabf779e50c6f3232",
+        "osrelease": "1.0", "ps": "ps -efH", "server_id": 29583293, "uuid": "3bcb66a2-e506-46dc-abf7-79e50c6f3232",
+        "ip6_interfaces": {"lo": ["::1"], "eth0": ["fe80::1835:caff:fe0c:aca8"]},
+        "num_cpus": 1, "hwaddr_interfaces": {"lo": "00:00:00:00:00:00", "eth0": "1a:35:ca:0c:ac:a8"},
+        "init": "systemd", "ip4_interfaces": {"lo": ["127.0.0.1"], "eth0": ["10.17.3.221"]},
+        "osfullname": "CAASP", "gid": 0, "master": "192.168.1.106", "ipv4": ["10.17.3.221",
+        "127.0.0.1"], "dns": {"domain": "", "sortlist": [], "nameservers": ["10.17.3.1"],
+        "ip4_nameservers": ["10.17.3.1"], "search": ["k8s.local"], "ip6_nameservers":
+        [], "options": []}, "ipv6": ["::1", "fe80::1835:caff:fe0c:aca8"], "cpu_flags":
+        ["fpu", "de", "pse", "tsc", "msr", "pae", "mce", "cx8", "apic", "sep", "mtrr",
+        "pge", "mca", "cmov", "pse36", "clflush", "mmx", "fxsr", "sse", "sse2", "syscall",
+        "nx", "lm", "rep_good", "nopl", "xtopology", "pni", "cx16", "x2apic", "hypervisor",
+        "lahf_lm"], "localhost": "minion0", "lsb_distrib_id": "CAASP", "username":
+        "root", "fqdn_ip4": ["10.17.3.221"], "saltpath": "/usr/lib/python2.7/site-packages/salt",
+        "fqdn_ip6": [], "nodename": "minion0", "saltversion": "2016.11.3", "lsb_distrib_release":
+        "1.0", "systemd": {"version": "228", "features": "+PAM -AUDIT +SELINUX -IMA
+        +APPARMOR -SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT -GNUTLS +ACL +XZ -LZ4
+        +SECCOMP +BLKID -ELFUTILS +KMOD -IDN"}, "biosreleasedate": "04/01/2014", "host":
+        "minion0", "os_family": "Suse", "oscodename": "SUSE Container as a Service
+        Platform 1.0", "osfinger": "CAASP-1", "pythonversion": [2, 7, 13, "final",
+        0], "manufacturer": "QEMU", "num_gpus": 0, "virtual": "kvm", "disks": ["sr0",
+        "vda"], "cpu_model": "QEMU Virtual CPU version 2.5+", "fqdn": "minion0.k8s.local",
+        "pythonexecutable": "/usr/bin/python", "productname": "Standard PC (i440FX
+        + PIIX, 1996)", "osarch": "x86_64", "cpuarch": "x86_64", "lsb_distrib_codename":
+        "SUSE Container as a Service Platform 1.0", "osrelease_info": [1, 0], "locale_info":
+        {"detectedencoding": "UTF-8", "defaultlanguage": "en_US", "defaultencoding":
+        "UTF-8"}, "gpus": [], "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "machine_id": "3bcb66a2e50646dcabf779e50c6f3232", "os": "SUSE"}}]}'
+    http_version: 
+  recorded_at: Tue, 18 Apr 2017 18:01:02 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
With this change we:

* Rename hostname to fqdn. Feels more correct.
* Do not assume on the salt part that the minion_id is the hostname/fqdn
* Explicitly save minion_id as a column, as well as fqdn as another column
* We will use minion_id internally to talk to salt, but show hostname, and
  probably other properties [that we can cache in the very near future as
  columns] like number of cores, memory, disk...


## Depends on
https://github.com/kubic-project/salt/pull/40