### PR TITLE
Add "update workers" button to velum.

### DIFF
--- a/app/controllers/salt_controller.rb
+++ b/app/controllers/salt_controller.rb
@@ -1,0 +1,15 @@
+require "velum/salt"
+# SaltController holds methods for triggering updates of nodes
+class SaltController < ApplicationController
+  skip_before_action :redirect_to_setup
+
+  def update
+    Minion.mark_pending_update
+    Velum::Salt.update_orchestration
+
+    respond_to do |format|
+      format.html { redirect_to root_path }
+      format.json { head :ok }
+    end
+  end
+end

--- a/app/models/salt_handler/minion_highstate.rb
+++ b/app/models/salt_handler/minion_highstate.rb
@@ -25,10 +25,11 @@ class SaltHandler::MinionHighstate
 
     # After applying a highstate once, it is applied again and again.
     # Salt probably tries to make sure it stays applied. We don't need to process
-    # those events. We only need to process a highstate if one is pending.
+    # those events. We only need to process a highstate if one is pending, or has
+    # failed in the past.
     minion = Minion.find_by(
       minion_id: minion_id,
-      highstate: Minion.highstates[:pending]
+      highstate: [Minion.highstates[:pending], Minion.highstates[:failed]]
     )
     return false unless minion
 

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -22,10 +22,14 @@ h1 Cluster Status
             dd.unassigned-count
         .col-md-6.right-column
           dl.side-by-side
-            dt Node updates
-            dd ?
+            dt Updates
+            dd Manual
             dt # of nodes w/ outdated software
-            dd.outdated-count ?
+            dd.outdated-count
+              span#out_dated_nodes 0
+              = link_to update_path, id: "update-all-nodes", class: "btn btn-xs btn-default pull-right", disabled: true, method: :post do
+                  i.fa.fa-arrow-circle-up
+                  | Update All Nodes
     .panel-footer.admin-outdated-notification.hidden
       .message
         i.fa.fw.fa-exclamation-circle
@@ -56,15 +60,17 @@ h1 Cluster Status
           thead
             tr
               th
-                | Id
-              th.text-center
+                | &nbsp;
+              th
                 | Status
+              th
+                | ID
               th
                 | Hostname
               th
                 | Role
-              th.text-center
-                | Master
+              th
+                | &nbsp;
           tbody
 
 = render "dashboard/update_admin_modal"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get "/autoyast", to: "dashboard#autoyast"
   get "/kubectl-config", to: "dashboard#kubectl_config"
   get "/_health", to: "health#index"
+  post "/update", to: "salt#update"
 
   namespace :setup do
     get "/", action: :welcome

--- a/lib/velum/salt.rb
+++ b/lib/velum/salt.rb
@@ -50,6 +50,15 @@ module Velum
       [res, JSON.parse(res.body)]
     end
 
+    # Call the update orchestration
+    def self.update_orchestration
+      res = perform_request(endpoint: "/run", method: "post",
+                            data: { client: "runner_async",
+                                    fun:    "state.orchestrate",
+                                    mods:   "orch.update" })
+      [res, JSON.parse(res.body)]
+    end
+
     # Returns the contents of the given file.
     def self.read_file(targets: "*", target_type: "glob", file: nil)
       _, data = Velum::Salt.call action:      "cmd.run",

--- a/spec/controllers/salt_controller_spec.rb
+++ b/spec/controllers/salt_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe SaltController, type: :controller do
+  let(:user)                 { create(:user) }
+  let(:master_minion)        { create(:master_minion) }
+  let(:worker_minion)        { create(:worker_minion) }
+  let(:stubbed) do
+    [
+      [{ "admin" => "",   master_minion.minion_id => true, worker_minion.minion_id => true }],
+      [{ "admin" => true, master_minion.minion_id => true, worker_minion.minion_id => ""   }]
+    ]
+  end
+  before do
+    sign_in user
+    setup_stubbed_update_status!(stubbed: stubbed)
+    allow(::Velum::Salt).to receive(:call).and_return(true)
+  end
+
+  describe "POST /update" do
+    it "gets an 302 response" do
+      VCR.use_cassette("salt/update_orch", record: :none) do
+        post :update
+        expect(response.status).to eq 302
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/salt/update_orch.yml
+++ b/spec/vcr_cassettes/salt/update_orch.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://127.0.0.1:8000/run
+    body:
+      encoding: UTF-8
+      string: '{"client":"runner_async","fun":"state.orchestrate","mods":"orch.update","username":"saltapi","password":"b0ugrUDP3C5KfP3vymLiTlAqWHJF3ExNIMkqVe/V45eOJZSFU8VVK75XX2XTg6IK+jk10jOOsu6o","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '85'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Tue, 13 Jun 2017 11:44:08 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"jid": "20170613114408589568", "tag": "salt/run/20170613114408589568"}]}'
+    http_version: 
+  recorded_at: Tue, 13 Jun 2017 11:44:08 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
* Adds a button that will trigger the update orchestration
  run, when there is nodes that can be updated.
* Updates the status column to show status of updates.
* Updated the Salt Event listener to update status of minions
  marked as "failed" if another highstate succeeds

![screenshot from 2017-06-13 13-00-48](https://user-images.githubusercontent.com/122395/27081456-5d0c9684-5038-11e7-8133-33e9cc51fc20.png)
