### PR TITLE
Fix `minion` -> `worker` terminology

### DIFF
--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -11,7 +11,7 @@ class Minion < ApplicationRecord
   scope :unassigned_role, -> { where role: nil }
 
   enum highstate: [:not_applied, :pending, :failed, :applied]
-  enum role: [:master, :minion]
+  enum role: [:master, :worker]
 
   validates :minion_id, presence: true, uniqueness: true
   validates :fqdn, presence: true
@@ -20,23 +20,23 @@ class Minion < ApplicationRecord
   #   Minion.assign_roles(
   #     roles: {
   #       master: [1],
-  #       minion: [2, 3]
+  #       worker: [2, 3]
   #     },
   #     default_role: :dns
   #   )
-  def self.assign_roles!(roles: {}, default_role: :minion)
-    # Lookup selected masters and minions
+  def self.assign_roles!(roles: {}, default_role: :worker)
+    # Lookup selected masters and workers
     masters = Minion.select_role_members(roles: roles, role: :master)
-    minions = Minion.select_role_members(roles: roles, role: :minion)
+    minions = Minion.select_role_members(roles: roles, role: :worker)
 
-    # assign roles to each master and minion
+    # assign roles to each master and worker
     {}.tap do |ret|
       masters.find_each do |master|
         ret[master.minion_id] = master.assign_role(:master)
       end
 
       minions.find_each do |minion|
-        ret[minion.minion_id] = minion.assign_role(:minion)
+        ret[minion.minion_id] = minion.assign_role(:worker)
       end
 
       # assign default role if there is any minion left with no role

--- a/lib/velum/salt_minion.rb
+++ b/lib/velum/salt_minion.rb
@@ -10,7 +10,7 @@ module Velum
 
     ROLES_MAP = {
       master: ["kube-master"],
-      minion: ["kube-minion"]
+      worker: ["kube-minion"]
     }.freeze
 
     # Initializes a new salt minion identified by mid.

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe SetupController, type: :controller do
     before do
       sign_in user
       Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "master" },
-                      { minion_id: SecureRandom.hex, fqdn: "minion0" }]
+                      { minion_id: SecureRandom.hex, fqdn: "worker0" }]
     end
 
     context "when the minion doesn't exist" do
@@ -59,7 +59,7 @@ RSpec.describe SetupController, type: :controller do
 
     context "when the user successfully chooses the master" do
       before do
-        [:minion, :master].each do |role|
+        [:worker, :master].each do |role|
           allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
             .and_return(role)
         end
@@ -67,24 +67,22 @@ RSpec.describe SetupController, type: :controller do
       end
 
       it "sets the master" do
-        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
-        # check that all minions are set to minion role
+        post :bootstrap, roles: { master: [Minion.first.id], worker: Minion.all[1..-1].map(&:id) }
         expect(Minion.first.role).to eq "master"
       end
 
       it "sets the other roles to minions" do
-        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
-        # check that all minions are set to minion role
-        expect(Minion.where("fqdn REGEXP ?", "minion*").map(&:role).uniq).to eq ["minion"]
+        post :bootstrap, roles: { master: [Minion.first.id], worker: Minion.all[1..-1].map(&:id) }
+        expect(Minion.where("fqdn REGEXP ?", "worker*").map(&:role).uniq).to eq ["worker"]
       end
 
       it "calls the orchestration" do
-        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], worker: Minion.all[1..-1].map(&:id) }
         expect(salt).to have_received(:orchestrate)
       end
 
       it "gets redirected to the list of nodes" do
-        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], worker: Minion.all[1..-1].map(&:id) }
         expect(response.redirect_url).to eq "http://test.host/"
         expect(response.status).to eq 302
       end
@@ -92,7 +90,7 @@ RSpec.describe SetupController, type: :controller do
 
     context "when the user fails to choose the master" do
       before do
-        [:minion, :master].each do |role|
+        [:worker, :master].each do |role|
           allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
             .and_return(false)
         end
@@ -100,13 +98,13 @@ RSpec.describe SetupController, type: :controller do
       end
 
       it "gets redirected to the discovery page" do
-        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], worker: Minion.all[1..-1].map(&:id) }
         expect(flash[:error]).to be_present
         expect(response.redirect_url).to eq "http://test.host/setup/discovery"
       end
 
       it "doesn't call the orchestration" do
-        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], worker: Minion.all[1..-1].map(&:id) }
         expect(Velum::Salt).to have_received(:orchestrate).exactly(0).times
       end
     end
@@ -129,7 +127,7 @@ RSpec.describe SetupController, type: :controller do
     before do
       sign_in user
       Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "master" },
-                      { minion_id: SecureRandom.hex, fqdn: "minion0" }]
+                      { minion_id: SecureRandom.hex, fqdn: "worker0" }]
       request.accept = "application/json"
     end
 
@@ -142,7 +140,7 @@ RSpec.describe SetupController, type: :controller do
 
     context "when the user successfully chooses the master" do
       before do
-        [:minion, :master].each do |role|
+        [:worker, :master].each do |role|
           allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
             .and_return(role)
         end
@@ -150,26 +148,24 @@ RSpec.describe SetupController, type: :controller do
       end
 
       it "sets the master" do
-        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
-        # check that all minions are set to minion role
+        post :bootstrap, roles: { master: [Minion.first.id], worker: Minion.all[1..-1].map(&:id) }
         expect(Minion.first.role).to eq "master"
       end
 
       it "sets the other roles to minions" do
-        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
-        # check that all minions are set to minion role
-        expect(Minion.where("fqdn REGEXP ?", "minion*").map(&:role).uniq).to eq ["minion"]
+        post :bootstrap, roles: { master: [Minion.first.id], worker: Minion.all[1..-1].map(&:id) }
+        expect(Minion.where("fqdn REGEXP ?", "worker*").map(&:role).uniq).to eq ["worker"]
       end
 
       it "calls the orchestration" do
