### PR TITLE
Fixed footer overlapping elements

### DIFF
--- a/app/assets/stylesheets/velum_general.scss
+++ b/app/assets/stylesheets/velum_general.scss
@@ -11,6 +11,7 @@ body {
     background-color: $velum-container-bg;
     min-height: 100%;
     position: relative;
+    padding-bottom: 45px;
 
     header .col-xs-12 {
         background-color: $velum-header-bg ;


### PR DESCRIPTION
If a page didn't fit users screen height, the footer overlaps any
element since its position is absolute to .container element.

An example of that was the "Next" button on initial configuration form.

See bsc#1041440