### PR TITLE
AutoYaST: disable creation of swap [bsc#1043813]

### DIFF
--- a/app/views/dashboard/autoyast.xml.erb
+++ b/app/views/dashboard/autoyast.xml.erb
@@ -73,10 +73,6 @@
           <size>30gb</size>
         </partition>
         <partition>
-          <mount>swap</mount>
-          <size>auto</size>
-        </partition>
-        <partition>
           <filesystem config:type="symbol">btrfs</filesystem>
           <mount>/var/lib/docker</mount>
           <size>max</size>


### PR DESCRIPTION
Disables the creation of the swap partition on the nodes provisioned by AutoYaST.

This fixes bsc#1043813

Tested manually.