-        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], worker: Minion.all[1..-1].map(&:id) }
         expect(salt).to have_received(:orchestrate)
       end
     end
 
     context "when the user fails to choose the master" do
       before do
-        [:minion, :master].each do |role|
+        [:worker, :master].each do |role|
           allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
             .and_return(false)
         end
@@ -177,12 +173,12 @@ RSpec.describe SetupController, type: :controller do
       end
 
       it "returns unprocessable entity" do
-        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], worker: Minion.all[1..-1].map(&:id) }
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it "doesn't call the orchestration" do
-        post :bootstrap, roles: { master: [Minion.first.id], minion: Minion.all[1..-1].map(&:id) }
+        post :bootstrap, roles: { master: [Minion.first.id], worker: Minion.all[1..-1].map(&:id) }
         expect(Velum::Salt).to have_received(:orchestrate).exactly(0).times
       end
     end

--- a/spec/factories/minions_factory.rb
+++ b/spec/factories/minions_factory.rb
@@ -8,6 +8,6 @@ FactoryGirl.define do
     role :master
   end
   factory :worker_minion, parent: :minion do
-    role :minion
+    role :worker
   end
 end

--- a/spec/models/minion_spec.rb
+++ b/spec/models/minion_spec.rb
@@ -9,8 +9,8 @@ describe Minion do
     let(:minions) do
       described_class.create! [
         { minion_id: SecureRandom.hex, fqdn: "master.example.com" },
-        { minion_id: SecureRandom.hex, fqdn: "minion0.example.com" },
-        { minion_id: SecureRandom.hex, fqdn: "minion1.example.com" }
+        { minion_id: SecureRandom.hex, fqdn: "worker0.example.com" },
+        { minion_id: SecureRandom.hex, fqdn: "worker1.example.com" }
       ]
     end
 
@@ -24,13 +24,13 @@ describe Minion do
         allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
           .with(:master).and_return(false)
         allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
-          .with(:minion).and_return(true)
+          .with(:worker).and_return(true)
         # rubocop:enable RSpec/AnyInstance
         expect(
           described_class.assign_roles!(
             roles: {
               master: [described_class.first.id],
-              minion: described_class.all[1..-1].map(&:id)
+              worker: described_class.all[1..-1].map(&:id)
             }
           )
         ).to eq(
@@ -51,13 +51,13 @@ describe Minion do
         allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
           .with(:master).and_return(true)
         allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
-          .with(:minion).and_return(false)
+          .with(:worker).and_return(false)
         # rubocop:enable RSpec/AnyInstance
         expect(
           described_class.assign_roles!(
             roles: {
               master: [described_class.first.id],
-              minion: described_class.all[1..-1].map(&:id)
+              worker: described_class.all[1..-1].map(&:id)
             }
           )
         ).to eq(
@@ -77,7 +77,7 @@ describe Minion do
         # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(:master)
           .and_return(true)
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(:minion)
+        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(:worker)
           .and_return(true)
         allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(:another_role)
           .and_return(false)
@@ -86,7 +86,7 @@ describe Minion do
           described_class.assign_roles!(
             roles: {
               master: [described_class.first.id],
-              minion: described_class.all[1..-2].map(&:id)
+              worker: described_class.all[1..-2].map(&:id)
             }, default_role: :another_role
           )
         ).to eq(
@@ -110,11 +110,11 @@ describe Minion do
         described_class.assign_roles!(
           roles: {
             master: [described_class.first.id],
-            minion: described_class.all[1..-1].map(&:id)
+            worker: described_class.all[1..-1].map(&:id)
           }
         )
 
-        expect(described_class.all.map(&:role).sort).to eq(["master", "minion", "minion"])
+        expect(described_class.all.map(&:role).sort).to eq(["master", "worker", "worker"])
       end
     end
 
@@ -131,15 +131,15 @@ describe Minion do
         described_class.assign_roles!(
           roles: {
             master: [described_class.first.id],
-            minion: described_class.all[1..-1].map(&:id)
+            worker: described_class.all[1..-1].map(&:id)
           }
         )
 
-        expect(described_class.all.map(&:role)).to eq(["master", "minion", "minion"])
+        expect(described_class.all.map(&:role)).to eq(["master", "worker", "worker"])
       end
     end
 
-    context "when explicit minion role is set" do
+    context "when explicit worker role is set" do
       before do
         minions
         # rubocop:disable RSpec/AnyInstance
@@ -148,15 +148,15 @@ describe Minion do
         # rubocop:enable RSpec/AnyInstance
       end
 
-      it "assigns the minion role to specific minions" do
+      it "assigns the worker role to specific minions" do
         described_class.assign_roles!(
           roles: {
             master: [described_class.first.id],
-            minion: described_class.all[1..-1].map(&:id)
+            worker: described_class.all[1..-1].map(&:id)
           }
         )
 
-        expect(described_class.all.last.role).to eq("minion")
+        expect(described_class.all.last.role).to eq("worker")
       end
     end
 
@@ -167,7 +167,7 @@ describe Minion do
         .and_return(true)
       # rubocop:enable RSpec/AnyInstance
       roles = described_class.assign_roles!(
-        roles: { master: [described_class.first.id], minion: described_class.all[1..-1].map(&:id) }
+        roles: { master: [described_class.first.id], worker: described_class.all[1..-1].map(&:id) }
       )
 
       expect(roles).to eq(


### PR DESCRIPTION
Internally we refer to `minion` as a salt minion generically, but
when it comes to assign roles (that will be shown to the user), fix
terminology and use `worker` instead of `minion`.