### PR TITLE
UI: show salt ID instead of rails' internal ID [bsc#1041789]

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -88,7 +88,7 @@ MinionPoller = {
 
     return "\
       <tr> \
-        <th>" + minion.id +  "</th>\
+        <th>" + minion.minion_id +  "</th>\
         <td class='text-center'>" + statusHtml +  "</td>\
         <td>" + minion.fqdn +  "</td>\
         <td>" + (minion.role || '') +  "</td>\
@@ -110,7 +110,7 @@ MinionPoller = {
 
     return "\
       <tr> \
-        <th>" + minion.id +  "</th>\
+        <th>" + minion.minion_id +  "</th>\
         <td>" + minion.fqdn +  "</td>\
         <td class='text-center'>" + masterHtml + "</td>\
       </tr>";

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -24,7 +24,7 @@ h1 Nodes
         - Minion.all.each do |m|
           tr
             th
-              | #{m.id}
+              | #{m.minion_id}
             td
               | #{m.fqdn}
             td.text-center


### PR DESCRIPTION
Change the UI to show the salt ID (which now is set to be equal to the machine-id) instead of showing Rails' internal ID.

This is required to fix bsc#1041789

Note well: I'm still working on setting up the devenv to test this code, but I didn't want to hold the code on my machine.