### PR TITLE
Warn minimum nodes to bootstrap cluster

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -107,9 +107,6 @@ MinionPoller = {
           $("#update-all-nodes").attr('disabled', false);
         }
 
-        // disable bootstrap button if there are no minions
-        $("#bootstrap").prop('disabled', minions.length === 0);
-
         MinionPoller.enable_kubeconfig(minions.length > 0 && allApplied);
 
         $('#out_dated_nodes').text(updateAvailableNodeCount)
@@ -338,11 +335,57 @@ function toggleAddNodesButton() {
   $('.add-nodes-btn').prop('disabled', selectedNodes === 0);
 };
 
+// unassigned nodes page
 $('body').on('change', '.new-nodes-container input[name="roles[worker][]"]', toggleAddNodesButton);
+
+// return true if master is selected
+// false otherwise
+function isMasterSelected() {
+  return $('input[name="roles[master][]"]:checked').length > 0;
+}
+
+// return number of selected checkboxes
+function selectedNodesLength() {
+  return $('input[name="roles[worker][]"]:checked').length;
+}
+
+// disable/enable button if it has 1 master and 1 worker at least
+function toggleBootstrapButton() {
+  var hasMinimumAmountToEnable = isMasterSelected() && selectedNodesLength() > 1;
+
+  $('#bootstrap').prop('disabled', !hasMinimumAmountToEnable);
+}
+
+// bootstrap cluster button click listener
+// if it has the minimum amount of nodes, form is submitted as expected
+// otherwise it shows the modal if didn't show yet
+$('body').on('click', '#bootstrap', function(e) {
+  var $warningModal = $('.warn-minimum-nodes-modal');
+  var hasMinimumAmountToSubmit = isMasterSelected() && selectedNodesLength() > 2;
+
+  if (!hasMinimumAmountToSubmit) {
+    e.preventDefault();
+
+    $warningModal.modal('show');
+    $warningModal.data('wasOpenedBefore', true);
+
+    return false;
+  }
+});
+
+// if user wants to bootstrap anyway, submit form
+$('body').on('click', '.bootstrap-anyway', function() {
+  $('.warn-minimum-nodes-modal').modal('hide');
+  $('form').submit();
+});
+
+// discovery page
+$('body').on('change', '.nodes-container input[name="roles[worker][]"]', toggleBootstrapButton);
 
 // checkbox on the top the checks/unchecks all nodes
 $('.check-all').on('change', function() {
   $('input[name="roles[worker][]"]:not(:disabled)').prop('checked', this.checked).change();
+  toggleBootstrapButton();
   toggleAddNodesButton();
 });
 
@@ -377,4 +420,6 @@ $('body').on('change', 'input[name="roles[master][]"]', function() {
     $checkbox.prop('checked', true);
     $checkbox.prop('disabled', true);
   }
+
+  toggleBootstrapButton();
 });

--- a/app/views/setup/_warn_minimum_nodes_modal.html.erb
+++ b/app/views/setup/_warn_minimum_nodes_modal.html.erb
@@ -1,0 +1,23 @@
+<div class="modal fade warn-minimum-nodes-modal" tabindex="-1" role="dialog" aria-labelledby="modal-label">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title" id="modal-label">
+          Cluster is too small
+        </h4>
+      </div>
+      <div class="modal-body">
+        <p>You are going to deploy a cluster made by only one master and one worker node.</p>
+
+        <p>This kind of clusters is meant to be used only for development/testing/evaluation of SUSE Container as a Service Platform and is not a supported topology</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary bootstrap-anyway">Proceed anyway</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -1,3 +1,8 @@
+.alert.alert-info role="alert"
+  i.fa.fa-4x.pull-left aria-hidden="true"
+  span
+    | A supported deployment of SUSE Container as a Service Platform requires a minimum of three nodes. Please select a minimum of three nodes.
+
 h1 Bootstrap Cluster
 
 .panel.panel-default.discovery-empty-panel class=('hide' if any_minion?)
@@ -10,7 +15,7 @@ h1 Bootstrap Cluster
 
     .text-right.steps-container
       = link_to "Back", setup_worker_bootstrap_path, class: "btn btn-danger"
-      = submit_tag "Bootstrap cluster", id: "bootstrap", class: "btn btn-primary", disabled: true
+      = submit_tag "Bootstrap cluster", class: "btn btn-primary", disabled: true
 
 .panel.panel-default.discovery-nodes-panel class=('hide' unless any_minion?)
   .panel-heading
@@ -47,7 +52,8 @@ h1 Bootstrap Cluster
 
         .clearfix.text-right.steps-container
           = link_to "Back", setup_worker_bootstrap_path, class: "btn btn-danger"
-          = submit_tag "Bootstrap cluster", id: "bootstrap", class: "btn btn-primary"
+          = submit_tag "Bootstrap cluster", id: "bootstrap", class: "btn btn-primary", disabled: true
 
 = render "dashboard/pending_nodes"
+= render "setup/warn_minimum_nodes_modal"
 = render "setup/polling"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -17,6 +17,13 @@ module Helpers
   def disabled?(selector)
     page.evaluate_script("$('#{selector}').attr('disabled')") == "disabled"
   end
+
+  # click on `selector element when enabled
+  def click_on_when_enabled(selector)
+    # will wait until it becomes enabled
+    have_css("#{selector}:not([disabled])")
+    find(selector).click
+  end
 end
 
 RSpec.configure { |config| config.include Helpers, type: :feature }


### PR DESCRIPTION
The etcd configuration used in CaaSP 1.0 requires
three total nodes to be present in the cluster
(can be 1 master and two minions) - without this,
etcd does not elect a leader, and bootstrap will fail.

See bsc#1040477

### Screenshots

Until 2 nodes and 1 master is selected:

* Bootstrap cluster button disabled
* Warning message always displayed 

![screenshot from 2017-06-21 19-27-48](https://user-images.githubusercontent.com/188554/27409479-15d2dd6a-56b8-11e7-912f-25385ebb64d5.png)

* Warning message gone when at least 2 nodes and 1 master is selected

![screenshot from 2017-06-21 19-28-21](https://user-images.githubusercontent.com/188554/27409480-15d56a12-56b8-11e7-8c0b-dda408f5fefc.png)

If only 1 node and 1 master is selected:

* Bootstrap cluster enabled
* Warning message still being displayed

![screenshot from 2017-06-21 19-28-58](https://user-images.githubusercontent.com/188554/27409481-15d6243e-56b8-11e7-8e79-e36816a92068.png)

If user clicks on Boostrap cluster button while only 1 node and 1 master is selected:

* Warning modal is displayed

![screenshot from 2017-06-21 19-29-19](https://user-images.githubusercontent.com/188554/27409478-15ce57e0-56b8-11e7-8538-ab3369ef3bbe.png)


- [X] Implementation
- [x] Feature specs
- [x] Screenshots
- [x] Modal title (help needed)
- [x] Modal text (help needed)
- [x] Alert content (help needed)

Previous discussion happened at https://github.com/kubic-project/velum/pull/183.