### PR TITLE
Allow selection of nodes to bootstrap cluster

### DIFF
--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -28,7 +28,7 @@ class Minion < ApplicationRecord
   #     },
   #     default_role: :dns
   #   )
-  def self.assign_roles!(roles: {}, default_role: :worker)
+  def self.assign_roles!(roles: {}, default_role: nil)
     # Lookup selected masters and workers
     masters = Minion.select_role_members(roles: roles, role: :master)
     minions = Minion.select_role_members(roles: roles, role: :worker)

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -4,16 +4,21 @@
       | &times;
   i.fa.fa-4x.pull-left aria-hidden="true"
   span
-    | After choosing the master and clicking "Bootstrap cluster" all other nodes will be set to the worker role
+    | After choosing the master and clicking "Bootstrap cluster" all the other selected nodes will be set to the worker role
+
 h1 Nodes
+
 .row
   .col-xs-12.discovery-control
     span#node-count #{Minion.count} Nodes found
+
 = form_tag(setup_bootstrap_path, method: "post")
   .nodes-container data-url=setup_discovery_path
     table.table
       thead
         tr
+          th width=10
+            = check_box_tag "all", "all", false, { class: "check-all" }
           th
             | Id
           th
@@ -23,12 +28,15 @@ h1 Nodes
       tbody
         - Minion.all.each do |m|
           tr
-            th
+            td
+              = check_box_tag "roles[worker][]", m.id
+            td
               | #{m.minion_id}
             td
               | #{m.fqdn}
             td.text-center
               = radio_button_tag "roles[master][]", m.id
+
     .clearfix.text-right.steps-container
       = link_to "Back", setup_worker_bootstrap_path, class: "btn btn-danger"
       = submit_tag "Bootstrap cluster", id: "bootstrap", class: "btn btn-primary"

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
+# rubocop:disable RSpec/AnyInstance
 feature "Bootstrap cluster feature" do
   let!(:user) { create(:user) }
 
@@ -10,6 +11,61 @@ feature "Bootstrap cluster feature" do
     visit setup_discovery_path
   end
 
+  # rubocop:disable RSpec/ExampleLength
+  context "Nodes bootstraping" do
+    let!(:minions) do
+      Minion.create!([{ minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local" },
+                      { minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local" },
+                      { minion_id: SecureRandom.hex, fqdn: "minion2.k8s.local" }])
+    end
+
+    before do
+      # mock salt methods
+      [:minion, :master].each do |role|
+        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
+          .and_return(role)
+      end
+      allow(Velum::Salt).to receive(:orchestrate)
+    end
+
+    scenario "An user selects which nodes will be bootstraped", js: true do
+      using_wait_time 10 do
+        # select master minion0.k8s.local
+        find("#roles_master_#{minions[0].id}").click
+        # select node minion1.k8s.local
+        find("#roles_minion_#{minions[1].id}").click
+      end
+
+      click_button "Bootstrap cluster"
+      using_wait_time 10 do
+        expect do
+          page.to have_content(minions[0].fqdn)
+          page.to have_content(minions[1].fqdn)
+          page.not_to have_content(minions[2].fqdn)
+        end
+      end
+    end
+
+    scenario "An user check all nodes at once to be bootstraped", js: true do
+      using_wait_time 10 do
+        # select master minion0.k8s.local
+        find("#roles_master_#{minions[0].id}").click
+        # select all nodes
+        find(".check-all").click
+      end
+
+      click_button "Bootstrap cluster"
+      using_wait_time 10 do
+        expect do
+          page.to have_content(minions[0].fqdn)
+          page.to have_content(minions[1].fqdn)
+          page.to have_content(minions[2].fqdn)
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength
+
   scenario "It shows the minions as soon as they register", js: true do
     expect(page).not_to have_content("minion0.k8s.local")
     Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local")
@@ -18,3 +74,4 @@ feature "Bootstrap cluster feature" do
     end
   end
 end
+# rubocop:enable RSpec/AnyInstance

--- a/spec/views/setup/discovery.html.slim_spec.rb
+++ b/spec/views/setup/discovery.html.slim_spec.rb
@@ -13,9 +13,8 @@ describe "setup/discovery" do
     it "has a button to bootstrap the cluster" do
       render
 
-      section = assert_select("input") { assert_select("[value='Bootstrap cluster']") }
-
-      text = section[1].attributes["value"].value
+      section = assert_select("input[type='submit']")
+      text = section[0].attributes["value"].value
       expect(text).to eq "Bootstrap cluster"
     end
   end


### PR DESCRIPTION
Previously, all the nodes found were used to be part of the cluster.
Now, user needs to select which ones they want to be used for it.

See bsc#1042193

- [X] Implement UI
- [x] Features' tests
- [ ] e2e test