### PR TITLE
Proper update detection and reboot of the admin node

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -38,6 +38,8 @@ MinionPoller = {
         }
         $(".nodes-container tbody").html(rendered);
 
+        MinionPoller.handleAdminUpdate(data.admin || {});
+
         // disable bootstrap button if there are no minions
         if (minions.length == 0) {
           $("#bootstrap").prop('disabled', true);
@@ -60,6 +62,15 @@ MinionPoller = {
       }
     });
   },
+
+  handleAdminUpdate: function(admin) {
+    if (admin.update_status === undefined) {
+      return;
+    }
+
+    $('.update-admin-btn').toggleClass('hidden', admin.update_status === 0);
+  },
+
 
   enable_kubeconfig: function(enabled) {
     $("#download-kubeconfig").attr("disabled", !enabled);
@@ -127,3 +138,28 @@ MinionPoller = {
       </tr>";
   }
 };
+
+// reboot to update admin node handler
+$('body').on('click', '.reboot-update-btn', function(e) {
+  var $btn = $(this);
+
+  e.preventDefault();
+
+  $btn.text('Rebooting...');
+  $btn.prop('disabled', true);
+
+  $.ajax({
+    url: $btn.data('url'),
+    method: 'POST'
+  })
+  .done(function() {
+    $('.update-admin-modal').modal('hide');
+    $btn.text('Reboot to update');
+  })
+  .fail(function() {
+    $btn.text('Update admin node (failed last time)');
+  })
+  .always(function() {
+    $btn.prop('disabled', false);
+  });
+});

--- a/app/controllers/concerns/discovery.rb
+++ b/app/controllers/concerns/discovery.rb
@@ -1,3 +1,5 @@
+require "velum/salt"
+
 # Discovery implements the discovery method that is shared both when
 # bootstrapping and when showing the dashboard.
 module Discovery
@@ -5,15 +7,46 @@ module Discovery
 
   # Responds with either an HTML or JSON version of the available minions.
   def discovery
-    @assigned_minions = Minion.assigned_role
+    @assigned_minions   = assigned_with_status
     @unassigned_minions = Minion.unassigned_role
 
     respond_to do |format|
       format.html
       format.json do
-        render json: { assigned_minions:   @assigned_minions,
-                       unassigned_minions: @unassigned_minions }
+        hsh = {
+          assigned_minions:   @assigned_minions,
+          unassigned_minions: @unassigned_minions,
+          admin:              admin_status
+        }
+        render json: hsh, methods: [:update_status]
       end
     end
+  end
+
+  protected
+
+  # TODO(mssola):
+  #  1. It would make more sense to have the update status on the DB and have
+  #     another process polling for this. Then, on the `discovery` method this
+  #     would all be returned transparently (thus removing all the methods below).
+  #  2. NOTE: Other nodes should only be taken into consideration if
+  #     automatic updates has not been enabled.
+
+  def assigned_with_status
+    needed, failed = ::Velum::Salt.update_status(targets: "*", cached: true)
+
+    # NOTE: this is highly inefficient and will disappear if we implement the
+    # idea written above.
+    minions = Minion.assigned_role
+    minions.each do |minion|
+      minion.update_status = Minion.computed_status(minion.minion_id, needed, failed)
+    end
+
+    minions
+  end
+
+  def admin_status
+    needed, failed = ::Velum::Salt.update_status(targets: "*", cached: true)
+    { update_status: Minion.computed_status("admin", needed, failed) }
   end
 end

--- a/app/controllers/updates_controller.rb
+++ b/app/controllers/updates_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "velum/salt"
+
+# UpdatesController handles all the interaction with the updates of all nodes.
+class UpdatesController < ApplicationController
+  before_action :admin_needs_update, only: :create
+
+  # Reboot the admin node.
+  def create
+    ::Velum::Salt.call(
+      action:  "cmd.run",
+      targets: "admin",
+      arg:     "systemctl reboot"
+    )
+
+    redirect_to root_path, flash: { info: "Rebooting..." }
+  end
+
+  protected
+
+  def admin_needs_update
+    needed, failed = ::Velum::Salt.update_status(targets: "*", cached: true)
+    status = Minion.computed_status("admin", needed, failed)
+
+    return if status == Minion.statuses[:update_needed] ||
+        status == Minion.statuses[:update_failed]
+
+    redirect_to root_path, flash: { error: "There's no need to update" }
+  end
+end

