### PR TITLE
autoyast: create /var/lib/docker partition (bsc#1034942)

### DIFF
--- a/app/views/dashboard/autoyast.xml.erb
+++ b/app/views/dashboard/autoyast.xml.erb
@@ -50,9 +50,24 @@
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>
-   <partitioning config:type="list">
+  <partitioning config:type="list">
     <drive>
       <use>all</use>
+      <partitions config:type="list">
+        <partition>
+          <mount>/</mount>
+          <size>30gb</size>
+        </partition>
+        <partition>
+          <mount>swap</mount>
+          <size>auto</size>
+        </partition>
+        <partition>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <mount>/var/lib/docker</mount>
+          <size>max</size>
+        </partition>
+      </partitions>
     </drive>
   </partitioning>
   <ssh_import>


### PR DESCRIPTION
fixes https://bugzilla.suse.com/show_bug.cgi?id=1034942

Signed-off-by: Maximilian Meister <mmeister@suse.de>