### PR TITLE
Add /var/log/pods/* to cleanup script

### DIFF
--- a/kubernetes/cleanup
+++ b/kubernetes/cleanup
@@ -8,5 +8,6 @@ log "Cleaning up old containers"
 for i in `docker ps -a | grep k8s | awk '{print $1}'`; do docker rm -vf $i; done
 
 log "Cleaning the tmp and manifests folders"
-sudo rm -rf tmp/* manifests/* 
+sudo rm -rf tmp/* manifests/*
+sudo rm -rf /var/log/pods/*
 git checkout tmp/ manifests/*


### PR DESCRIPTION
Re running the dev environment can fail to start from time to time if the old log files for the pods are still in place.