--- a/app/models/salt_handler/minion_start.rb
+++ b/app/models/salt_handler/minion_start.rb
@@ -20,12 +20,14 @@ class SaltHandler::MinionStart
   def process_event
     parsed_data = salt_event.parsed_data
 
-    # Ignore the ca minion. It shouldn't be used as part of the k8s cluster.
-    return false if parsed_data["id"] == "ca"
+    # Ignore the ca and the dashboard minions. It shouldn't be used as part of
+    # the k8s cluster.
+    id = parsed_data["id"]
+    return false if id == "ca" || id == "admin"
 
-    minion_info = Velum::Salt.minions[parsed_data["id"]]
+    minion_info = Velum::Salt.minions[id]
 
     # false if a minion with this minion_id or fqdn already exists (uniqueness validation)
-    Minion.new(minion_id: parsed_data["id"], fqdn: minion_info["fqdn"]).save
+    Minion.new(minion_id: id, fqdn: minion_info["fqdn"]).save
   end
 end

--- a/app/views/dashboard/_update_admin_modal.html.erb
+++ b/app/views/dashboard/_update_admin_modal.html.erb
@@ -1,0 +1,22 @@
+<div class="modal fade update-admin-modal" tabindex="-1" role="dialog" aria-labelledby="modal-label">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title" id="modal-label">
+          The admin node needs to reboot in order to apply the software update
+        </h4>
+      </div>
+      <div class="modal-body">
+       <p>Rebooting the admin node will break ongoing operations like the creation of the cluster, the addition or removal of nodes and upgrades.</p>
+       <p>Please ensure none of the following operations are ongoing before proceeding with the upgrade of the admin node.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary reboot-update-btn" data-url="<%= updates_url %>">Reboot to update</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -7,6 +7,12 @@ h1 Cluster Status
         strong  new
         | nodes are available but have not been added to the cluster yet
 = link_to "Download kubectl config", kubectl_config_path, id: "download-kubeconfig", class: "btn btn-default btn-table pull-right", disabled: true
+
+| &nbsp;
+
+a.btn.btn-default.update-admin-btn.pull-right.hidden data-toggle="modal" data-target=".update-admin-modal"
+  | Update admin node
+
 .nodes-container data-url=authenticated_root_path
   table.table
     thead
@@ -23,4 +29,5 @@ h1 Cluster Status
           | Master
     tbody
 
+= render "dashboard/update_admin_modal"
 = render "dashboard/polling"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
                                     sessions:      "auth/sessions" }
 
   resource :dashboard, only: [:index]
+  resource :updates, only: [:create]
 
   authenticated :user do
     root "dashboard#index", as: :authenticated_root

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe DashboardController, type: :controller do
   let(:master_minion)        { create(:master_minion) }
   let(:worker_minion)        { create(:worker_minion) }
   let(:external_fqdn_pillar) { create(:external_fqdn_pillar) }
+  let(:stubbed) do
+    [
+      [{ "admin" => "",   master_minion.minion_id => true, worker_minion.minion_id => true }],
+      [{ "admin" => true, master_minion.minion_id => true, worker_minion.minion_id => ""   }]
+    ]
+  end
 
   before do
     minion1 && minion2 # Create two minions (no roles assigned)
@@ -36,6 +42,8 @@ RSpec.describe DashboardController, type: :controller do
     end
 
     it "shows a simple monitoring when roles have already been assigned" do
+      setup_stubbed_update_status!(stubbed: stubbed)
+
       sign_in user
       # Create a master minion and a worker minion
       master_minion && worker_minion
