### PR TITLE
[WIP] Add unnasigned nodes after cluster bootstrap

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -48,18 +48,16 @@ MinionPoller = {
           return memo;
         }, []);
 
-        if (MinionPoller.renderMode == "discovery") {
-          minions = minions.concat(unassignedMinions);
+        if (MinionPoller.renderMode !== "Dashboard") {
+          minions = unassignedMinions;
         } else {
           MinionPoller.sortMinions(minions);
         }
 
+        var renderMethod = 'render' + MinionPoller.renderMode;
         for (i = 0; i < minions.length; i++) {
-          if (MinionPoller.renderMode == "discovery") {
-            rendered += MinionPoller.renderDiscovery(minions[i]);
-          } else {
-            rendered += MinionPoller.render(minions[i]);
-          }
+          rendered += MinionPoller[renderMethod].call(MinionPoller, minions[i]);
+
           if (minions[i].highstate != "applied") {
             allApplied = false;
           }
@@ -76,11 +74,14 @@ MinionPoller = {
         $('.assigned-count').text(minions.length);
         $('.master-count').text(MinionPoller.selectedMasters.length);
 
+        var addNodesUrl = $('.unassigned-count').data('url');
         if (unassignedMinions.length > 0) {
+          // discovery page uses #node-count,
+          // overview page otherwise
           if ($("#node-count").length > 0) {
             $("#node-count").text(unassignedMinions.length + " nodes found");
           } else {
-            $('.unassigned-count').text(unassignedMinions.length);
+            $('.unassigned-count').html(unassignedMinions.length + ' <a href="' + addNodesUrl + '">(new)</a>');
           }
         } else {
           $('.unassigned-count').text(0);
@@ -120,12 +121,11 @@ MinionPoller = {
     }
   },
 
-
   enable_kubeconfig: function(enabled) {
     $("#download-kubeconfig").attr("disabled", !enabled);
   },
 
-  render: function(minion) {
+  renderDashboard: function(minion) {
     var statusHtml;
     var checked;
     var masterHtml;
@@ -168,7 +168,7 @@ MinionPoller = {
       </tr>";
   },
 
-  renderDiscovery: function(minion) {
+  renderDiscovery: function(minion, onlyWorkers) {
     var masterHtml;
     var masterChecked = '';
     var minionHtml;
@@ -179,8 +179,13 @@ MinionPoller = {
       minionChecked += 'disabled="disabled" checked ';
     }
 
-    masterHtml = '<input name="roles[master][]" id="roles_master_' + minion.id +
-      '" value="' + minion.id + '" type="radio" ' + masterChecked + '>';
+    if (onlyWorkers) {
+      masterHtml = '';
+    } else {
+      masterHtml = '<td class="text-center">\
+        <input name="roles[master][]" id="roles_master_' + minion.id +
+        '" value="' + minion.id + '" type="radio" ' + masterChecked + '></td>';
+    }
 
     if (MinionPoller.selectedNodes && MinionPoller.selectedNodes.indexOf(minion.id) != -1) {
       minionChecked += 'checked';
@@ -194,8 +199,12 @@ MinionPoller = {
         <td>" + minionHtml +  "</td>\
         <td>" + minion.minion_id +  "</td>\
         <td>" + minion.fqdn +  "</td>\
-        <td class='text-center'>" + masterHtml + "</td>\
+        " + masterHtml + "\
       </tr>";
+  },
+
+  renderUnassigned: function(minion) {
+    return MinionPoller.renderDiscovery(minion, true);
   }
 };
 
@@ -224,9 +233,19 @@ $('body').on('click', '.reboot-update-btn', function(e) {
   });
 });
 
+// enable/disable Add nodes button to assign nodes
+function toggleAddNodesButton() {
+  var selectedNodes = $("input[name='roles[worker][]']:checked").length;
+
+  $('.add-nodes-btn').prop('disabled', selectedNodes === 0);
+};
+
+$('body').on('change', '.new-nodes-container input[name="roles[worker][]"]', toggleAddNodesButton);
+
 // checkbox on the top the checks/unchecks all nodes
 $('.check-all').on('change', function() {
   $('input[name="roles[worker][]"]').prop('checked', this.checked).change();
+  toggleAddNodesButton();
 });
 
 // when checking/unchecking a node
@@ -245,6 +264,7 @@ $('body').on('change', 'input[name="roles[worker][]"]', function() {
 // when selecting a master
 // selects node and makes it impossible to uncheck
 // enable and keep the previous state of the previous master (selected or not)
+// if user select node as master, it checks it as selected
 $('body').on('change', 'input[name="roles[master][]"]', function() {
   var $previousMaster = $('input[name="roles[worker][]"]:disabled');
   var previousMasterValue = parseInt($previousMaster.val(), 10);

--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -1,4 +1,6 @@
 MinionPoller = {
+  selectedNodes: [],
+
   poll: function() {
     this.request();
   },
@@ -168,19 +170,29 @@ MinionPoller = {
 
   renderDiscovery: function(minion) {
     var masterHtml;
-    var checked;
+    var masterChecked = '';
+    var minionHtml;
+    var minionChecked = '';
 
     if (MinionPoller.selectedMasters && MinionPoller.selectedMasters.indexOf(minion.id) != -1) {
-      checked = "checked";
-    } else {
-      checked = '';
+      masterChecked = 'checked';
+      minionChecked += 'disabled="disabled" checked ';
     }
+
     masterHtml = '<input name="roles[master][]" id="roles_master_' + minion.id +
-      '" value="' + minion.id + '" type="radio" ' + checked + '>';
+      '" value="' + minion.id + '" type="radio" ' + masterChecked + '>';
+
+    if (MinionPoller.selectedNodes && MinionPoller.selectedNodes.indexOf(minion.id) != -1) {
+      minionChecked += 'checked';
+    }
+
+    minionHtml = '<input name="roles[worker][]" id="roles_minion_' + minion.id +
+      '" value="' + minion.id + '" type="checkbox" ' + minionChecked + '>';
 
     return "\
       <tr> \
-        <th>" + minion.minion_id +  "</th>\
+        <td>" + minionHtml +  "</td>\
+        <td>" + minion.minion_id +  "</td>\
         <td>" + minion.fqdn +  "</td>\
         <td class='text-center'>" + masterHtml + "</td>\
       </tr>";
@@ -210,4 +222,41 @@ $('body').on('click', '.reboot-update-btn', function(e) {
   .always(function() {
     $btn.prop('disabled', false);
   });
+});
+
+// checkbox on the top the checks/unchecks all nodes
+$('.check-all').on('change', function() {
+  $('input[name="roles[worker][]"]').prop('checked', this.checked).change();
+});
+
+// when checking/unchecking a node
+// stores it on MinionPoller.selectedNodes for future rendering
+$('body').on('change', 'input[name="roles[worker][]"]', function() {
+  var value = parseInt(this.value, 10);
+
+  if (this.checked) {
+    MinionPoller.selectedNodes.push(value);
+  } else {
+    var index = MinionPoller.selectedNodes.indexOf(value);
+    MinionPoller.selectedNodes.splice(index, 1);
+  }
+});
+
+// when selecting a master
+// selects node and makes it impossible to uncheck
+// enable and keep the previous state of the previous master (selected or not)
+$('body').on('change', 'input[name="roles[master][]"]', function() {
+  var $previousMaster = $('input[name="roles[worker][]"]:disabled');
+  var previousMasterValue = parseInt($previousMaster.val(), 10);
+  var checked = MinionPoller.selectedNodes.indexOf(previousMasterValue) !== -1;
+
+  $previousMaster.prop('disabled', false);
+  $previousMaster.prop('checked', checked);
+
+  if (this.checked) {
+    var $checkbox = $(this).closest('tr').find('input[name="roles[worker][]"]');
+
+    $checkbox.prop('checked', true);
+    $checkbox.prop('disabled', true);
+  }
 });

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,10 @@ class ApplicationController < ActionController::Base
 
   def redirect_to_setup
     return true unless signed_in?
-    redirect_to setup_path if Minion.assigned_role.count.zero?
+    redirect_to setup_path if no_setup?
+  end
+
+  def no_setup?
+    Minion.assigned_role.count.zero?
   end
 end

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -67,7 +67,9 @@ class SetupController < ApplicationController
   end
 
   def update_nodes_params
-    params.require(:roles)
+    roles_params = params.require(:roles)
+    roles_params[:worker] = (roles_params[:worker] || []) - roles_params[:master]
+    roles_params
   end
 
   def failed_assigned_nodes(assigned)

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -67,9 +67,7 @@ class SetupController < ApplicationController
   end
 
   def update_nodes_params
-    roles_params = params.require(:roles)
-    roles_params[:worker] = (roles_params[:worker] || []) - roles_params[:master]
-    roles_params
+    params.require(:roles)
   end
 
   def failed_assigned_nodes(assigned)

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -43,6 +43,7 @@ class SetupController < ApplicationController
     respond_to do |format|
       if assigned.values.include?(false)
         message = "Failed to assign #{failed_assigned_nodes(assigned)}"
+
         format.html do
           flash[:error] = message
           redirect_to setup_discovery_path
@@ -58,10 +59,6 @@ class SetupController < ApplicationController
 
   private
 
-  def redirect_to_dashboard
-    redirect_to root_path unless Minion.assigned_role.count.zero?
-  end
-
   def settings_params
     params.require(:settings).permit(*Pillar.all_pillars.keys)
   end
@@ -70,6 +67,10 @@ class SetupController < ApplicationController
     roles_params = params.require(:roles)
     roles_params[:worker] = (roles_params[:worker] || []) - roles_params[:master]
     roles_params
+  end
+
+  def redirect_to_dashboard
+    redirect_to root_path unless no_setup?
   end
 
   def failed_assigned_nodes(assigned)

--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -28,7 +28,7 @@ class Minion < ApplicationRecord
   #     },
   #     default_role: :dns
   #   )
-  def self.assign_roles!(roles: {}, default_role: :worker)
+  def self.assign_roles!(roles: {}, default_role: nil)
     # Lookup selected masters and workers
     masters = Minion.select_role_members(roles: roles, role: :master)
     minions = Minion.select_role_members(roles: roles, role: :worker)

--- a/app/views/dashboard/_polling.html.slim
+++ b/app/views/dashboard/_polling.html.slim
@@ -1,5 +1,5 @@
 = content_for :page_javascript do
   javascript:
-    MinionPoller.renderMode = "dashboard";
+    MinionPoller.renderMode = "Dashboard";
     MinionPoller.poll();
 

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -19,7 +19,7 @@ h1 Cluster Status
             dt
               | New nodes
               i.fa.fw.fa-info-circle title="Available but have not been added to the cluster yet"
-            dd.unassigned-count
+            dd.unassigned-count data-url=assign_nodes_url
         .col-md-6.right-column
           dl.side-by-side
             dt Node updates

--- a/app/views/dashboard/unassigned_nodes.html.slim
+++ b/app/views/dashboard/unassigned_nodes.html.slim
@@ -1,0 +1,45 @@
+.alert.alert-info.alert-dismissible role="alert"
+  button.close[type="button" data-dismiss="alert" aria-label="Close"]
+    span[aria-hidden="true"]
+      | &times;
+  i.fa.fa-4x.pull-left aria-hidden="true"
+  span
+    | After choosing the nodes and clicking "Add nodes" all the selected nodes will be set to the worker role
+
+h1 Unassigned Nodes
+
+.row
+  .col-xs-12.discovery-control
+    p#node-count #{@unassigned_minions.count} nodes found
+
+= form_tag(assign_nodes_url, method: "post")
+  .nodes-container.new-nodes-container data-url=authenticated_root_path
+    table.table
+      thead
+        tr
+          th width=10
+            = check_box_tag "all", "all", false, { class: "check-all" }
+          th
+            | Id
+          th
+            | Hostname
+      tbody
+        - @unassigned_minions.each do |m|
+          tr
+            td
+              = check_box_tag "roles[worker][]", m.id
+            td
+              | #{m.minion_id}
+            td
+              | #{m.fqdn}
+
+    .clearfix.text-right.steps-container
+      = link_to "Back", authenticated_root_path, class: "btn btn-default"
+      | &nbsp;
+      = submit_tag "Add nodes", class: "btn btn-primary add-nodes-btn", disabled: true
+
+= content_for :page_javascript do
+  javascript:
+    MinionPoller.renderMode = "Unassigned";
+    MinionPoller.poll();
+

--- a/app/views/setup/_polling.html.slim
+++ b/app/views/setup/_polling.html.slim
@@ -1,4 +1,4 @@
 = content_for :page_javascript do
   javascript:
-    MinionPoller.renderMode = "discovery";
+    MinionPoller.renderMode = "Discovery";
     MinionPoller.poll();

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -4,16 +4,21 @@
       | &times;
   i.fa.fa-4x.pull-left aria-hidden="true"
   span
-    | After choosing the master and clicking "Bootstrap cluster" all other nodes will be set to the worker role
+    | After choosing the master and clicking "Bootstrap cluster" all the other selected nodes will be set to the worker role
+
 h1 Nodes
+
 .row
   .col-xs-12.discovery-control
     span#node-count #{Minion.count} Nodes found
+
 = form_tag(setup_bootstrap_path, method: "post")
   .nodes-container data-url=setup_discovery_path
     table.table
       thead
         tr
+          th width=10
+            = check_box_tag "all", "all", false, { class: "check-all" }
           th
             | Id
           th
@@ -23,12 +28,15 @@ h1 Nodes
       tbody
         - Minion.all.each do |m|
           tr
-            th
+            td
+              = check_box_tag "roles[worker][]", m.id
+            td
               | #{m.minion_id}
             td
               | #{m.fqdn}
             td.text-center
               = radio_button_tag "roles[master][]", m.id
+
     .clearfix.text-right.steps-container
       = link_to "Back", setup_worker_bootstrap_path, class: "btn btn-danger"
       = submit_tag "Bootstrap cluster", id: "bootstrap", class: "btn btn-primary"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
   resource :dashboard, only: [:index]
   resource :updates, only: [:create]
 
+  get "/assign_nodes", to: "dashboard#unassigned_nodes"
+  post "/assign_nodes", to: "dashboard#assign_nodes"
+
   authenticated :user do
     root "dashboard#index", as: :authenticated_root
   end

--- a/spec/features/add_unassigned_nodes_feature_spec.rb
+++ b/spec/features/add_unassigned_nodes_feature_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+# rubocop:disable RSpec/AnyInstance
+feature "Add unassigned nodes" do
+  let!(:user) { create(:user) }
+  let!(:minions) do
+    Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master" },
+                    { minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local", role: "worker" },
+                    { minion_id: SecureRandom.hex, fqdn: "minion2.k8s.local" },
+                    { minion_id: SecureRandom.hex, fqdn: "minion3.k8s.local" }]
+  end
+
+  before do
+    login_as user, scope: :user
+    setup_stubbed_update_status!
+
+    [:minion, :master].each do |role|
+      allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
+        .and_return(role)
+    end
+    allow(Velum::Salt).to receive(:orchestrate)
+
+    visit assign_nodes_path
+  end
+
+  scenario "An user sees (new) link", js: true do
+    visit authenticated_root_path
+
+    expect(page).to have_content("(new)")
+  end
+
+  # rubocop:disable RSpec/ExampleLength
+  scenario "An user selects which nodes will be added", js: true do
+    using_wait_time 10 do
+      # select node minion3.k8s.local
+      find("#roles_minion_#{minions[2].id}").click
+    end
+
+    click_button "Add nodes"
+    using_wait_time 10 do
+      expect do
+        page.to have_content(minions[2].fqdn)
+        page.not_to have_content(minions[3].fqdn)
+      end
+    end
+  end
+
+  scenario "An user check all nodes at once to be added", js: true do
+    using_wait_time 5 do
+      # select all nodes
+      find(".check-all").click
+    end
+
+    click_button "Add nodes"
+    using_wait_time 10 do
+      expect do
+        page.to have_content(minions[2].fqdn)
+        page.to have_content(minions[3].fqdn)
+      end
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength
+
+  scenario "It shows the nodes as soon as they register", js: true do
+    expect(page).not_to have_content("minion4.k8s.local")
+    Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion4.k8s.local")
+    using_wait_time 10 do
+      expect(page).to have_content("minion4.k8s.local")
+    end
+  end
+end
+# rubocop:enable RSpec/AnyInstance

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
+# rubocop:disable RSpec/AnyInstance
 feature "Bootstrap cluster feature" do
   let!(:user) { create(:user) }
 
@@ -10,6 +11,61 @@ feature "Bootstrap cluster feature" do
     visit setup_discovery_path
   end
 
+  # rubocop:disable RSpec/ExampleLength
+  context "Nodes bootstraping" do
+    let!(:minions) do
+      Minion.create!([{ minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local" },
+                      { minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local" },
+                      { minion_id: SecureRandom.hex, fqdn: "minion2.k8s.local" }])
+    end
+
+    before do
+      # mock salt methods
+      [:minion, :master].each do |role|
+        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
+          .and_return(role)
+      end
+      allow(Velum::Salt).to receive(:orchestrate)
+    end
+
+    scenario "An user selects which nodes will be bootstraped", js: true do
+      using_wait_time 10 do
+        # select master minion0.k8s.local
+        find("#roles_master_#{minions[0].id}").click
+        # select node minion1.k8s.local
+        find("#roles_minion_#{minions[1].id}").click
+      end
+
+      click_button "Bootstrap cluster"
+      using_wait_time 10 do
+        expect do
+          page.to have_content(minions[0].fqdn)
+          page.to have_content(minions[1].fqdn)
+          page.not_to have_content(minions[2].fqdn)
+        end
+      end
+    end
+
+    scenario "An user check all nodes at once to be bootstraped", js: true do
+      using_wait_time 5 do
+        # select master minion0.k8s.local
+        find("#roles_master_#{minions[0].id}").click
+        # select all nodes
+        find(".check-all").click
+      end
+
+      click_button "Bootstrap cluster"
+      using_wait_time 10 do
+        expect do
+          page.to have_content(minions[0].fqdn)
+          page.to have_content(minions[1].fqdn)
+          page.to have_content(minions[2].fqdn)
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength
+
   scenario "It shows the minions as soon as they register", js: true do
     expect(page).not_to have_content("minion0.k8s.local")
     Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local")
@@ -18,3 +74,4 @@ feature "Bootstrap cluster feature" do
     end
   end
 end
+# rubocop:enable RSpec/AnyInstance

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -33,7 +33,7 @@ feature "Bootstrap cluster feature" do
         # select master minion0.k8s.local
         find("#roles_master_#{minions[0].id}").click
         # select node minion1.k8s.local
-        find("#roles_worker_#{minions[1].id}").click
+        find("#roles_minion_#{minions[1].id}").click
       end
 
       click_button "Bootstrap cluster"

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -33,7 +33,7 @@ feature "Bootstrap cluster feature" do
         # select master minion0.k8s.local
         find("#roles_master_#{minions[0].id}").click
         # select node minion1.k8s.local
-        find("#roles_minion_#{minions[1].id}").click
+        find("#roles_worker_#{minions[1].id}").click
       end
 
       click_button "Bootstrap cluster"

--- a/spec/views/setup/discovery.html.slim_spec.rb
+++ b/spec/views/setup/discovery.html.slim_spec.rb
@@ -13,9 +13,8 @@ describe "setup/discovery" do
     it "has a button to bootstrap the cluster" do
       render
 
-      section = assert_select("input") { assert_select("[value='Bootstrap cluster']") }
-
-      text = section[1].attributes["value"].value
+      section = assert_select("input[type='submit']")
+      text = section[0].attributes["value"].value
       expect(text).to eq "Bootstrap cluster"
     end
   end


### PR DESCRIPTION
After the initial selection of the cluster (discovery page), new nodes can eventually come up and user might want to add them. This PR makes that available with a dedicated page similar to the discovery one.

- [X] UI
- [X] Routes
- [x] Feature's specs
- [x] Controller's specs

ATENTION: I've checked out this branch based on another branch (#173) instead of master since it reuses some of that code. So, only worry to review this after merging #173.

![](https://github.trello.services/images/mini-trello-icon.png) [UI: create the add unassigned nodes to the cluster](https://trello.com/c/yzU3t5EC/229-5-ui-create-the-add-unassigned-nodes-to-the-cluster)