### PR TITLE
Set .bundle/config location by stripping the buildroot automatically

### DIFF
--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -81,6 +81,9 @@ bundle list
 # deploy gems
 bundle install --retry=3 --local --deployment --path=%{buildroot}/usr/local/velum/bundle
 
+# remove buildroot from bundler path
+bundle config --local path /usr/local/velum/bundle
+
 # install bundler
 gem install --no-rdoc --no-ri --install-dir %{buildroot}/usr/local/velum/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
 


### PR DESCRIPTION
Set `.bundle/config` location by stripping the buildroot automatically added when installing with `--path`