### PR TITLE
Cleaning folders that can be problematic

### DIFF
--- a/kubernetes/cleanup
+++ b/kubernetes/cleanup
@@ -2,5 +2,11 @@
 
 log()   { echo ">>> $1" ; }
 
+[[ -d manifest-templates ]] || { echo >&2 "Please run this script from within the kubernetes folder"; exit 1; }
+
 log "Cleaning up old containers"
-docker ps -a | grep k8s | awk '{print $1}' | xargs docker rm -vf
+for i in `docker ps -a | grep k8s | awk '{print $1}'`; do docker rm -vf $i; done
+
+log "Cleaning the tmp and manifests folders"
+sudo rm -rf tmp/* manifests/* 
+git checkout tmp/ manifests/*

--- a/kubernetes/start
+++ b/kubernetes/start
@@ -30,7 +30,7 @@ while (( $interactive_mode == 1)) ; do
   esac
 done
 
-./cleanup || true
+./cleanup
 
 default_interface=$(awk '$2 == 00000000 { print $1 }' /proc/net/route)
 ip_address=$(ip addr show $default_interface | awk '$1 == "inet" {print $2}' | cut -f1 -d/)


### PR DESCRIPTION
I was having a lot of trouble starting a cluster because I ended up with
two SaltStack files that were supposed to be UNIX sockets, but were
regular files instead.

Making the cleanup script clear out the manifests/ and tmp/ folders

Also making a change to the cleanup script suggested in #104