### PR TITLE
packaging: build velum as noarch

### DIFF
--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -56,6 +56,7 @@ __RUBYGEMS_BUILD_REQUIRES__
 
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildArch:      noarch
 
 %description
 velum is the dashboard for CaasP to manage and deploy kubernetes clusters on top of MicroOS


### PR DESCRIPTION
there's nothing architecture-specific about the velum package
and we can't build for all arches if we deposit files under /usr/share
which is reserved for architecture independent files

Signed-off-by: Maximilian Meister <mmeister@suse.de>