@@ -50,6 +58,8 @@ RSpec.describe DashboardController, type: :controller do
       # Create a master minion and a worker minion
       master_minion && worker_minion
       request.accept = "application/json"
+
+      setup_stubbed_update_status!(stubbed: stubbed)
     end
 
     it "renders assigned and unassigned minions" do
@@ -59,6 +69,27 @@ RSpec.describe DashboardController, type: :controller do
         expect(JSON.parse(response.body).key?(key)).to be true
       end
     end
+
+    # rubocop:disable RSpec/ExampleLength
+    # rubocop:disable RSpec/MultipleExpectations
+    it "sets the update_status properly" do
+      stubbed = [
+        [{ "admin" => "", master_minion.minion_id => true, worker_minion.minion_id => true }],
+        [{ "admin" => true, master_minion.minion_id => true, worker_minion.minion_id => "" }]
+      ]
+      allow(::Velum::Salt).to receive(:update_status).and_return(stubbed)
+
+      get :index
+      resp = JSON.parse(response.body)
+      master = resp["assigned_minions"].find { |m| m["id"] == master_minion.id }
+      worker = resp["assigned_minions"].find { |m| m["id"] == worker_minion.id }
+
+      expect(resp["admin"]["update_status"]).to eq(Minion.statuses[:update_failed])
+      expect(master["update_status"]).to eq(Minion.statuses[:update_failed])
+      expect(worker["update_status"]).to eq(Minion.statuses[:update_needed])
+    end
+    # rubocop:enable RSpec/ExampleLength
+    # rubocop:enable RSpec/MultipleExpectations
   end
 
   describe "GET /autoyast" do

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -302,6 +302,7 @@ RSpec.describe SetupController, type: :controller do
       sign_in user
       allow_any_instance_of(SetupController).to receive(:redirect_to_dashboard)
         .and_return(true)
+      setup_stubbed_update_status!
     end
 
     it "shows the minions" do

--- a/spec/controllers/updates_controller_spec.rb
+++ b/spec/controllers/updates_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe UpdatesController, type: :controller do
+  before do
+    user = create(:user)
+    create(:master_minion)
+    create(:worker_minion)
+    sign_in user
+  end
+
+  describe "reboot admin node" do
+    it "does nothing if no update was needed" do
+      stubbed = [[{ "admin" => "" }], [{ "admin" => "" }]]
+      setup_stubbed_update_status!(stubbed: stubbed)
+
+      post :create
+      expect(flash[:error]).to eq "There's no need to update"
+    end
+
+    it "allows the node to reboot if an update is needed" do
+      allow(::Velum::Salt).to receive(:call).and_return(true)
+      stubbed = [[{ "admin" => true }], [{ "admin" => "" }]]
+      setup_stubbed_update_status!(stubbed: stubbed)
+
+      post :create
+      expect(flash[:info]).to eq "Rebooting..."
+    end
+
+    it "allows the node to reboot if a previous update failed" do
+      allow(::Velum::Salt).to receive(:call).and_return(true)
+      stubbed = [[{ "admin" => "" }], [{ "admin" => true }]]
+      setup_stubbed_update_status!(stubbed: stubbed)
+
+      post :create
+      expect(flash[:info]).to eq "Rebooting..."
+    end
+  end
+end

