### PR TITLE
Added NTP configuration for nodes in autoyast.xml

### DIFF
--- a/app/views/dashboard/autoyast.xml.erb
+++ b/app/views/dashboard/autoyast.xml.erb
@@ -13,6 +13,17 @@
         ]]>
         </source>
       </script>
+      <script>
+        <chrooted config:type="boolean">true</chrooted>
+        <filename>configure_timesyncd.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+        #!/bin/sh
+        sed -i -e 's|#NTP=.*|NTP=<%= @controller_node %>|g' /etc/systemd/timesyncd.conf
+        timedatectl set-ntp true
+        ]]>
+        </source>
+      </script>
     </chroot-scripts>
   </scripts>
   <bootloader>
@@ -123,6 +134,7 @@
         <service>issue-generator</service>
         <service>issue-add-ssh-keys</service>
         <service>salt-minion</service>
+        <service>systemd-timesyncd</service>
       </enable>
     </services>
   </services-manager>


### PR DESCRIPTION
Implement the changes suggested by @thkukuk in the `autoyast.xml` template for configuring NTP in the minions.

(see [this Trello card](https://trello.com/c/Orzhm7rZ))