### PR TITLE
bsc#1043592 Add support for accepting nodes

### DIFF
--- a/app/assets/stylesheets/pages/nodes_list.scss
+++ b/app/assets/stylesheets/pages/nodes_list.scss
@@ -31,6 +31,23 @@
   }
 }
 
+.pending-nodes-container {
+  .panel-title {
+    display: inline-block;
+  }
+
+  form {
+    height: 450px;
+    margin-bottom: $line-height-computed;
+    overflow-x: hidden;
+    overflow-y: scroll;
+
+    table {
+      margin-bottom: 0px;
+    }
+  }
+}
+
 .nodes-summary {
   .fa-info-circle {
     margin-left: 5px;
@@ -100,4 +117,8 @@
   .modal-dialog {
     width: 450px;
   }
+}
+
+.pending-nodes-container {
+  margin-top: 15px
 }

--- a/app/controllers/concerns/discovery.rb
+++ b/app/controllers/concerns/discovery.rb
@@ -9,6 +9,7 @@ module Discovery
   def discovery
     @assigned_minions   = assigned_with_status
     @unassigned_minions = Minion.unassigned_role
+    pending_minions     = ::Velum::Salt.pending_minions
 
     respond_to do |format|
       format.html
@@ -16,6 +17,7 @@ module Discovery
         hsh = {
           assigned_minions:   @assigned_minions,
           unassigned_minions: @unassigned_minions,
+          pending_minions:    pending_minions,
           admin:              admin_status
         }
         render json: hsh, methods: [:update_status]

--- a/app/controllers/salt_controller.rb
+++ b/app/controllers/salt_controller.rb
@@ -12,4 +12,17 @@ class SaltController < ApplicationController
       format.json { head :ok }
     end
   end
+
+  def accept_minion
+    Velum::Salt.accept_minion(minion_id: minion_id_param)
+
+    respond_to do |format|
+      format.html { redirect_to root_path }
+      format.json { head :ok }
+    end
+  end
+
+  def minion_id_param
+    params.require(:minion_id)
+  end
 end

--- a/app/views/dashboard/_pending_nodes.html.slim
+++ b/app/views/dashboard/_pending_nodes.html.slim
@@ -1,0 +1,23 @@
+.pending-nodes-container data-url=authenticated_root_path
+  .panel.panel-default
+    .panel-heading
+      h3.panel-title Pending Nodes
+
+      = link_to '#', id: "accept-all", class: "btn btn-xs btn-default pull-right accept-minion" do
+        i.fa.fa-check.fa-fw
+        | Accept All Nodes
+
+    .panel-body
+      .row.nodes-loading
+        p.text-center
+          i class="fa fa-spinner fa-pulse fa-3x fa-fw"
+          span class="sr-only" Loading...
+      .nodes-content.hidden
+        table.table
+          thead
+            tr
+              th
+                | ID
+              th
+                | Actions
+          tbody

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -73,5 +73,6 @@ h1 Cluster Status
                 | &nbsp;
           tbody
 
+= render "dashboard/pending_nodes"
 = render "dashboard/update_admin_modal"
 = render "dashboard/polling"

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -41,4 +41,5 @@ h1 Nodes
       = link_to "Back", setup_worker_bootstrap_path, class: "btn btn-danger"
       = submit_tag "Bootstrap cluster", id: "bootstrap", class: "btn btn-primary"
 
+= render "dashboard/pending_nodes"
 = render "setup/polling"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   get "/kubectl-config", to: "dashboard#kubectl_config"
   get "/_health", to: "health#index"
   post "/update", to: "salt#update"
+  post "/accept-minion", to: "salt#accept_minion"
 
   namespace :setup do
     get "/", action: :welcome

--- a/lib/velum/salt.rb
+++ b/lib/velum/salt.rb
@@ -41,6 +41,26 @@ module Velum
       JSON.parse(res.body)["return"].first
     end
 
+    # Returns the minions that have not been accepted into the cluster
+    def self.pending_minions
+      res = perform_request(endpoint: "/", method: "post",
+                            data: { client: "wheel",
+                                    fun:    "key.list",
+                                    match:  "all",
+                                    tgt:    "ca" })
+      JSON.parse(res.body)["return"].first["data"]["return"]["minions_pre"]
+    end
+
+    # Accepts a minion into the cluster
+    def self.accept_minion(minion_id: "")
+      res = perform_request(endpoint: "/", method: "post",
+                            data: { client: "wheel",
+                                    fun:    "key.accept",
+                                    match:  minion_id,
+                                    tgt:    "ca" })
+      JSON.parse(res.body)["return"].first["data"]["return"]["minions"]
+    end
+
     # Call the salt orchestration.
     def self.orchestrate
       res = perform_request(endpoint: "/run", method: "post",

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe DashboardController, type: :controller do
     end
     # rubocop:enable RSpec/AnyInstance
     allow(Velum::Salt).to receive(:orchestrate)
+    setup_stubbed_pending_minions!
   end
 
   describe "GET / via HTML" do

--- a/spec/controllers/salt_controller_spec.rb
+++ b/spec/controllers/salt_controller_spec.rb
@@ -25,4 +25,13 @@ RSpec.describe SaltController, type: :controller do
       end
     end
   end
+
+  describe "POST /accept-minion" do
+    it "gets an 302 response" do
+      VCR.use_cassette("salt/accept_node", record: :none) do
+        post :accept_minion, minion_id: "81ad05b9d7ae4d26a83c421b64ca1952"
+        expect(response.status).to eq 302
+      end
+    end
+  end
 end

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe SetupController, type: :controller do
   let(:user)   { create(:user)   }
   let(:minion) { create(:minion) }
 
+  before do
+    setup_stubbed_pending_minions!
+  end
+
   describe "GET /" do
     it "gets redirected if not logged in" do
       get :welcome

--- a/spec/features/add_unassigned_nodes_feature_spec.rb
+++ b/spec/features/add_unassigned_nodes_feature_spec.rb
@@ -14,6 +14,7 @@ feature "Add unassigned nodes" do
   before do
     login_as user, scope: :user
     setup_stubbed_update_status!
+    setup_stubbed_pending_minions!
 
     [:minion, :master].each do |role|
       allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
@@ -32,6 +33,7 @@ feature "Add unassigned nodes" do
 
   # rubocop:disable RSpec/ExampleLength
   scenario "An user selects which nodes will be added", js: true do
+
     using_wait_time 10 do
       # select node minion3.k8s.local
       find("#roles_minion_#{minions[2].id}").click

--- a/spec/features/admin_node_update_feature_spec.rb
+++ b/spec/features/admin_node_update_feature_spec.rb
@@ -7,6 +7,7 @@ feature "Manage nodes updates feature" do
   before do
     login_as user, scope: :user
     Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master")
+    setup_stubbed_pending_minions!
   end
 
   scenario "Admin node has no update available", js: true do

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -8,6 +8,7 @@ feature "Bootstrap cluster feature" do
   before do
     login_as user, scope: :user
     setup_stubbed_update_status!
+    setup_stubbed_pending_minions!
     visit setup_discovery_path
   end
 

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -10,7 +10,7 @@ feature "Dashboard" do
       Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master")
       Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local", role: "worker")
       setup_stubbed_update_status!
-
+      setup_stubbed_pending_minions!
       visit authenticated_root_path
     end
 

--- a/spec/features/monitoring_feature_spec.rb
+++ b/spec/features/monitoring_feature_spec.rb
@@ -8,6 +8,7 @@ feature "Monitoring feature" do
     login_as user, scope: :user
     Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master")
     setup_stubbed_update_status!
+    setup_stubbed_pending_minions!
     visit authenticated_root_path
   end
 

--- a/spec/lib/velum/salt_spec.rb
+++ b/spec/lib/velum/salt_spec.rb
@@ -27,6 +27,14 @@ describe Velum::Salt do
     end
   end
 
+  describe "pending_minions" do
+    it "fetches a list of pending minions" do
+      VCR.use_cassette("salt/fetch_pending_minions", record: :none) do
+        expect(described_class.pending_minions.size).to eq 1
+      end
+    end
+  end
+
   describe "orchestration" do
     it "runs the orchestration in async mode" do
       VCR.use_cassette("salt/orchestrate_async", record: :none) do

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -5,6 +5,11 @@ module Utils
   def setup_stubbed_update_status!(stubbed: [[], []])
     allow(::Velum::Salt).to receive(:update_status).and_return(stubbed)
   end
+
+  # Stubs the ::Velum::Salt.pending_minions method with the given data.
+  def setup_stubbed_pending_minions!(stubbed: [""])
+    allow(::Velum::Salt).to receive(:pending_minions).and_return(stubbed)
+  end
 end
 
 RSpec.configure { |config| config.include Utils }

--- a/spec/vcr_cassettes/salt/accept_node.yml
+++ b/spec/vcr_cassettes/salt/accept_node.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"0COpCmgadWq9/91eNjOaoKOR0giqni+FrAFsgGnnKg/izEOOk1JlP7CHLyhY8b5wr7aog+UeWmr8","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '217'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Fri, 23 Jun 2017 11:42:58 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Auth-Token:
+      - 03fd871e370f40ddb14aedc0acf048a505ce01d3
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=03fd871e370f40ddb14aedc0acf048a505ce01d3; expires=Fri, 23 Jun 2017
+        21:42:58 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
+        "start": 1498218178.687943, "token": "03fd871e370f40ddb14aedc0acf048a505ce01d3",
+        "expire": 1498261378.687944, "user": "saltapi", "eauth": "pam"}]}'
+    http_version: 
+  recorded_at: Fri, 23 Jun 2017 11:42:58 GMT
+- request:
+    method: post
+    uri: http://127.0.0.1:8000/
+    body:
+      encoding: UTF-8
+      string: '{"client":"wheel","fun":"key.accept","match":"81ad05b9d7ae4d26a83c421b64ca1952","tgt":"ca"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Auth-Token:
+      - 03fd871e370f40ddb14aedc0acf048a505ce01d3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '303'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Cache-Control:
+      - private
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Fri, 23 Jun 2017 11:42:58 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=03fd871e370f40ddb14aedc0acf048a505ce01d3; expires=Fri, 23 Jun 2017
+        21:42:58 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"tag": "salt/wheel/20170623114258698842", "data": {"jid":
+        "20170623114258698842", "return": {"minions": ["81ad05b9d7ae4d26a83c421b64ca1952"]},
+        "success": true, "_stamp": "2017-06-23T11:42:58.707968", "tag": "salt/wheel/20170623114258698842",
+        "user": "saltapi", "fun": "wheel.key.accept"}}]}'
+    http_version: 
+  recorded_at: Fri, 23 Jun 2017 11:42:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/salt/fetch_pending_minions.yml
+++ b/spec/vcr_cassettes/salt/fetch_pending_minions.yml
@@ -1,0 +1,380 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:8000/minions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Auth-Token:
+      - 65041449d8ebb8b590be8b42b530b3f7f8932db8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '17863'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Cache-Control:
+      - private
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Fri, 23 Jun 2017 11:47:43 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=65041449d8ebb8b590be8b42b530b3f7f8932db8; expires=Fri, 23 Jun 2017
+        21:47:43 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"01664daa312f4cd4876a389f84140e4b": {"biosversion": "rel-1.9.1-0-gb3ef39f-prebuilt.qemu-project.org",
+        "kernel": "Linux", "domain": "infra.caasp.local", "biosreleasedate": "04/01/2014",
+        "uid": 0, "zmqversion": "4.0.4", "kernelrelease": "4.4.59-92.20-default",
+        "pythonpath": ["/usr/bin", "/usr/lib/python27.zip", "/usr/lib64/python2.7",
+        "/usr/lib64/python2.7/plat-linux2", "/usr/lib64/python2.7/lib-tk", "/usr/lib64/python2.7/lib-old",
+        "/usr/lib64/python2.7/lib-dynload", "/usr/lib64/python2.7/site-packages",
+        "/usr/local/lib64/python2.7/site-packages", "/usr/local/lib/python2.7/site-packages",
+        "/usr/lib/python2.7/site-packages"], "pid": 2409, "ip_interfaces": {"flannel0":
+        ["172.20.76.0"], "lo": ["127.0.0.1", "::1"], "docker0": ["172.20.76.1"], "eth0":
+        ["10.17.3.208", "fe80::a845:f7ff:febf:4703"]}, "groupname": "root", "fqdn_ip6":
+        [], "mem_total": 1999, "caasp_fqdn": "01664daa312f4cd4876a389f84140e4b.infra.caasp.local",
+        "saltversioninfo": [2016, 11, 4, 0], "SSDs": [], "id": "01664daa312f4cd4876a389f84140e4b",
+        "osrelease": "1.0", "ps": "ps -efH", "server_id": 1670181208, "fqdn": "01664daa312f4cd4876a389f84140e4b.infra.caasp.local",
+        "uuid": "01664daa-312f-4cd4-876a-389f84140e4b", "ip6_interfaces": {"flannel0":
+        [], "lo": ["::1"], "docker0": [], "eth0": ["fe80::a845:f7ff:febf:4703"]},
+        "num_cpus": 1, "hwaddr_interfaces": {"lo": "00:00:00:00:00:00", "docker0":
+        "02:42:08:36:51:ed", "eth0": "aa:45:f7:bf:47:03"}, "osfullname": "CAASP",
+        "ip4_interfaces": {"flannel0": ["172.20.76.0"], "lo": ["127.0.0.1"], "docker0":
+        ["172.20.76.1"], "eth0": ["10.17.3.208"]}, "init": "systemd", "gid": 0, "master":
+        "10.4.10.189", "ipv4": ["10.17.3.208", "127.0.0.1", "172.20.76.0", "172.20.76.1"],
+        "dns": {"domain": "", "sortlist": [], "nameservers": ["10.17.3.1"], "ip4_nameservers":
+        ["10.17.3.1"], "search": ["k8s.local"], "ip6_nameservers": [], "options":
+        []}, "ipv6": ["::1", "fe80::a845:f7ff:febf:4703"], "cpu_flags": ["fpu", "de",
+        "pse", "tsc", "msr", "pae", "mce", "cx8", "apic", "sep", "mtrr", "pge", "mca",
+        "cmov", "pse36", "clflush", "mmx", "fxsr", "sse", "sse2", "syscall", "nx",
+        "lm", "rep_good", "nopl", "pni", "cx16", "x2apic", "hypervisor", "lahf_lm"],
+        "localhost": "minion1", "lsb_distrib_id": "CAASP", "username": "root", "fqdn_ip4":
+        ["10.17.3.208"], "shell": "/bin/sh", "nodename": "minion1", "saltversion":
+        "2016.11.4", "lsb_distrib_release": "1.0", "bootstrap_complete": true, "systemd":
+        {"version": "228", "features": "+PAM -AUDIT +SELINUX -IMA +APPARMOR -SMACK
+        +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT -GNUTLS +ACL +XZ -LZ4 +SECCOMP +BLKID
+        -ELFUTILS +KMOD -IDN"}, "saltpath": "/usr/lib/python2.7/site-packages/salt",
+        "host": "01664daa312f4cd4876a389f84140e4b", "os_family": "Suse", "oscodename":
+        "SUSE Container as a Service Platform 1.0", "osfinger": "CAASP-1", "pythonversion":
+        [2, 7, 13, "final", 0], "manufacturer": "QEMU", "num_gpus": 0, "roles": ["kube-minion"],
+        "virtual": "kvm", "disks": ["sr0", "vda"], "cpu_model": "QEMU Virtual CPU
+        version 2.5+", "osmajorrelease": "1", "pythonexecutable": "/usr/bin/python",
+        "productname": "Standard PC (i440FX + PIIX, 1996)", "osarch": "x86_64", "cpuarch":
+        "x86_64", "lsb_distrib_codename": "SUSE Container as a Service Platform 1.0",
+        "osrelease_info": [1, 0], "locale_info": {"detectedencoding": "UTF-8", "defaultlanguage":
+        "en_US", "defaultencoding": "UTF-8"}, "gpus": [], "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "machine_id": "01664daa312f4cd4876a389f84140e4b", "os": "SUSE"}, "3600f74aac004f3b97dd833005eaf5ff":
+        {"biosversion": "rel-1.9.1-0-gb3ef39f-prebuilt.qemu-project.org", "kernel":
+        "Linux", "domain": "infra.caasp.local", "biosreleasedate": "04/01/2014", "uid":
+        0, "zmqversion": "4.0.4", "kernelrelease": "4.4.59-92.20-default", "pythonpath":
+        ["/usr/bin", "/usr/lib/python27.zip", "/usr/lib64/python2.7", "/usr/lib64/python2.7/plat-linux2",
+        "/usr/lib64/python2.7/lib-tk", "/usr/lib64/python2.7/lib-old", "/usr/lib64/python2.7/lib-dynload",
+        "/usr/lib64/python2.7/site-packages", "/usr/local/lib64/python2.7/site-packages",
+        "/usr/local/lib/python2.7/site-packages", "/usr/lib/python2.7/site-packages"],
+        "pid": 2307, "ip_interfaces": {"flannel0": ["172.20.126.0"], "lo": ["127.0.0.1",
+        "::1"], "docker0": ["172.20.126.1"], "eth0": ["10.17.3.94", "fe80::743a:e9ff:fee2:6686"]},
+        "groupname": "root", "fqdn_ip6": [], "mem_total": 1999, "caasp_fqdn": "3600f74aac004f3b97dd833005eaf5ff.infra.caasp.local",
+        "saltversioninfo": [2016, 11, 4, 0], "SSDs": [], "id": "3600f74aac004f3b97dd833005eaf5ff",
+        "osrelease": "1.0", "ps": "ps -efH", "server_id": 1206297024, "fqdn": "3600f74aac004f3b97dd833005eaf5ff.infra.caasp.local",
+        "uuid": "3600f74a-ac00-4f3b-97dd-833005eaf5ff", "ip6_interfaces": {"flannel0":
+        [], "lo": ["::1"], "docker0": [], "eth0": ["fe80::743a:e9ff:fee2:6686"]},
+        "num_cpus": 1, "hwaddr_interfaces": {"lo": "00:00:00:00:00:00", "docker0":
+        "02:42:a0:7f:60:74", "eth0": "76:3a:e9:e2:66:86"}, "osfullname": "CAASP",
+        "ip4_interfaces": {"flannel0": ["172.20.126.0"], "lo": ["127.0.0.1"], "docker0":
+        ["172.20.126.1"], "eth0": ["10.17.3.94"]}, "init": "systemd", "gid": 0, "master":
+        "10.4.10.189", "ipv4": ["10.17.3.94", "127.0.0.1", "172.20.126.0", "172.20.126.1"],
+        "dns": {"domain": "", "sortlist": [], "nameservers": ["10.17.3.1"], "ip4_nameservers":
+        ["10.17.3.1"], "search": ["k8s.local"], "ip6_nameservers": [], "options":
+        []}, "ipv6": ["::1", "fe80::743a:e9ff:fee2:6686"], "cpu_flags": ["fpu", "de",
+        "pse", "tsc", "msr", "pae", "mce", "cx8", "apic", "sep", "mtrr", "pge", "mca",
+        "cmov", "pse36", "clflush", "mmx", "fxsr", "sse", "sse2", "syscall", "nx",
+        "lm", "rep_good", "nopl", "pni", "cx16", "x2apic", "hypervisor", "lahf_lm"],
+        "localhost": "minion2", "lsb_distrib_id": "CAASP", "username": "root", "fqdn_ip4":
+        ["10.17.3.94"], "shell": "/bin/sh", "nodename": "minion2", "saltversion":
+        "2016.11.4", "lsb_distrib_release": "1.0", "bootstrap_complete": true, "systemd":
+        {"version": "228", "features": "+PAM -AUDIT +SELINUX -IMA +APPARMOR -SMACK
+        +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT -GNUTLS +ACL +XZ -LZ4 +SECCOMP +BLKID
+        -ELFUTILS +KMOD -IDN"}, "saltpath": "/usr/lib/python2.7/site-packages/salt",
+        "host": "3600f74aac004f3b97dd833005eaf5ff", "os_family": "Suse", "oscodename":
+        "SUSE Container as a Service Platform 1.0", "osfinger": "CAASP-1", "pythonversion":
+        [2, 7, 13, "final", 0], "manufacturer": "QEMU", "num_gpus": 0, "roles": ["kube-minion"],
+        "virtual": "kvm", "disks": ["sr0", "vda"], "cpu_model": "QEMU Virtual CPU
+        version 2.5+", "osmajorrelease": "1", "pythonexecutable": "/usr/bin/python",
+        "productname": "Standard PC (i440FX + PIIX, 1996)", "osarch": "x86_64", "cpuarch":
+        "x86_64", "lsb_distrib_codename": "SUSE Container as a Service Platform 1.0",
+        "osrelease_info": [1, 0], "locale_info": {"detectedencoding": "UTF-8", "defaultlanguage":
+        "en_US", "defaultencoding": "UTF-8"}, "gpus": [], "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "machine_id": "3600f74aac004f3b97dd833005eaf5ff", "os": "SUSE"}, "ca": {"kernel":
+        "Linux", "domain": "", "uid": 0, "zmqversion": "4.0.4", "kernelrelease": "4.4.49-16-default",
+        "pythonpath": ["/usr/bin", "/usr/lib/python27.zip", "/usr/lib64/python2.7",
+        "/usr/lib64/python2.7/plat-linux2", "/usr/lib64/python2.7/lib-tk", "/usr/lib64/python2.7/lib-old",
+        "/usr/lib64/python2.7/lib-dynload", "/usr/lib64/python2.7/site-packages",
+        "/usr/local/lib64/python2.7/site-packages", "/usr/local/lib/python2.7/site-packages",
+        "/usr/lib/python2.7/site-packages"], "pid": 10, "ip_interfaces": {"docker0":
+        ["172.17.0.1"], "lo": ["127.0.0.1"], "tun0": ["10.163.1.207"], "vnet3": [],
+        "vethdd701": [], "vnet0": [], "vnet1": [], "vnet2": [], "virbr1-ni": [], "vnet4":
+        [], "virbr1": ["10.17.3.1"], "eth2": [], "eth1": ["10.4.10.189", "fe80::42a8:f0ff:fe3d:20c7"],
+        "eth0": []}, "groupname": "root", "fqdn_ip6": [], "mem_total": 128865, "saltversioninfo":
+        [2016, 11, 4, 0], "SSDs": ["sda", "dm-0", "dm-1"], "id": "ca", "osrelease":
+        "12.2", "ps": "ps -efH", "server_id": 610049290, "fqdn": "linux-o8xt", "ip6_interfaces":
+        {"docker0": [], "lo": [], "tun0": [], "vnet3": [], "vethdd701": [], "vnet0":
+        [], "vnet1": [], "vnet2": [], "virbr1-ni": [], "vnet4": [], "virbr1": [],
+        "eth2": [], "eth1": ["fe80::42a8:f0ff:fe3d:20c7"], "eth0": []}, "num_cpus":
+        12, "hwaddr_interfaces": {"docker0": "02:42:01:CA:8D:1D", "tun0": "00", "vnet3":
+        "FE:3A:E9:E2:66:86", "vethdd701": "3A:4B:A0:03:1A:D8", "vnet0": "FE:AD:B5:83:87:3C",
+        "vnet1": "FE:45:F7:BF:47:03", "vnet2": "FE:84:18:68:C2:FE", "virbr1-ni": "52:54:00:C7:09:A9",
+        "vnet4": "FE:4A:EB:20:75:49", "virbr1": "52:54:00:C7:09:A9", "eth2": "40:A8:F0:3D:20:C8",
+        "eth1": "40:A8:F0:3D:20:C7", "eth0": "A0:36:9F:42:C5:53"}, "osfullname": "SLES",
+        "ip4_interfaces": {"docker0": ["172.17.0.1"], "lo": ["127.0.0.1"], "tun0":
+        ["10.163.1.207"], "vnet3": [], "vethdd701": [], "vnet0": [], "vnet1": [],
+        "vnet2": [], "virbr1-ni": [], "vnet4": [], "virbr1": ["10.17.3.1"], "eth2":
+        [], "eth1": ["10.4.10.189"], "eth0": []}, "virtual_subtype": "Docker", "init":
+        "unknown", "gid": 0, "master": "localhost", "lsb_distrib_id": "SLES", "dns":
+        {"domain": "", "sortlist": [], "nameservers": ["10.160.0.1", "10.160.2.88",
+        "10.4.0.1"], "ip4_nameservers": ["10.160.0.1", "10.160.2.88", "10.4.0.1"],
+        "search": ["suse.de"], "ip6_nameservers": [], "options": []}, "ipv6": ["fe80::42a8:f0ff:fe3d:20c7"],
+        "cpu_flags": ["fpu", "vme", "de", "pse", "tsc", "msr", "pae", "mce", "cx8",
+        "apic", "sep", "mtrr", "pge", "mca", "cmov", "pat", "pse36", "clflush", "dts",
+        "acpi", "mmx", "fxsr", "sse", "sse2", "ss", "ht", "tm", "pbe", "syscall",
+        "nx", "pdpe1gb", "rdtscp", "lm", "constant_tsc", "arch_perfmon", "pebs", "bts",
+        "rep_good", "nopl", "xtopology", "nonstop_tsc", "aperfmperf", "eagerfpu",
+        "pni", "pclmulqdq", "dtes64", "monitor", "ds_cpl", "vmx", "smx", "est", "tm2",
+        "ssse3", "cx16", "xtpr", "pdcm", "pcid", "dca", "sse4_1", "sse4_2", "x2apic",
+        "popcnt", "tsc_deadline_timer", "aes", "xsave", "avx", "f16c", "rdrand", "lahf_lm",
+        "ida", "arat", "epb", "pln", "pts", "dtherm", "tpr_shadow", "vnmi", "flexpriority",
+        "ept", "vpid", "fsgsbase", "smep", "erms", "xsaveopt"], "localhost": "linux-o8xt",
+        "ipv4": ["10.4.10.189", "10.17.3.1", "10.163.1.207", "127.0.0.1", "172.17.0.1"],
+        "username": "root", "fqdn_ip4": [], "shell": "/bin/sh", "nodename": "linux-o8xt",
+        "saltversion": "2016.11.4", "lsb_distrib_release": "12.2", "systemd": {"version":
+        "228", "features": "+PAM -AUDIT +SELINUX -IMA +APPARMOR -SMACK +SYSVINIT +UTMP
+        +LIBCRYPTSETUP +GCRYPT -GNUTLS +ACL +XZ -LZ4 +SECCOMP +BLKID -ELFUTILS +KMOD
+        -IDN"}, "saltpath": "/usr/lib/python2.7/site-packages/salt", "host": "linux-o8xt",
+        "os_family": "Suse", "oscodename": "SUSE Linux Enterprise Server 12 SP2",
+        "osfinger": "SLES-12", "pythonversion": [2, 7, 13, "final", 0], "num_gpus":
+        0, "roles": ["ca"], "virtual": "physical", "disks": ["sdb", "sr0"], "cpu_model":
+        "Intel(R) Xeon(R) CPU E5-2620 v2 @ 2.10GHz", "osmajorrelease": "12", "pythonexecutable":
+        "/usr/bin/python", "osarch": "x86_64", "cpuarch": "x86_64", "lsb_distrib_codename":
+        "SUSE Linux Enterprise Server 12 SP2", "osrelease_info": [12, 2], "locale_info":
+        {"detectedencoding": "ascii", "defaultlanguage": null, "defaultencoding":
+        null}, "gpus": [], "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "machine_id": "be26fcb76e9d3aca03bf977c594bcf37", "os": "SUSE"}, "81ad05b9d7ae4d26a83c421b64ca1952":
+        {"biosversion": "rel-1.9.1-0-gb3ef39f-prebuilt.qemu-project.org", "kernel":
+        "Linux", "domain": "k8s.local", "biosreleasedate": "04/01/2014", "uid": 0,
+        "zmqversion": "4.0.4", "kernelrelease": "4.4.59-92.20-default", "pythonpath":
+        ["/usr/bin", "/usr/lib/python27.zip", "/usr/lib64/python2.7", "/usr/lib64/python2.7/plat-linux2",
+        "/usr/lib64/python2.7/lib-tk", "/usr/lib64/python2.7/lib-old", "/usr/lib64/python2.7/lib-dynload",
+        "/usr/lib64/python2.7/site-packages", "/usr/local/lib64/python2.7/site-packages",
+        "/usr/local/lib/python2.7/site-packages", "/usr/lib/python2.7/site-packages"],
+        "pid": 2296, "ip_interfaces": {"lo": ["127.0.0.1", "::1"], "docker0": ["172.17.0.1"],
+        "eth0": ["10.17.3.136", "fe80::e04a:ebff:fe20:7549"]}, "groupname": "root",
+        "fqdn_ip6": [], "mem_total": 1999, "saltversioninfo": [2016, 11, 4, 0], "SSDs":
+        [], "id": "81ad05b9d7ae4d26a83c421b64ca1952", "osrelease": "1.0", "ps": "ps
+        -efH", "server_id": 1514956574, "fqdn": "minion4.k8s.local", "uuid": "81ad05b9-d7ae-4d26-a83c-421b64ca1952",
+        "ip6_interfaces": {"lo": ["::1"], "docker0": [], "eth0": ["fe80::e04a:ebff:fe20:7549"]},
+        "num_cpus": 1, "hwaddr_interfaces": {"lo": "00:00:00:00:00:00", "docker0":
+        "02:42:f8:d8:d4:76", "eth0": "e2:4a:eb:20:75:49"}, "osfullname": "CAASP",
+        "ip4_interfaces": {"lo": ["127.0.0.1"], "docker0": ["172.17.0.1"], "eth0":
+        ["10.17.3.136"]}, "init": "systemd", "gid": 0, "master": "10.4.10.189", "ipv4":
+        ["10.17.3.136", "127.0.0.1", "172.17.0.1"], "dns": {"domain": "", "sortlist":
+        [], "nameservers": ["10.17.3.1"], "ip4_nameservers": ["10.17.3.1"], "search":
+        ["k8s.local"], "ip6_nameservers": [], "options": []}, "ipv6": ["::1", "fe80::e04a:ebff:fe20:7549"],
+        "cpu_flags": ["fpu", "de", "pse", "tsc", "msr", "pae", "mce", "cx8", "apic",
+        "sep", "mtrr", "pge", "mca", "cmov", "pse36", "clflush", "mmx", "fxsr", "sse",
+        "sse2", "syscall", "nx", "lm", "rep_good", "nopl", "pni", "cx16", "x2apic",
+        "hypervisor", "lahf_lm"], "localhost": "minion4", "lsb_distrib_id": "CAASP",
+        "username": "root", "fqdn_ip4": ["10.17.3.136"], "shell": "/bin/sh", "nodename":
+        "minion4", "saltversion": "2016.11.4", "lsb_distrib_release": "1.0", "systemd":
+        {"version": "228", "features": "+PAM -AUDIT +SELINUX -IMA +APPARMOR -SMACK
+        +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT -GNUTLS +ACL +XZ -LZ4 +SECCOMP +BLKID
+        -ELFUTILS +KMOD -IDN"}, "saltpath": "/usr/lib/python2.7/site-packages/salt",
+        "host": "minion4", "os_family": "Suse", "oscodename": "SUSE Container as a
+        Service Platform 1.0", "osfinger": "CAASP-1", "pythonversion": [2, 7, 13,
+        "final", 0], "manufacturer": "QEMU", "num_gpus": 0, "virtual": "kvm", "disks":
+        ["sr0", "vda"], "cpu_model": "QEMU Virtual CPU version 2.5+", "osmajorrelease":
+        "1", "pythonexecutable": "/usr/bin/python", "productname": "Standard PC (i440FX
+        + PIIX, 1996)", "osarch": "x86_64", "cpuarch": "x86_64", "lsb_distrib_codename":
+        "SUSE Container as a Service Platform 1.0", "osrelease_info": [1, 0], "locale_info":
+        {"detectedencoding": "UTF-8", "defaultlanguage": "en_US", "defaultencoding":
+        "UTF-8"}, "gpus": [], "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "machine_id": "81ad05b9d7ae4d26a83c421b64ca1952", "os": "SUSE"}, "91103109314442658dfc2dd3e41bb921":
+        {"biosversion": "rel-1.9.1-0-gb3ef39f-prebuilt.qemu-project.org", "kernel":
+        "Linux", "domain": "infra.caasp.local", "biosreleasedate": "04/01/2014", "uid":
+        0, "zmqversion": "4.0.4", "kernelrelease": "4.4.59-92.20-default", "pythonpath":
+        ["/usr/bin", "/usr/lib/python27.zip", "/usr/lib64/python2.7", "/usr/lib64/python2.7/plat-linux2",
+        "/usr/lib64/python2.7/lib-tk", "/usr/lib64/python2.7/lib-old", "/usr/lib64/python2.7/lib-dynload",
+        "/usr/lib64/python2.7/site-packages", "/usr/local/lib64/python2.7/site-packages",
+        "/usr/local/lib/python2.7/site-packages", "/usr/lib/python2.7/site-packages"],
+        "pid": 2291, "ip_interfaces": {"flannel0": ["172.20.120.0"], "lo": ["127.0.0.1",
+        "::1"], "docker0": ["172.20.120.1"], "eth0": ["10.17.3.99", "fe80::c0ad:b5ff:fe83:873c"]},
+        "groupname": "root", "fqdn_ip6": [], "mem_total": 1999, "caasp_fqdn": "91103109314442658dfc2dd3e41bb921.infra.caasp.local",
+        "saltversioninfo": [2016, 11, 4, 0], "SSDs": [], "id": "91103109314442658dfc2dd3e41bb921",
+        "osrelease": "1.0", "ps": "ps -efH", "server_id": 698422679, "fqdn": "api.infra.caasp.local",
+        "uuid": "91103109-3144-4265-8dfc-2dd3e41bb921", "ip6_interfaces": {"flannel0":
+        [], "lo": ["::1"], "docker0": [], "eth0": ["fe80::c0ad:b5ff:fe83:873c"]},
+        "num_cpus": 1, "hwaddr_interfaces": {"lo": "00:00:00:00:00:00", "docker0":
+        "02:42:88:08:0b:f7", "eth0": "c2:ad:b5:83:87:3c"}, "osfullname": "CAASP",
+        "ip4_interfaces": {"flannel0": ["172.20.120.0"], "lo": ["127.0.0.1"], "docker0":
+        ["172.20.120.1"], "eth0": ["10.17.3.99"]}, "init": "systemd", "gid": 0, "master":
+        "10.4.10.189", "ipv4": ["10.17.3.99", "127.0.0.1", "172.20.120.0", "172.20.120.1"],
+        "dns": {"domain": "", "sortlist": [], "nameservers": ["10.17.3.1"], "ip4_nameservers":
+        ["10.17.3.1"], "search": ["k8s.local"], "ip6_nameservers": [], "options":
+        []}, "ipv6": ["::1", "fe80::c0ad:b5ff:fe83:873c"], "cpu_flags": ["fpu", "de",
+        "pse", "tsc", "msr", "pae", "mce", "cx8", "apic", "sep", "mtrr", "pge", "mca",
+        "cmov", "pse36", "clflush", "mmx", "fxsr", "sse", "sse2", "syscall", "nx",
+        "lm", "rep_good", "nopl", "pni", "cx16", "x2apic", "hypervisor", "lahf_lm"],
+        "localhost": "minion0", "lsb_distrib_id": "CAASP", "username": "root", "fqdn_ip4":
+        ["10.17.3.99"], "shell": "/bin/sh", "nodename": "minion0", "saltversion":
+        "2016.11.4", "lsb_distrib_release": "1.0", "bootstrap_complete": true, "systemd":
+        {"version": "228", "features": "+PAM -AUDIT +SELINUX -IMA +APPARMOR -SMACK
+        +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT -GNUTLS +ACL +XZ -LZ4 +SECCOMP +BLKID
+        -ELFUTILS +KMOD -IDN"}, "saltpath": "/usr/lib/python2.7/site-packages/salt",
+        "host": "api", "os_family": "Suse", "oscodename": "SUSE Container as a Service
+        Platform 1.0", "osfinger": "CAASP-1", "pythonversion": [2, 7, 13, "final",
+        0], "manufacturer": "QEMU", "num_gpus": 0, "roles": ["kube-master"], "virtual":
+        "kvm", "disks": ["sr0", "vda"], "cpu_model": "QEMU Virtual CPU version 2.5+",
+        "osmajorrelease": "1", "pythonexecutable": "/usr/bin/python", "productname":
+        "Standard PC (i440FX + PIIX, 1996)", "osarch": "x86_64", "cpuarch": "x86_64",
+        "lsb_distrib_codename": "SUSE Container as a Service Platform 1.0", "osrelease_info":
+        [1, 0], "locale_info": {"detectedencoding": "UTF-8", "defaultlanguage": "en_US",
+        "defaultencoding": "UTF-8"}, "gpus": [], "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "machine_id": "91103109314442658dfc2dd3e41bb921", "os": "SUSE"}}]}'
+    http_version: 
+  recorded_at: Fri, 23 Jun 2017 11:47:44 GMT
+- request:
+    method: post
+    uri: http://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"0COpCmgadWq9/91eNjOaoKOR0giqni+FrAFsgGnnKg/izEOOk1JlP7CHLyhY8b5wr7aog+UeWmr8","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '217'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Fri, 23 Jun 2017 11:48:03 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Auth-Token:
+      - 27f6a2136e2d1771782f2672805295947a8e25e7
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=27f6a2136e2d1771782f2672805295947a8e25e7; expires=Fri, 23 Jun 2017
+        21:48:03 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
+        "start": 1498218483.492372, "token": "27f6a2136e2d1771782f2672805295947a8e25e7",
+        "expire": 1498261683.492373, "user": "saltapi", "eauth": "pam"}]}'
+    http_version: 
+  recorded_at: Fri, 23 Jun 2017 11:48:03 GMT
+- request:
+    method: post
+    uri: http://127.0.0.1:8000/
+    body:
+      encoding: UTF-8
+      string: '{"client":"wheel","fun":"key.list","match":"all","tgt":"ca"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Auth-Token:
+      - 27f6a2136e2d1771782f2672805295947a8e25e7
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '553'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Cache-Control:
+      - private
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Fri, 23 Jun 2017 11:48:03 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=27f6a2136e2d1771782f2672805295947a8e25e7; expires=Fri, 23 Jun 2017
+        21:48:03 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"tag": "salt/wheel/20170623114803502780", "data": {"jid":
+        "20170623114803502780", "return": {"minions_pre": ["e46c06494d164b05823148c4674ceae0"],
+        "minions_rejected": [], "minions_denied": [], "local": ["master.pem", "master.pub"],
+        "minions": ["01664daa312f4cd4876a389f84140e4b", "3600f74aac004f3b97dd833005eaf5ff",
+        "81ad05b9d7ae4d26a83c421b64ca1952", "91103109314442658dfc2dd3e41bb921", "ca"]},
+        "success": true, "_stamp": "2017-06-23T11:48:03.508614", "tag": "salt/wheel/20170623114803502780",
+        "user": "saltapi", "fun": "wheel.key.list"}}]}'
+    http_version: 
+  recorded_at: Fri, 23 Jun 2017 11:48:03 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Turning off `auto_accept` for salt means we need
to have a mechanism to accept nodes on a node
by node basis into the cluster.

This adds a pending nodes table that will show
all nodes that have not had their key accepted in salt
yet.

Current Issues: 
- [ ] When clicking "Accept Node" it does not disappear from the list immediately 