--- a/spec/features/admin_node_update_feature_spec.rb
+++ b/spec/features/admin_node_update_feature_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+feature "Manage nodes updates feature" do
+  let!(:user) { create(:user) }
+
+  before do
+    login_as user, scope: :user
+    Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master")
+  end
+
+  scenario "Admin node has no update available", js: true do
+    setup_stubbed_update_status!(stubbed: [["admin" => ""], ["admin" => ""]])
+
+    visit authenticated_root_path
+
+    expect(page).not_to have_content("Update admin node")
+  end
+
+  context "Admin node has an update available" do
+    before do
+      setup_stubbed_update_status!(stubbed: [["admin" => true], ["admin" => ""]])
+
+      visit authenticated_root_path
+    end
+
+    scenario "Admin node has an update available", js: true do
+      expect(page).to have_content("Update admin node")
+    end
+
+    # rubocop:disable RSpec/MultipleExpectations
+    scenario "User clicks on admin 'Update admin node'", js: true do
+      expect(page).not_to have_content("Reboot to update")
+
+      # clicks on "Update admin node"
+      find(".update-admin-btn").click
+
+      expect(page).to have_content("The admin node needs to reboot "\
+                                   "in order to apply the software update")
+      expect(page).to have_content("Reboot to update")
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+
+    scenario "User clicks on 'Reboot to update'", js: true do
+      allow(::Velum::Salt).to receive(:call)
+
+      # clicks on "Update admin node"
+      find(".update-admin-btn").click
+
+      # clicks on "Reboot to update"
+      find(".reboot-update-btn").click
+
+      # rubocop:disable RSpec/MessageSpies
+      expect(::Velum::Salt).to receive(:call)
+      # rubocop:enable RSpec/MessageSpies
+      expect(page).to have_content("Rebooting...")
+    end
+  end
+
+  scenario "Admin node has an update available (failed to update)", js: true do
+    setup_stubbed_update_status!(stubbed: [["admin" => ""], ["admin" => true]])
+
+    visit authenticated_root_path
+
+    expect(page).to have_content("Update admin node")
+  end
+end

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -6,6 +6,7 @@ feature "Bootstrap cluster feature" do
 
   before do
     login_as user, scope: :user
+    setup_stubbed_update_status!
     visit setup_discovery_path
   end
 

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -9,6 +9,8 @@ feature "Dashboard" do
       login_as user, scope: :user
       Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master")
       Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local", role: "worker")
+      setup_stubbed_update_status!
+
       visit authenticated_root_path
     end
 

--- a/spec/features/monitoring_feature_spec.rb
+++ b/spec/features/monitoring_feature_spec.rb
@@ -7,6 +7,7 @@ feature "Monitoring feature" do
   before do
     login_as user, scope: :user
     Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master")
+    setup_stubbed_update_status!
     visit authenticated_root_path
   end
 
@@ -28,8 +29,9 @@ feature "Monitoring feature" do
         "nodes are available but have not been added to the cluster yet"
       )
       Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local", role: nil)
+
       expect(page).to have_content(
-        "1 new nodes are available but have not been added to the cluster yet"
+        "1 new nodes are available but have not been added to the cluster"
       )
       expect(page).not_to have_content("minion1.k8s.local")
     end

--- a/spec/lib/velum/salt_spec.rb
+++ b/spec/lib/velum/salt_spec.rb
@@ -35,4 +35,15 @@ describe Velum::Salt do
       end
     end
   end
+
+  describe "update_status" do
+    it "returns the update status of the given nodes" do
+      VCR.use_cassette("salt/update_status", record: :none) do
+        needed, failed = described_class.update_status
+        # In the VCR both values were set to true, so we can check this in a
+        # single 'expect' statement.
+        expect(needed.first["admin"] && failed.first["admin"]).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/models/minion_spec.rb
+++ b/spec/models/minion_spec.rb
@@ -226,5 +226,39 @@ describe Minion do
       end
     end
   end
+
+  describe "computed_status" do
+    it "computes unknown if all fields are empty" do
+      needed = [{ "admin" => "" }]
+      failed = [{ "admin" => "" }]
+      expect(described_class.computed_status("admin", needed, failed)).to(
+        eq described_class.statuses[:unknown]
+      )
+    end
+
+    it "computes needed if is set to true" do
+      needed = [{ "admin" => true }]
+      failed = [{ "admin" => "" }]
+      expect(described_class.computed_status("admin", needed, failed)).to(
+        eq described_class.statuses[:update_needed]
+      )
+    end
+
+    it "computes failed if is set to true" do
+      needed = [{ "admin" => "" }]
+      failed = [{ "admin" => true }]
+      expect(described_class.computed_status("admin", needed, failed)).to(
+        eq described_class.statuses[:update_failed]
+      )
+    end
+
+    it "computes failed if is set to true, even if needed is also true" do
+      needed = [{ "admin" => true }]
+      failed = [{ "admin" => true }]
+      expect(described_class.computed_status("admin", needed, failed)).to(
+        eq described_class.statuses[:update_failed]
+      )
+    end
+  end
   # rubocop:enable RSpec/ExampleLength
 end

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# A simple module containing some utility methods.
+module Utils
+  # Stubs the ::Velum::Salt.update_status method with the given data.
+  def setup_stubbed_update_status!(stubbed: [[], []])
+    allow(::Velum::Salt).to receive(:update_status).and_return(stubbed)
+  end
+end
+
+RSpec.configure { |config| config.include Utils }

