### PR TITLE
[WIP] Move to init containers

### DIFF
--- a/kubernetes/manifest-templates/public.yaml
+++ b/kubernetes/manifest-templates/public.yaml
@@ -16,7 +16,7 @@ spec:
     - name: MARIADB_SOCKET
       value: /var/run/mysqld/mysqld.sock
     command: ["sh", "-c"]
-    args: ["until mysqladmin -p\"${MYSQL_ROOT_PASSWORD}\" -S \"${MARIADB_SOCKET}\" ping; do echo 'Database not online yet, waiting...' && sleep 3; done"]
+    args: ["ls && until mysqladmin -p\"${MYSQL_ROOT_PASSWORD}\" -S \"${MARIADB_SOCKET}\" ping; do echo 'Database not online yet, waiting...' && sleep 3; done"]
     volumeMounts:
       - mountPath: /var/run/mysqld
         name: mariadb-unix-socket

--- a/kubernetes/manifest-templates/public.yaml
+++ b/kubernetes/manifest-templates/public.yaml
@@ -13,7 +13,10 @@ spec:
     env:
     - name: MYSQL_ROOT_PASSWORD
       value: "salt"
-    command: ["sh", "-c", "ls -ltr && until mysqladmin -p\"${MYSQL_ROOT_PASSWORD}\" -S /var/run/mysqld/mysqld.sock ping; do echo 'Database not online yet, waiting...' && sleep 3; done"]
+    - name: MARIADB_SOCKET
+      value: /var/run/mysqld/mysqld.sock
+    command: ["sh", "-c"]
+    args: ["until mysqladmin -p\"${MYSQL_ROOT_PASSWORD}\" -S \"${MARIADB_SOCKET}\" ping; do echo 'Database not online yet, waiting...' && sleep 3; done"]
     volumeMounts:
       - mountPath: /var/run/mysqld
         name: mariadb-unix-socket
@@ -29,8 +32,6 @@ spec:
       value: "true"
     - name: VELUM_PORT
       value: "3000"
-    - name: VELUM_DB_HOST
-      value:
     - name: VELUM_DB_USERNAME
       value: "root"
     - name: VELUM_DB_PASSWORD
@@ -45,13 +46,8 @@ spec:
       value: saltapi
     - name: VELUM_SALT_PASSWORD
       value: saltapi
-    - name: VELUM_KUBERNETES_HOST
-      value:
-    - name: VELUM_KUBERNETES_PORT
-      value:
-    - name: VELUM_KUBERNETES_CERT_DIRECTORY
-      value:
-    command: ["/bin/sh", "-c", "bundle exec rake db:create && bundle exec rake db:schema:load && bundle exec rake db:migrate"]
+    command: ["/bin/sh", "-c"]
+    args: ["bundle exec rake db:create && bundle exec rake db:schema:load && bundle exec rake db:migrate"]
     volumeMounts:
       - mountPath: /usr/src/app
         name: velum-source-code

--- a/kubernetes/manifest-templates/public.yaml
+++ b/kubernetes/manifest-templates/public.yaml
@@ -6,6 +6,59 @@ metadata:
     name: velum-public
 spec:
   hostNetwork: true
