### PR TITLE
Explicitly ask for the dashboard location

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -18,11 +18,9 @@ class SetupController < ApplicationController
     status = {}
 
     respond_to do |format|
-      auto_pillars = { dashboard: request.host }
-
       Pillar.all_pillars.each do |key, pillar_key|
         pillar = Pillar.find_or_initialize_by pillar: pillar_key
-        pillar.value = settings_params[key] || auto_pillars[key]
+        pillar.value = settings_params[key]
         next if pillar.save
         status[:failed_pillar] ||= []
         status[:failed_pillar].push(pillar.value)
@@ -40,6 +38,10 @@ class SetupController < ApplicationController
         format.json { head :ok }
       end
     end
+  end
+
+  def worker_bootstrap
+    @controller_node = Pillar.value pillar: :dashboard
   end
 
   def discovery

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -8,6 +8,9 @@
 h1 Initial CaaSP Configuration
 = form_for :settings, url: setup_path, method: :put do |f|
   .form-group
+    = f.label :dashboard, "Dashboard location"
+    = f.text_field :dashboard, value: (Pillar.value(pillar: :dashboard) || request.host), class: "form-control"
+  .form-group
     = f.label :company_name, "Company Name"
     = f.text_field :company_name, value: Pillar.value(pillar: :company_name), class: "form-control", required: true
   .form-group

--- a/app/views/setup/worker_bootstrap.html.slim
+++ b/app/views/setup/worker_bootstrap.html.slim
@@ -14,19 +14,19 @@ p
   |  This process leverages AutoYaST and is (almost) fully automated.
   |  In case you are not familiar with it, you can find more information about AutoYaST in the&nbsp;
   a href="https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html" official documentation.
-  |  The automatic installation gets invoked by adding <strong>autoyast=#{autoyast_url}</strong> to the kernel parameter list.
+  |  The automatic installation gets invoked by adding <strong>autoyast=#{autoyast_url host: @controller_node}</strong> to the kernel parameter list.
   |  If you aren't under a PXE environment you can also use <strong>netsetup=dhcp</strong> kernel parameter for the network to be automatically configured using a reachable DHCP server.
   |  As installation media, you can use the very same image you bootstrapped the admin node with.
 
   |  A ready to use AutoYaST profile has already been generated for you during the bootstrap of the admin node.
   |  Bootstrap all the nodes you want to make part of this platform by adding the following boot parameter
-  |  <strong>autoyast=#{autoyast_url}</strong>
+  |  <strong>autoyast=#{autoyast_url host: @controller_node}</strong>
 
 h2 Tips
 p
   | You don't need to boot each node by hand. More information on how to embed an AutoYaST profile in your PXE environment is available&nbsp;
   a href="https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#bootmedium.pxe" here
-  | . Where <strong>#{autoyast_url}</strong> is the real, generated path to the AutoYaST profile served by the dashboard.
+  | . Where <strong>#{autoyast_url host: @controller_node}</strong> is the real, generated path to the AutoYaST profile served by the dashboard.
 
 .clearfix.text-right.steps-container
   = link_to "Back", setup_path, class: "btn btn-danger"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,4 +8,5 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+Pillar.create pillar: "dashboard", value: "localhost"
 User.create email: "test@test.com", password: "password"

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -63,9 +63,22 @@ RSpec.describe DashboardController, type: :controller do
 
   describe "GET /autoyast" do
     before do
+      Pillar.create pillar: "dashboard", value: "localhost"
       allow(Velum::SUSEConnect).to receive(:config).and_return(
         Velum::SUSEConnect::SUSEConnectConfig.new("https://scc.suse.com", "validregcode")
       )
+    end
+
+    context "no dashboard pillar is set" do
+      before do
+        Pillar.where(pillar: "dashboard").destroy_all
+      end
+
+      it "renders a 503 status and a blank page" do
+        get :autoyast
+        expect(response.body).to be_blank
+        expect(response.status).to eq 503
+      end
     end
 
     it "if not logged in serves the autoyast content" do

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe SetupController, type: :controller do
     end
   end
 
+  describe "GET /setup/worker-bootstrap via HTML" do
+    before do
+      sign_in user
+      Pillar.create pillar: "dashboard", value: "localhost"
+    end
+
+    it "sets @controller_node to dashboard pillar value" do
+      get :worker_bootstrap
+      expect(assigns(:controller_node)).to eq("localhost")
+    end
+  end
+
   describe "POST /setup/bootstrap via HTML" do
     let(:salt) { Velum::Salt }
     before do
@@ -197,12 +209,6 @@ RSpec.describe SetupController, type: :controller do
         state:        "Bavaria",
         city:         "Nuremberg"
       }
-    end
-
-    it 'assigns the Pillar "dashboard" to the host of the request automatically' do
-      sign_in user
-      put :configure, settings: settings_params
-      expect(Pillar.find_by(pillar: "dashboard").value).to eq("test.host")
     end
 
     context "when the user configures the cluster successfully" do


### PR DESCRIPTION
It will come with a reasonable default, but the person bootstrapping
the cluster will have the chance to set a different value so the
rest of the machines that will form part of the cluster will use this
reference during the bootstrapping process.

This modifies the workflow of the bootstrapping. To avoid problems, now
it's required for the customer/user to fill in all the first step
information in velum (registering first) for the autoyast profile to be
served (since it will contain a reference to the salt-master that will be
set on the rest of the machines). This way, the reference to the salt-master
on the autoyast profile, as well as the reference to the administration node
during the bootstrapping phase will be the one the customer/user set,
intead of being inferred from how the customer/user visited velum.

Until this first step of the setup is completed (dashboard reachable
location by the rest of the cluster for autoyast and salt) it won't be
possible to bring up new nodes (the autoyast profile will not be served, so
they will just raise an error in the YaST UI saying they can't retrieve
the autoyast configuration, since a 503 error will be returned).

Fixes bsc#1032461
Fixes bsc#1031605