### PR TITLE
fix version in package to be a sequence

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -25,11 +25,13 @@ else
 fi
 if [ $TRAVIS_COMMIT ];then
   commit=$TRAVIS_COMMIT
+  revision="travis"
 else
+  revision=$(git rev-list HEAD | wc -l)
   commit=$(git rev-parse HEAD)
 fi
 version=$(sed s/-/~/g ../../VERSION)
-version="$version+git$commit"
+version="$version+git_r$revision\_$commit"
 date=$(date --rfc-2822)
 year=$(date +%Y)
 


### PR DESCRIPTION
Let's use the git revision number in the version so that zypper will
see each new revision as an update. Otherwise, if we only use the commit
number, zypper gets confused