### PR TITLE
Fixed regression introduced when changed dashboard layout

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -40,13 +40,22 @@ MinionPoller = {
         var minions = data.assigned_minions || [];
         var unassignedMinions = data.unassigned_minions || [];
 
-        MinionPoller.selectedMasters = data.assigned_minions.reduce(function(memo, minion) {
-          if (minion.role === 'master') {
-            memo.push(minion.id);
-          }
+        // for the dashboard, if we rely on radio, the first time this comes
+        // it won't detect that there's a master, so we need to rely on the data
+        // itself for counting masters
+        if (MinionPoller.renderMode === 'dashboard') {
+          MinionPoller.selectedMasters = data.assigned_minions.reduce(function(memo, minion) {
+            if (minion.role === 'master') {
+              memo.push(minion.id);
+            }
 
-          return memo;
-        }, []);
+            return memo;
+          }, []);
+        } else {
+          MinionPoller.selectedMasters = $("input[name='roles[master][]']:checked").map(function() {
+            return parseInt($( this ).val());
+          }).get();
+        }
 
         if (MinionPoller.renderMode == "discovery") {
           minions = minions.concat(unassignedMinions);

--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -101,7 +101,7 @@ class Minion < ApplicationRecord
   end
   # rubocop:enable SkipsModelValidations
 
-  # Updates all nodes with a grain of `tx_update_reboot_needed: True` with a 
+  # Updates all nodes with a grain of `tx_update_reboot_needed: True` with a
   # highstate = pending, and persists it to the database
   def self.mark_pending_update
     needed, failed = ::Velum::Salt.update_status(targets: "*", cached: true)


### PR DESCRIPTION
For 1.0 we changed the layout of overview page. During that process,
I accidentally changed this piece of code without reminding that
the discovery page also depended on this.

Now it separates different behavior depending on the page.