--- a/spec/vcr_cassettes/salt/update_status.yml
+++ b/spec/vcr_cassettes/salt/update_status.yml
@@ -1,0 +1,211 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"saltapi","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '217'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Mon, 12 Jun 2017 07:48:13 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Auth-Token:
+      - f174c5e53c3aa8e524dde1a0b3c3e336ca5ceb39
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=f174c5e53c3aa8e524dde1a0b3c3e336ca5ceb39; expires=Mon, 12 Jun 2017
+        17:48:13 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
+        "start": 1497253693.959465, "token": "f174c5e53c3aa8e524dde1a0b3c3e336ca5ceb39",
+        "expire": 1497296893.959466, "user": "saltapi", "eauth": "pam"}]}'
+    http_version:
+  recorded_at: Mon, 12 Jun 2017 07:48:13 GMT
+- request:
+    method: post
+    uri: http://127.0.0.1:8000/
+    body:
+      encoding: UTF-8
+      string: '{"tgt":"*","fun":"grains.get","expr_form":"glob","client":"local","arg":"tx_update_reboot_needed"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Auth-Token:
+      - f174c5e53c3aa8e524dde1a0b3c3e336ca5ceb39
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '39'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Cache-Control:
+      - private
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Mon, 12 Jun 2017 07:48:13 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=f174c5e53c3aa8e524dde1a0b3c3e336ca5ceb39; expires=Mon, 12 Jun 2017
+        17:48:13 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"admin": true, "ca": ""}]}'
+    http_version:
+  recorded_at: Mon, 12 Jun 2017 07:48:14 GMT
+- request:
+    method: post
+    uri: http://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"saltapi","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '217'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Mon, 12 Jun 2017 07:48:14 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Auth-Token:
+      - d80ee6d78c81ed2aff4881d42a7007832685c985
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=d80ee6d78c81ed2aff4881d42a7007832685c985; expires=Mon, 12 Jun 2017
+        17:48:14 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
+        "start": 1497253694.123571, "token": "d80ee6d78c81ed2aff4881d42a7007832685c985",
+        "expire": 1497296894.123572, "user": "saltapi", "eauth": "pam"}]}'
+    http_version:
+  recorded_at: Mon, 12 Jun 2017 07:48:14 GMT
+- request:
+    method: post
+    uri: http://127.0.0.1:8000/
+    body:
+      encoding: UTF-8
+      string: '{"tgt":"*","fun":"grains.get","expr_form":"glob","client":"local","arg":"tx_update_failed"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Auth-Token:
+      - d80ee6d78c81ed2aff4881d42a7007832685c985
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '39'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Cache-Control:
+      - private
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Mon, 12 Jun 2017 07:48:14 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=d80ee6d78c81ed2aff4881d42a7007832685c985; expires=Mon, 12 Jun 2017
+        17:48:14 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"admin": true, "ca": ""}]}'
+    http_version:
+  recorded_at: Mon, 12 Jun 2017 07:48:14 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
- [x] Initial code
- [x] UI: I've taken the same code as in PR #181. @vitoravelino: let's scratch what you did (since it's going to #180), and let's simply add the update & reboot button (dialog) when the `admin` value contains an update (the backend does the same as in #181).
- [x] Update tests
- [x] More tests (coverage < 100%)