### PR TITLE
When setting the highstate resolution, consider all highstates

### DIFF
--- a/app/models/salt_handler/minion_highstate.rb
+++ b/app/models/salt_handler/minion_highstate.rb
@@ -23,14 +23,7 @@ class SaltHandler::MinionHighstate
     minion_id = salt_event.tag.match(TAG_MATCHER)[1]
     return false unless minion_id
 
-    # After applying a highstate once, it is applied again and again.
-    # Salt probably tries to make sure it stays applied. We don't need to process
-    # those events. We only need to process a highstate if one is pending, or has
-    # failed in the past.
-    minion = Minion.find_by(
-      minion_id: minion_id,
-      highstate: [Minion.highstates[:pending], Minion.highstates[:failed]]
-    )
+    minion = Minion.find_by minion_id: minion_id
     return false unless minion
 
     data = JSON.parse(salt_event.data)


### PR DESCRIPTION
With the current logic, it could happen that during the same
orchestration run the first highstate succeeds (setting the minion
status to :applied as succeeded), while the second highstate fails
(and the :applied status as succeeded will be kept).

With this change we consider the latest highstate run is the most
recent, and whatever it reports is what the final status of the
minion will be.