+  initContainers:
+  - name: init-mariadb
+    image: library/mariadb:10.0.29
+    imagePullPolicy: IfNotPresent
+    env:
+    - name: MYSQL_ROOT_PASSWORD
+      value: "salt"
+    command: ["sh", "-c", "ls -ltr && until mysqladmin -p\"${MYSQL_ROOT_PASSWORD}\" -S /var/run/mysqld/mysqld.sock ping; do echo 'Database not online yet, waiting...' && sleep 3; done"]
+    volumeMounts:
+      - mountPath: /var/run/mysqld
+        name: mariadb-unix-socket
+  - name: init-rake-setup
+    image: opensuse/velum:development
+    imagePullPolicy: IfNotPresent
+    env:
+    - name: RAILS_ENV
+      value: development
+    - name: VELUM_SECRETS_DIR
+      value: /var/lib/misc/velum-secrets
+    - name: RAILS_SERVE_STATIC_FILES
+      value: "true"
+    - name: VELUM_PORT
+      value: "3000"
+    - name: VELUM_DB_HOST
+      value:
+    - name: VELUM_DB_USERNAME
+      value: "root"
+    - name: VELUM_DB_PASSWORD
+      value: "salt"
+    - name: VELUM_DB_SOCKET
+      value: /var/run/mysqld/mysqld.sock
+    - name: VELUM_SALT_HOST
+      value: "127.0.0.1"
+    - name: VELUM_SALT_PORT
+      value: "8000"
+    - name: VELUM_SALT_USER
+      value: saltapi
+    - name: VELUM_SALT_PASSWORD
+      value: saltapi
+    - name: VELUM_KUBERNETES_HOST
+      value:
+    - name: VELUM_KUBERNETES_PORT
+      value:
+    - name: VELUM_KUBERNETES_CERT_DIRECTORY
+      value:
+    command: ["/bin/sh", "-c", "bundle exec rake db:create && bundle exec rake db:schema:load && bundle exec rake db:migrate"]
+    volumeMounts:
+      - mountPath: /usr/src/app
+        name: velum-source-code
+      - mountPath: /var/lib/misc/velum-secrets
+        name: velum-secrets
+      - mountPath: /var/run/mysqld
+        name: mariadb-unix-socket
   containers:
   - name: salt-master
     image: opensuse/salt-master:boron
@@ -67,16 +120,7 @@ spec:
         name: velum-secrets
       - mountPath: /var/run/mysqld
         name: mariadb-unix-socket
-    command: ["/bin/sh","-c"]
-    args: ["bin/init"]
-    command: ['sh', '-c', 'echo']
-  initContainers:
-  - name: init-mariadb
-    image: codeflavor/nspawn-toolbox:latest
-    command: ['mysqladmin', '-s', '/var/run/mysqld/mysqld.sock', 'ping']
-    volumeMounts:
-      - mountPath: /var/run/mysqld
-        name: mariadb-unix-socket
+    command: ["/bin/sh", "-c", "bundle exec rails s -b 0.0.0.0 -p $VELUM_PORT --pid /tmp/puma.pid Puma"]
   - name: salt-api
     image: opensuse/salt-api:boron
     imagePullPolicy: Always

--- a/kubernetes/manifest-templates/public.yaml
+++ b/kubernetes/manifest-templates/public.yaml
@@ -69,6 +69,14 @@ spec:
         name: mariadb-unix-socket
     command: ["/bin/sh","-c"]
     args: ["bin/init"]
+    command: ['sh', '-c', 'echo']
+  initContainers:
+  - name: init-mariadb
+    image: codeflavor/nspawn-toolbox:latest
+    command: ['mysqladmin', '-s', '/var/run/mysqld/mysqld.sock', 'ping']
+    volumeMounts:
+      - mountPath: /var/run/mysqld
+        name: mariadb-unix-socket
   - name: salt-api
     image: opensuse/salt-api:boron
     imagePullPolicy: Always

--- a/kubernetes/mariadb/skip-networking.cnf
+++ b/kubernetes/mariadb/skip-networking.cnf
@@ -1,1 +1,2 @@
+[mysqld]
 skip-networking


### PR DESCRIPTION
This change will take advantage of kubernetes init containers for setting up velum
What this means is that 
a) no application containers are started before the checks inside the init containers are done
b) once the database is up, in the second init container, we execute `bundle exec rake db:create && bundle exec rake db:schema:load && bundle exec rake db:migrate` before we start the `velum-event-processor`. This solves the current issue with the even-processor crashing and restarting because it can't reach the database.  
We can now ditch the `init` script together with showing the page. I think we can also ditch any other checks that we do.

This is here, and not in the caasp-manifests repo because it's meant to be a test for now, since i'm not sure what else it would impact.
It's a work in progress because, for the life of me, i can't understand why the check at https://github.com/kubic-project/velum/compare/master...PI-Victor:move_to_init_container?expand=1#diff-f1f577cbb090fc9738404e4d85e9c1ddR19 fails with 
```shell
https://github.com/kubic-project/velum/compare/master...PI-Victor:move_to_init_container?expand=1#diff-f1f577cbb090fc9738404e4d85e9c1ddR19
```
unless i put a different command before the execution of the `until`.
I didn't add the removal of the init script and other checks because i'm not sure if we use it for anything else.