### PR TITLE
Check that result isn't `nil` before checking result contents

### DIFF
--- a/lib/velum/salt.rb
+++ b/lib/velum/salt.rb
@@ -46,7 +46,7 @@ module Velum
         val = el.values.first
 
         # TODO: improve error handling...
-        val.include?("No such file or directory") ? nil : val
+        val && val.include?("No such file or directory") ? nil : val
       end
     end
   end


### PR DESCRIPTION
We are checking that the referenced file exists by performing a
rudimentary check. However, the result might be completely empty
under certain circumstances, making our check fail (`include?` called
on `nil` will fail).

This fixes the 500 error, but we still need to find out why the salt
side of things is failing at all to retrieve the contents of the
file.

Fixes: bsc#1043843