### PR TITLE
Improve cluster configuration page [bsc#1040367]

### DIFF
--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -1,47 +1,68 @@
 = content_for :body_class, "welcome"
-.alert.alert-info.alert-dismissible role="alert"
-  button.close[type="button" data-dismiss="alert" aria-label="Close"]
-    span[aria-hidden="true"]
-      | &times;
-  i.fa.fa-4x.pull-left aria-hidden="true"
-  span In order to secure transactions and communication between your cluster nodes, it is required to generate certificates. Please enter the details for your certificate authority (CA).
 h1 Initial CaaSP Configuration
 = form_for :settings, url: setup_path, method: :put do |f|
-  .form-group
-    = f.label :dashboard, "Dashboard location"
-    = f.text_field :dashboard, value: (Pillar.value(pillar: :dashboard) || request.host), class: "form-control", required: true
-  .form-group
-    = f.label :apiserver, "External Kubernetes API server FQDN"
-    = f.text_field :apiserver, value: Pillar.value(pillar: :apiserver), class: "form-control", required: true
-  .form-group
-    = f.label :http_proxy, "HTTP proxy for Docker"
-    = f.url_field :http_proxy, value: Pillar.value(pillar: :http_proxy), class: "form-control"
-  .form-group
-    = f.label :https_proxy, "HTTPS proxy for Docker"
-    = f.url_field :https_proxy, value: Pillar.value(pillar: :https_proxy), class: "form-control"
-  .form-group
-    = f.label :no, "No-proxy settings for Docker"
-    = f.text_field :no_proxy, value: Pillar.value(pillar: :no_proxy), class: "form-control"
-  .form-group
-    = f.label :company_name, "Company Name"
-    = f.text_field :company_name, value: Pillar.value(pillar: :company_name), class: "form-control", required: true
-  .form-group
-    = f.label :company_unit, "Company Unit"
-    = f.text_field :company_unit, value: Pillar.value(pillar: :company_unit), class: "form-control", required: true
-  .form-group
-    = f.label :email, "E-Mail"
-    = f.email_field :email, value: Pillar.value(pillar: :email), class: "form-control", required: true
-  .form-group
-    = f.label :country
-    - if Pillar.value(pillar: :country)
-      = f.select :country, options_for_select(country_codes, Pillar.value(pillar: :country)), {}, class: "form-control"
-    - else
-      = f.select :country, country_codes, { include_blank: true }, class: "form-control"
-  .form-group
-    = f.label :state
-    = f.text_field :state, value: Pillar.value(pillar: :state), class: "form-control", required: true
-  .form-group
-    = f.label :city
-    = f.text_field :city, value: Pillar.value(pillar: :city), class: "form-control", required: true
+  .panel.panel-default
+    .panel-heading Generic settings
+    .panel-body
+      .form-group
+        = f.label :dashboard, "Dashboard location"
+        .input-group
+          = f.text_field :dashboard, value: (Pillar.value(pillar: :dashboard) || request.host), class: "form-control", required: true
+          span class="input-group-addon"
+            a data-toggle="tooltip" data-placement="left" title="Hostname or IP of the node running this web interface."
+              i class='glyphicon glyphicon-info-sign'
+      .form-group
+        = f.label :apiserver, "External Kubernetes API server FQDN"
+        .input-group
+          = f.text_field :apiserver, value: Pillar.value(pillar: :apiserver), class: "form-control", required: true
+          span class="input-group-addon"
+            a data-toggle="tooltip" data-placement="left" title="Fully qualified domain name used to reach the cluster from the outside. In a simple, single master deployment this will be the FQDN of the node you are about to select as master. For advanced options refer to the documentation."
+              i class='glyphicon glyphicon-info-sign'
+
+  .panel.panel-default
+    .panel-heading Container engine proxy settings
+    .panel-body
+      p Proxy server the container engine will use to download images.
+      p Leave them empty if no proxy server is in place inside of your organization.
+      .form-group
+        = f.label :http_proxy, "HTTP proxy"
+        = f.url_field :http_proxy, value: Pillar.value(pillar: :http_proxy), class: "form-control"
+      .form-group
+        = f.label :https_proxy, "HTTPS proxy"
+        = f.url_field :https_proxy, value: Pillar.value(pillar: :https_proxy), class: "form-control"
+      .form-group
+        = f.label :no, "No-proxy"
+        .input-group
+          = f.text_field :no_proxy, value: Pillar.value(pillar: :no_proxy), class: "form-control"
+          span class="input-group-addon"
+            a data-toggle="tooltip" data-placement="left" title="Comma separated list of sites or domains that should not be accessed via the proxy server."
+              i class='glyphicon glyphicon-info-sign'
+
+  .panel.panel-default
+    .panel-heading Certificate settings
+    .panel-body
+      p In order to secure transactions and communication between your cluster nodes, it is required to generate certificates. Please enter the details for your certificate authority (CA).
+
+      .form-group
+        = f.label :company_name, "Company Name"
+        = f.text_field :company_name, value: Pillar.value(pillar: :company_name), class: "form-control", required: true
+      .form-group
+        = f.label :company_unit, "Company Unit"
+        = f.text_field :company_unit, value: Pillar.value(pillar: :company_unit), class: "form-control", required: true
+      .form-group
+        = f.label :email, "E-Mail"
+        = f.email_field :email, value: Pillar.value(pillar: :email), class: "form-control", required: true
+      .form-group
+        = f.label :country
+        - if Pillar.value(pillar: :country)
+          = f.select :country, options_for_select(country_codes, Pillar.value(pillar: :country)), {}, class: "form-control"
+        - else
+          = f.select :country, country_codes, { include_blank: true }, class: "form-control"
+      .form-group
+        = f.label :state
+        = f.text_field :state, value: Pillar.value(pillar: :state), class: "form-control", required: true
+      .form-group
+        = f.label :city
+        = f.text_field :city, value: Pillar.value(pillar: :city), class: "form-control", required: true
   .clearfix.steps-container
     = submit_tag "Next", class: "btn btn-primary pull-right"


### PR DESCRIPTION
I know the UX of the cluster configuration page is still ongoing, but I think we can make a significant improvement with a few lines of code.

This is **not meant** to be the final look of the page, it's just something that we can can get out quickly before 1.0.

This is just something that I hacked together in between today's meeting thanks to my mad UI skills (yes, I'm kidding!)

This also helps with [bsc#1040367](https://bugzilla.suse.com/show_bug.cgi?id=1040367).

## Before

![full-page-before](https://user-images.githubusercontent.com/22728/26891423-3bebed1a-4bb5-11e7-8c24-3961374c875d.png)

## After

The different options have been grouped together based on their "topic":

![full-page-after](https://user-images.githubusercontent.com/22728/26891442-4fc0ea8e-4bb5-11e7-9d15-fb0e9030f3f7.png)

### Contextual help

For cryptic settings we could provide some contextual help, you can see that in action here:

![tooltip](https://user-images.githubusercontent.com/22728/26891469-672b74c8-4bb5-11e7-8a5b-ae1be0ad66c0.png)

# Open questions

  * [x] proxy configuration: I took a look at the salt code and these settings are applied only to the docker engine. The proxy settings are not going to be extended to the node too (the autoyast profile is not changed -> zypper on the new nodes won't use it). Am I right?
   * [x] no-proxy: this is a white space separated list. Am I right?
   * [x] External Kubernetes API server FQDN: this is a tough one to document. I tried my best, but I'm open to feedback. Maybe @kiall has something better :)
   * [x] Generic settings: I couldn't come with a better name for this group of options
   * [x] openQA tests: I guess these changes are going to break them. Isn't it?




