### PR TITLE
discovery: only send json responses to AJAX calls

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -8,6 +8,7 @@ MinionPoller = {
     $.ajax({
       url: $('.nodes-container').data('url'),
       dataType: "json",
+      cache: false,
       success: function(data) {
         var rendered = "";
         MinionPoller.selectedMasters = $("input[name='roles[master][]']:checked").map(function() {


### PR DESCRIPTION
When pressing the back/forward buttons in Chrome it sometimes returned a
JSON response for the HTML version. To avoid this, let's be explicit on
this and only allow JSON responses for requests ending with ".json"
(rails convention).

bsc#103174

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>