### PR TITLE
Add unassigned nodes after cluster bootstrap

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,10 @@ class ApplicationController < ActionController::Base
 
   def redirect_to_setup
     return true unless signed_in?
-    redirect_to setup_path if Minion.assigned_role.count.zero?
+    redirect_to setup_path if no_setup?
+  end
+
+  def no_setup?
+    Minion.assigned_role.count.zero?
   end
 end

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -43,6 +43,7 @@ class SetupController < ApplicationController
     respond_to do |format|
       if assigned.values.include?(false)
         message = "Failed to assign #{failed_assigned_nodes(assigned)}"
+
         format.html do
           flash[:error] = message
           redirect_to setup_discovery_path
@@ -58,16 +59,16 @@ class SetupController < ApplicationController
 
   private
 
-  def redirect_to_dashboard
-    redirect_to root_path unless Minion.assigned_role.count.zero?
-  end
-
   def settings_params
     params.require(:settings).permit(*Pillar.all_pillars.keys)
   end
 
   def update_nodes_params
     params.require(:roles)
+  end
+
+  def redirect_to_dashboard
+    redirect_to root_path unless no_setup?
   end
 
   def failed_assigned_nodes(assigned)

--- a/app/views/dashboard/_polling.html.slim
+++ b/app/views/dashboard/_polling.html.slim
@@ -1,5 +1,5 @@
 = content_for :page_javascript do
   javascript:
-    MinionPoller.renderMode = "dashboard";
+    MinionPoller.renderMode = "Dashboard";
     MinionPoller.poll();
 

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -19,7 +19,7 @@ h1 Cluster Status
             dt
               | New nodes
               i.fa.fw.fa-info-circle title="Available but have not been added to the cluster yet"
-            dd.unassigned-count
+            dd.unassigned-count data-url=assign_nodes_url
         .col-md-6.right-column
           dl.side-by-side
             dt Updates

--- a/app/views/dashboard/unassigned_nodes.html.slim
+++ b/app/views/dashboard/unassigned_nodes.html.slim
@@ -1,0 +1,45 @@
+.alert.alert-info.alert-dismissible role="alert"
+  button.close[type="button" data-dismiss="alert" aria-label="Close"]
+    span[aria-hidden="true"]
+      | &times;
+  i.fa.fa-4x.pull-left aria-hidden="true"
+  span
+    | After choosing the nodes and clicking "Add nodes" all the selected nodes will be set to the worker role
+
+h1 Unassigned Nodes
+
+.row
+  .col-xs-12.discovery-control
+    p#node-count #{@unassigned_minions.count} nodes found
+
+= form_tag(assign_nodes_url, method: "post")
+  .nodes-container.new-nodes-container data-url=authenticated_root_path
+    table.table
+      thead
+        tr
+          th width=10
+            = check_box_tag "all", "all", false, { class: "check-all" }
+          th
+            | Id
+          th
+            | Hostname
+      tbody
+        - @unassigned_minions.each do |m|
+          tr
+            td
+              = check_box_tag "roles[worker][]", m.id
+            td
+              | #{m.minion_id}
+            td
+              | #{m.fqdn}
+
+    .clearfix.text-right.steps-container
+      = link_to "Back", authenticated_root_path, class: "btn btn-default"
+      | &nbsp;
+      = submit_tag "Add nodes", class: "btn btn-primary add-nodes-btn", disabled: true
+
+= content_for :page_javascript do
+  javascript:
+    MinionPoller.renderMode = "Unassigned";
+    MinionPoller.poll();
+

--- a/app/views/setup/_polling.html.slim
+++ b/app/views/setup/_polling.html.slim
@@ -1,4 +1,4 @@
 = content_for :page_javascript do
   javascript:
-    MinionPoller.renderMode = "discovery";
+    MinionPoller.renderMode = "Discovery";
     MinionPoller.poll();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
   resource :dashboard, only: [:index]
   resource :updates, only: [:create]
 
+  get "/assign_nodes", to: "dashboard#unassigned_nodes"
+  post "/assign_nodes", to: "dashboard#assign_nodes"
+
   authenticated :user do
     root "dashboard#index", as: :authenticated_root
   end

--- a/spec/features/add_unassigned_nodes_feature_spec.rb
+++ b/spec/features/add_unassigned_nodes_feature_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+# rubocop:disable RSpec/AnyInstance
+feature "Add unassigned nodes" do
+  let!(:user) { create(:user) }
+  let!(:minions) do
+    Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master" },
+                    { minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local", role: "worker" },
+                    { minion_id: SecureRandom.hex, fqdn: "minion2.k8s.local" },
+                    { minion_id: SecureRandom.hex, fqdn: "minion3.k8s.local" }]
+  end
+
+  before do
+    login_as user, scope: :user
+    setup_stubbed_update_status!
+
+    [:minion, :master].each do |role|
+      allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
+        .and_return(role)
+    end
+    allow(Velum::Salt).to receive(:orchestrate)
+
+    visit assign_nodes_path
+  end
+
+  scenario "An user sees (new) link", js: true do
+    visit authenticated_root_path
+
+    expect(page).to have_content("(new)")
+  end
+
+  # rubocop:disable RSpec/ExampleLength
+  scenario "An user selects which nodes will be added", js: true do
+    using_wait_time 10 do
+      # select node minion3.k8s.local
+      find("#roles_minion_#{minions[2].id}").click
+    end
+
+    click_button "Add nodes"
+    using_wait_time 10 do
+      expect do
+        page.to have_content(minions[2].fqdn)
+        page.not_to have_content(minions[3].fqdn)
+      end
+    end
+  end
+
+  scenario "An user check all nodes at once to be added", js: true do
+    using_wait_time 5 do
+      # select all nodes
+      find(".check-all").click
+    end
+
+    click_button "Add nodes"
+    using_wait_time 10 do
+      expect do
+        page.to have_content(minions[2].fqdn)
+        page.to have_content(minions[3].fqdn)
+      end
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength
+
+  scenario "It shows the nodes as soon as they register", js: true do
+    expect(page).not_to have_content("minion4.k8s.local")
+    Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion4.k8s.local")
+    using_wait_time 10 do
+      expect(page).to have_content("minion4.k8s.local")
+    end
+  end
+end
+# rubocop:enable RSpec/AnyInstance


### PR DESCRIPTION
After the initial selection of the cluster (discovery page), new nodes can eventually come up and user might want to add them. This PR makes that available with a dedicated page similar to the discovery one.

- [X] UI
- [X] Routes
- [x] Feature's specs
- [x] Controller's specs

![](https://github.trello.services/images/mini-trello-icon.png) [UI: create the add unassigned nodes to the cluster](https://trello.com/c/yzU3t5EC/229-5-ui-create-the-add-unassigned-nodes-to-the-cluster)