### PR TITLE
WIP: Ensure that gem dependencies versions are the same in development/test and production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,52 +21,30 @@ gem "gravatar_image_tag"
 gem "devise"
 gem "kubeclient", "~> 2.3.0"
 
-# Assets group.
-#
-# Do not set it or set it to no when precompiling the assets.
-#
-# IGNORE_ASSETS="no" RAILS_ENV=production bundle exec rake assets:precompile
-#
-# Set IGNORE_ASSETS to YES when creating the Gemfile.lock for
-# production after having precompiled the assets
-# run:
-#
-# IGNORE_ASSETS=yes bundle list
+gem "sass-rails", "~> 5.0"
+gem "bootstrap-sass"
+gem "uglifier", ">= 1.3.0"
 
-unless ENV["IGNORE_ASSETS"] == "yes"
-  gem "sass-rails", "~> 5.0"
-  gem "bootstrap-sass"
-  gem "uglifier", ">= 1.3.0"
+group :development, :test do
+  gem "rspec-rails"
+  gem "rubocop", "~> 0.46", require: false
+  gem "brakeman", require: false
+  gem "database_cleaner"
+  gem "pry"
+  gem "pry-nav"
 end
 
-# In order to create the Gemfile.lock required for packaging
-# meaning that it should contain only the production packages
-# run:
-#
-# PACKAGING=yes bundle list
-
-unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
-  group :development, :test do
-    gem "rspec-rails"
-    gem "rubocop", "~> 0.46", require: false
-    gem "brakeman", require: false
-    gem "database_cleaner"
-    gem "pry"
-    gem "pry-nav"
-  end
-
-  group :test do
-    gem "shoulda"
-    gem "vcr"
-    gem "webmock", require: false
-    gem "simplecov", require: false
-    gem "capybara"
-    gem "poltergeist", require: false
-    gem "json-schema"
-    gem "timecop"
-    gem "codeclimate-test-reporter", "~> 1.0.0", require: nil
-    gem "factory_girl_rails"
-    gem "ffaker"
-    gem "rubocop-rspec"
-  end
+group :test do
+  gem "shoulda"
+  gem "vcr"
+  gem "webmock", require: false
+  gem "simplecov", require: false
+  gem "capybara"
+  gem "poltergeist", require: false
+  gem "json-schema"
+  gem "timecop"
+  gem "codeclimate-test-reporter", "~> 1.0.0", require: nil
+  gem "factory_girl_rails"
+  gem "ffaker"
+  gem "rubocop-rspec"
 end

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -65,11 +65,9 @@ pushd build/$packagename-$branch/
           patch -p1 < $p || exit -1
       done
   fi
-  echo "generate the Gemfile.lock for packaging"
   export BUNDLE_GEMFILE=$PWD/Gemfile
-  cp Gemfile.lock Gemfile.lock.orig
   bundle config build.nokogiri --use-system-libraries
-  PACKAGING=yes bundle install --retry=3 --no-deployment
+  bundle install --retry=3 --no-deployment
   grep "git-review" Gemfile.lock
   if [ $? == 0 ];then
     echo "DEBUG: ohoh something went wrong and you have devel packages"

--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -68,7 +68,7 @@ __PATCHEXECS__
 
 %build
 
-install -d vendor/cache %{buildroot}/usr/share/velum/bundle
+install -d vendor/cache %{buildroot}/usr/local/velum
 cp %{_libdir}/ruby/gems/%{rb_ver}/cache/*.gem vendor/cache
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 export PACKAGING=yes
@@ -79,7 +79,7 @@ export IGNORE_ASSETS=yes
 bundle list
 
 # deploy gems
-bundle install --retry=3 --local --deployment --path=%{buildroot}/usr/share/velum/bundle
+bundle install --retry=3 --local --deployment --path=%{buildroot}/usr/local/velum
 
 # install bundler
 gem install --no-rdoc --no-ri --install-dir %{buildroot}/usr/share/velum/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem

--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -81,9 +81,6 @@ bundle list
 # deploy gems
 bundle install --retry=3 --local --deployment --path=%{buildroot}/usr/share/velum/bundle
 
-# remove buildroot from bundler path
-bundle config --local path /usr/share/velum/bundle
-
 # install bundler
 gem install --no-rdoc --no-ri --install-dir %{buildroot}/usr/share/velum/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
 

--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -68,7 +68,7 @@ __PATCHEXECS__
 
 %build
 
-install -d vendor/cache %{buildroot}/usr/local/velum
+install -d vendor/cache
 cp %{_libdir}/ruby/gems/%{rb_ver}/cache/*.gem vendor/cache
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 export PACKAGING=yes
@@ -79,10 +79,10 @@ export IGNORE_ASSETS=yes
 bundle list
 
 # deploy gems
-bundle install --retry=3 --local --deployment --path=%{buildroot}/usr/local/velum
+bundle install --retry=3 --local --deployment
 
 # install bundler
-gem install --no-rdoc --no-ri --install-dir %{buildroot}/usr/share/velum/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
+gem install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
 
 rm -rf vendor/cache
 
@@ -101,7 +101,6 @@ mkdir %{buildroot}/%{velumdir}/tmp
 rm -rf %{buildroot}/%{velumdir}/Gemfile.lock.orig
 
 %fdupes %{buildroot}/%{velumdir}
-%fdupes %{buildroot}/usr/share/velum
 
 %pre
 
@@ -114,7 +113,6 @@ rm -rf %{buildroot}/%{velumdir}/Gemfile.lock.orig
 %files
 %defattr(-,root,root)
 %{velumdir}
-/usr/share/velum
 %exclude %{velumdir}/spec
 %doc %{velumdir}/README.md
 %doc %{velumdir}/LICENSE

--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -71,9 +71,7 @@ __PATCHEXECS__
 install -d vendor/cache
 cp %{_libdir}/ruby/gems/%{rb_ver}/cache/*.gem vendor/cache
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=1
-export PACKAGING=yes
 VELUM_SECRETS_DIR=%{buildroot}/%{velumdir}/tmp RAILS_ENV=production bundle exec rake assets:precompile
-export IGNORE_ASSETS=yes
 
 # run bundle list to redo the Gemfile.lock
 bundle list


### PR DESCRIPTION
By removing code conditionals on the Gemfile we ensure that a restriction
that (dis)appears in production don't shift dependencies versions. Is one
of the good points of bundler, that we can use groups to avoid installing
unnecessary gems in certain environments, but the versions of the gems
are the same both in development/test and production.

This makes bug easier to reproduce if they are related to dependencies.
We can still use groups to only install the groups that we want, or
discard groups that we won't need (--without development test in production
for instance). But we are sure that the installed gems are always the same
versions in all environments.