### PR TITLE
WIP: bootstrap: enforce at least 3 nodes for cluster

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -1,4 +1,6 @@
 MinionPoller = {
+  selectedNodes: [],
+
   poll: function() {
     this.request();
   },
@@ -168,19 +170,29 @@ MinionPoller = {
 
   renderDiscovery: function(minion) {
     var masterHtml;
-    var checked;
+    var masterChecked = '';
+    var minionHtml;
+    var minionChecked = '';
 
     if (MinionPoller.selectedMasters && MinionPoller.selectedMasters.indexOf(minion.id) != -1) {
-      checked = "checked";
-    } else {
-      checked = '';
+      masterChecked = 'checked';
+      minionChecked += 'disabled="disabled" checked ';
     }
+
     masterHtml = '<input name="roles[master][]" id="roles_master_' + minion.id +
-      '" value="' + minion.id + '" type="radio" ' + checked + '>';
+      '" value="' + minion.id + '" type="radio" ' + masterChecked + '>';
+
+    if (MinionPoller.selectedNodes && MinionPoller.selectedNodes.indexOf(minion.id) != -1) {
+      minionChecked += 'checked';
+    }
+
+    minionHtml = '<input name="roles[worker][]" id="roles_minion_' + minion.id +
+      '" value="' + minion.id + '" type="checkbox" ' + minionChecked + '>';
 
     return "\
       <tr> \
-        <th>" + minion.minion_id +  "</th>\
+        <td>" + minionHtml +  "</td>\
+        <td>" + minion.minion_id +  "</td>\
         <td>" + minion.fqdn +  "</td>\
         <td class='text-center'>" + masterHtml + "</td>\
       </tr>";
@@ -210,4 +222,41 @@ $('body').on('click', '.reboot-update-btn', function(e) {
   .always(function() {
     $btn.prop('disabled', false);
   });
+});
+
+// checkbox on the top the checks/unchecks all nodes
+$('.check-all').on('change', function() {
+  $('input[name="roles[worker][]"]').prop('checked', this.checked).change();
+});
+
+// when checking/unchecking a node
+// stores it on MinionPoller.selectedNodes for future rendering
+$('body').on('change', 'input[name="roles[worker][]"]', function() {
+  var value = parseInt(this.value, 10);
+
+  if (this.checked) {
+    MinionPoller.selectedNodes.push(value);
+  } else {
+    var index = MinionPoller.selectedNodes.indexOf(value);
+    MinionPoller.selectedNodes.splice(index, 1);
+  }
+});
+
+// when selecting a master
+// selects node and makes it impossible to uncheck
+// enable and keep the previous state of the previous master (selected or not)
+$('body').on('change', 'input[name="roles[master][]"]', function() {
+  var $previousMaster = $('input[name="roles[worker][]"]:disabled');
+  var previousMasterValue = parseInt($previousMaster.val(), 10);
+  var checked = MinionPoller.selectedNodes.indexOf(previousMasterValue) !== -1;
+
+  $previousMaster.prop('disabled', false);
+  $previousMaster.prop('checked', checked);
+
+  if (this.checked) {
+    var $checkbox = $(this).closest('tr').find('input[name="roles[worker][]"]');
+
+    $checkbox.prop('checked', true);
+    $checkbox.prop('disabled', true);
+  }
 });

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -67,7 +67,9 @@ class SetupController < ApplicationController
   end
 
   def update_nodes_params
-    params.require(:roles)
+    roles_params = params.require(:roles)
+    roles_params[:worker] = (roles_params[:worker] || []) - roles_params[:master]
+    roles_params
   end
 
   def failed_assigned_nodes(assigned)

--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -28,7 +28,7 @@ class Minion < ApplicationRecord
   #     },
   #     default_role: :dns
   #   )
-  def self.assign_roles!(roles: {}, default_role: :worker)
+  def self.assign_roles!(roles: {}, default_role: nil)
     # Lookup selected masters and workers
     masters = Minion.select_role_members(roles: roles, role: :master)
     minions = Minion.select_role_members(roles: roles, role: :worker)

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -4,16 +4,21 @@
       | &times;
   i.fa.fa-4x.pull-left aria-hidden="true"
   span
-    | After choosing the master and clicking "Bootstrap cluster" all other nodes will be set to the worker role
+    | After choosing the master and clicking "Bootstrap cluster" all the other selected nodes will be set to the worker role
+
 h1 Nodes
+
 .row
   .col-xs-12.discovery-control
     span#node-count #{Minion.count} Nodes found
+
 = form_tag(setup_bootstrap_path, method: "post")
   .nodes-container data-url=setup_discovery_path
     table.table
       thead
         tr
+          th width=10
+            = check_box_tag "all", "all", false, { class: "check-all" }
           th
             | Id
           th
@@ -23,12 +28,15 @@ h1 Nodes
       tbody
         - Minion.all.each do |m|
           tr
-            th
+            td
+              = check_box_tag "roles[worker][]", m.id
+            td
               | #{m.minion_id}
             td
               | #{m.fqdn}
             td.text-center
               = radio_button_tag "roles[master][]", m.id
+
     .clearfix.text-right.steps-container
       = link_to "Back", setup_worker_bootstrap_path, class: "btn btn-danger"
       = submit_tag "Bootstrap cluster", id: "bootstrap", class: "btn btn-primary"

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
+# rubocop:disable RSpec/AnyInstance
 feature "Bootstrap cluster feature" do
   let!(:user) { create(:user) }
 
@@ -10,6 +11,61 @@ feature "Bootstrap cluster feature" do
     visit setup_discovery_path
   end
 
+  # rubocop:disable RSpec/ExampleLength
+  context "Nodes bootstraping" do
+    let!(:minions) do
+      Minion.create!([{ minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local" },
+                      { minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local" },
+                      { minion_id: SecureRandom.hex, fqdn: "minion2.k8s.local" }])
+    end
+
+    before do
+      # mock salt methods
+      [:minion, :master].each do |role|
+        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
+          .and_return(role)
+      end
+      allow(Velum::Salt).to receive(:orchestrate)
+    end
+
+    scenario "An user selects which nodes will be bootstraped", js: true do
+      using_wait_time 10 do
+        # select master minion0.k8s.local
+        find("#roles_master_#{minions[0].id}").click
+        # select node minion1.k8s.local
+        find("#roles_worker_#{minions[1].id}").click
+      end
+
+      click_button "Bootstrap cluster"
+      using_wait_time 10 do
+        expect do
+          page.to have_content(minions[0].fqdn)
+          page.to have_content(minions[1].fqdn)
+          page.not_to have_content(minions[2].fqdn)
+        end
+      end
+    end
+
+    scenario "An user check all nodes at once to be bootstraped", js: true do
+      using_wait_time 5 do
+        # select master minion0.k8s.local
+        find("#roles_master_#{minions[0].id}").click
+        # select all nodes
+        find(".check-all").click
+      end
+
+      click_button "Bootstrap cluster"
+      using_wait_time 10 do
+        expect do
+          page.to have_content(minions[0].fqdn)
+          page.to have_content(minions[1].fqdn)
+          page.to have_content(minions[2].fqdn)
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength
+
   scenario "It shows the minions as soon as they register", js: true do
     expect(page).not_to have_content("minion0.k8s.local")
     Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local")
@@ -18,3 +74,4 @@ feature "Bootstrap cluster feature" do
     end
   end
 end
+# rubocop:enable RSpec/AnyInstance

--- a/spec/views/setup/discovery.html.slim_spec.rb
+++ b/spec/views/setup/discovery.html.slim_spec.rb
@@ -13,9 +13,8 @@ describe "setup/discovery" do
     it "has a button to bootstrap the cluster" do
       render
 
-      section = assert_select("input") { assert_select("[value='Bootstrap cluster']") }
-
-      text = section[1].attributes["value"].value
+      section = assert_select("input[type='submit']")
+      text = section[0].attributes["value"].value
       expect(text).to eq "Bootstrap cluster"
     end
   end


### PR DESCRIPTION
The etcd configuration used in CaaSP 1.0 *requires*
three total nodes to be present in the cluster
(can be 1 master and two minions) - without this,
etcd does not elect a leader, and bootstrap will fail.

See bsc#1040477

**ATENTION**: To avoid extra work and only because this bugfix was really simple, I've checked out this branch based on another branch (#173) instead of master. So, only worry to review this after merging https://github.com/kubic-project/velum/pull/173.

The only changes were on `setup_controller.rb` and `setup_controller_spec.rb` (e1a6f5b60f6).