### PR TITLE
prevent caching of pages (bsc#1044237)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,11 +5,19 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :redirect_to_setup
   protect_from_forgery with: :exception
+  # https://bugzilla.suse.com/show_bug.cgi?id=1044237
+  before_action :prevent_page_cache
 
   private
 
   def redirect_to_setup
     return true unless signed_in?
     redirect_to setup_path if Minion.assigned_role.count.zero?
+  end
+
+  def prevent_page_cache
+    response.headers["Cache-Control"] = "no-cache, no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = 1.year.ago.to_s
   end
 end


### PR DESCRIPTION
after logout you can still access the application pages via
the browser's back button

disabling caching completely prevents this, as all pages contain
sensitive information

Signed-off-by: Maximilian Meister <mmeister@suse.de>