### PR TITLE
registration: allow only one admin user

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # Auth::RegistrationsController manages user signup/removal.
 class Auth::RegistrationsController < Devise::RegistrationsController
+  before_action :restrict_admin_users
+
   layout "authentication", except: :edit
 
   skip_before_action :redirect_to_setup
@@ -9,5 +11,12 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   def new
     @have_users = User.any?
     super
+  end
+
+  # Restrict the amount of admin users to 1, see bsc#1040831
+  def restrict_admin_users
+    return if User.count.zero?
+    flash[:alert] = "Admin user already exists."
+    redirect_to root_path
   end
 end

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -8,9 +8,10 @@
       p SUSE Container as a Service Platform allows you to provision, manage, and scale container-based applications.
       p It automates your tedious management tasks allowing you to focus on development and writing apps to meet business goals.
     p
-      | Don't have an account? 
-      a.btn.btn-default[href="/users/sign_up"]
-        | Create an account
+      - if User.count.zero?
+        | Don't have an account?
+        a.btn.btn-default[href="/users/sign_up"]
+          | Create an account
   .col-sm-4.col-sm-offset-1
     h2.Raleway-font
       | Log In


### PR DESCRIPTION
The administration dashboard allows to create as many admin users as
desired, which is a potential security threat as Velum does not have any
user management. Besides, an admin cannot see how many other users
exist.

Avoid creating more than one admin user by not showing the
`Create an account` button when a user already exists. `users/sign_up`
will further redirect to the `root_path` and print an alert.

Notice that this is only an intermediate solution until multiuser
support and RBAC is implemented. Until then, a password reset must be
done by connecting to the machine (manually or via a script).

See bsc#1040831

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>

See the screenshot below. The button is not displayed anymore and an 
alert is printed when forcefully visiting the registration path.
![screenshot from 2017-06-12 12-56-49](https://user-images.githubusercontent.com/11679875/27036303-ba97a2da-4f84-11e7-8302-b071765c1f44.png)
