### PR TITLE
Internally support selection of multiple masters

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -10,7 +10,9 @@ MinionPoller = {
       dataType: "json",
       success: function(data) {
         var rendered = "";
-        MinionPoller.selectedMaster = $("input[name='roles[master]']:checked").val();
+        MinionPoller.selectedMasters = $("input[name='roles[master][]']:checked").map(function() {
+          return parseInt($( this ).val());
+        }).get();
 
         // depending on the url we might have these data:
         // when monitoring:
@@ -72,12 +74,12 @@ MinionPoller = {
         break;
     }
 
-    if ((MinionPoller.selectedMaster && MinionPoller.selectedMaster == minion.id) || minion.role == "master") {
+    if ((MinionPoller.selectedMasters && MinionPoller.selectedMasters.indexOf(minion.id) != -1) || minion.role == "master") {
       checked =  "checked";
     } else {
       checked = '';
     }
-    masterHtml = '<input name="roles[master]" id="roles_master_' + minion.id +
+    masterHtml = '<input name="roles[master][]" id="roles_master_' + minion.id +
       '" value="' + minion.id + '" type="radio" disabled="" ' + checked + '>';
 
     return "\
@@ -94,12 +96,12 @@ MinionPoller = {
     var masterHtml;
     var checked;
 
-    if (MinionPoller.selectedMaster && MinionPoller.selectedMaster == minion.id) {
+    if (MinionPoller.selectedMasters && MinionPoller.selectedMasters.indexOf(minion.id) != -1) {
       checked = "checked";
     } else {
       checked = '';
     }
-    masterHtml = '<input name="roles[master]" id="roles_master_' + minion.id +
+    masterHtml = '<input name="roles[master][]" id="roles_master_' + minion.id +
       '" value="' + minion.id + '" type="radio" ' + checked + '>';
 
     return "\

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -7,7 +7,7 @@ require "velum/salt"
 # welcoming, setting certain general settings, master selection, discovery and
 # bootstrapping
 class SetupController < ApplicationController
-  rescue_from Minion::NonExistingMinion, with: :minion_not_found
+  rescue_from Minion::NonExistingNode, with: :node_not_found
 
   skip_before_action :redirect_to_setup
   before_action :redirect_to_dashboard
@@ -90,7 +90,7 @@ class SetupController < ApplicationController
     assigned.select { |_name, success| !success }.keys.join(", ")
   end
 
-  def minion_not_found(exception)
+  def node_not_found(exception)
     respond_to do |format|
       format.html do
         flash[:error] = exception.message

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -28,7 +28,7 @@ h1 Nodes
             td
               | #{m.fqdn}
             td.text-center
-              = radio_button_tag "roles[master]", m.id
+              = radio_button_tag "roles[master][]", m.id
     .clearfix.text-right.steps-container
       = link_to "Back", setup_worker_bootstrap_path, class: "btn btn-danger"
       = submit_tag "Bootstrap cluster", id: "bootstrap", class: "btn btn-primary"

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SetupController, type: :controller do
 
     context "when the minion doesn't exist" do
       it "renders an error with not_found" do
-        post :bootstrap, roles: { master: 9999999 }
+        post :bootstrap, roles: { master: [9999999] }
         expect(flash[:error]).to be_present
         expect(response.redirect_url).to eq "http://test.host/setup"
       end
@@ -67,24 +67,24 @@ RSpec.describe SetupController, type: :controller do
       end
 
       it "sets the master" do
-        post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
         # check that all minions are set to minion role
         expect(Minion.first.role).to eq "master"
       end
 
       it "sets the other roles to minions" do
-        post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
         # check that all minions are set to minion role
         expect(Minion.where("fqdn REGEXP ?", "minion*").map(&:role).uniq).to eq ["minion"]
       end
 
       it "calls the orchestration" do
-        post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
         expect(salt).to have_received(:orchestrate)
       end
 
       it "gets redirected to the list of nodes" do
-        post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
         expect(response.redirect_url).to eq "http://test.host/"
         expect(response.status).to eq 302
       end
@@ -100,13 +100,13 @@ RSpec.describe SetupController, type: :controller do
       end
 
       it "gets redirected to the discovery page" do
-        post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
         expect(flash[:error]).to be_present
         expect(response.redirect_url).to eq "http://test.host/setup/discovery"
       end
 
       it "doesn't call the orchestration" do
-        post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
         expect(Velum::Salt).to have_received(:orchestrate).exactly(0).times
       end
     end
@@ -135,7 +135,7 @@ RSpec.describe SetupController, type: :controller do
 
     context "when the minion doesn't exist" do
       it "renders an error with not_found" do
-        post :bootstrap, roles: { master: 9999999 }
+        post :bootstrap, roles: { master: [9999999] }
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -150,19 +150,19 @@ RSpec.describe SetupController, type: :controller do
       end
 
       it "sets the master" do
-        post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
         # check that all minions are set to minion role
         expect(Minion.first.role).to eq "master"
       end
 
       it "sets the other roles to minions" do
-        post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
         # check that all minions are set to minion role
         expect(Minion.where("fqdn REGEXP ?", "minion*").map(&:role).uniq).to eq ["minion"]
       end
 
       it "calls the orchestration" do
-        post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
         expect(salt).to have_received(:orchestrate)
       end
     end
@@ -177,12 +177,12 @@ RSpec.describe SetupController, type: :controller do
       end
 
       it "returns unprocessable entity" do
-        post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it "doesn't call the orchestration" do
-        post :bootstrap, roles: { master: Minion.first.id, minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
         expect(Velum::Salt).to have_received(:orchestrate).exactly(0).times
       end
     end

--- a/spec/models/minion_spec.rb
+++ b/spec/models/minion_spec.rb
@@ -29,7 +29,7 @@ describe Minion do
         expect(
           described_class.assign_roles!(
             roles: {
-              master: described_class.first.id,
+              master: [described_class.first.id],
               minion: described_class.all[1..-1].map(&:id)
             }
           )
@@ -56,7 +56,7 @@ describe Minion do
         expect(
           described_class.assign_roles!(
             roles: {
-              master: described_class.first.id,
+              master: [described_class.first.id],
               minion: described_class.all[1..-1].map(&:id)
             }
           )
@@ -85,7 +85,7 @@ describe Minion do
         expect(
           described_class.assign_roles!(
             roles: {
-              master: described_class.first.id,
+              master: [described_class.first.id],
               minion: described_class.all[1..-2].map(&:id)
             }, default_role: :another_role
           )
@@ -108,7 +108,10 @@ describe Minion do
 
       it "assigns the default role to the rest of the available minions" do
         described_class.assign_roles!(
-          roles: { master: described_class.first.id, minion: described_class.all[1..-1].map(&:id) }
+          roles: {
+            master: [described_class.first.id],
+            minion: described_class.all[1..-1].map(&:id)
+          }
         )
 
         expect(described_class.all.map(&:role).sort).to eq(["master", "minion", "minion"])
@@ -126,7 +129,10 @@ describe Minion do
 
       it "assigns the minion role to the rest of the available minions" do
         described_class.assign_roles!(
-          roles: { master: described_class.first.id, minion: described_class.all[1..-1].map(&:id) }
+          roles: {
+            master: [described_class.first.id],
+            minion: described_class.all[1..-1].map(&:id)
+          }
         )
 
         expect(described_class.all.map(&:role)).to eq(["master", "minion", "minion"])
@@ -144,7 +150,10 @@ describe Minion do
 
       it "assigns the minion role to specific minions" do
         described_class.assign_roles!(
-          roles: { master: described_class.first.id, minion: described_class.all[1..-1].map(&:id) }
+          roles: {
+            master: [described_class.first.id],
+            minion: described_class.all[1..-1].map(&:id)
+          }
         )
 
         expect(described_class.all.last.role).to eq("minion")
@@ -158,7 +167,7 @@ describe Minion do
         .and_return(true)
       # rubocop:enable RSpec/AnyInstance
       roles = described_class.assign_roles!(
-        roles: { master: described_class.first.id, minion: described_class.all[1..-1].map(&:id) }
+        roles: { master: [described_class.first.id], minion: described_class.all[1..-1].map(&:id) }
       )
 
       expect(roles).to eq(


### PR DESCRIPTION
This change allows for the selection of multiple masters when bootstrapping
the cluster. Note that, this commit does not expose this functionality in
the UI. Allowing users to choose multiple masters will come further down the
line once HA deployments are working etc.

A second commit (which will land on a different branch) will expose this in the
UI for dev/test purposes.