### PR TITLE
'Reboot to update' after click behavior

### DIFF
--- a/app/controllers/updates_controller.rb
+++ b/app/controllers/updates_controller.rb
@@ -14,7 +14,7 @@ class UpdatesController < ApplicationController
       arg:     "systemctl reboot"
     )
 
-    redirect_to root_path, flash: { info: "Rebooting..." }
+    render json: { status: Minion.statuses[:rebooting] }
   end
 
   protected
@@ -26,6 +26,6 @@ class UpdatesController < ApplicationController
     return if status == Minion.statuses[:update_needed] ||
         status == Minion.statuses[:update_failed]
 
-    redirect_to root_path, flash: { error: "There's no need to update" }
+    render json: { status: Minion.statuses[:unknown] }
   end
 end

--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -12,7 +12,7 @@ class Minion < ApplicationRecord
 
   enum highstate: [:not_applied, :pending, :failed, :applied]
   enum role: [:master, :worker]
-  enum status: [:unknown, :update_needed, :update_failed]
+  enum status: [:unknown, :update_needed, :update_failed, :rebooting]
 
   validates :minion_id, presence: true, uniqueness: true
   validates :fqdn, presence: true

--- a/app/views/dashboard/_update_admin_modal.html.erb
+++ b/app/views/dashboard/_update_admin_modal.html.erb
@@ -12,10 +12,13 @@
       <div class="modal-body">
        <p>Rebooting the admin node will break ongoing operations like the creation of the cluster, the addition or removal of nodes and upgrades.</p>
        <p>Please ensure none of the following operations are ongoing before proceeding with the upgrade of the admin node.</p>
+       <p>Once the admin node is rebooted, the page will be refreshed.</p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary reboot-update-btn" data-url="<%= updates_url %>">Reboot to update</button>
+        <button type="button" class="btn btn-primary reboot-update-btn" data-url="<%= updates_url %>" data-health-check="<%= _health_url %>">
+          Reboot to update
+        </button>
       </div>
     </div>
   </div>

--- a/spec/controllers/updates_controller_spec.rb
+++ b/spec/controllers/updates_controller_spec.rb
@@ -12,20 +12,31 @@ RSpec.describe UpdatesController, type: :controller do
   end
 
   describe "reboot admin node" do
+    it "returns a json response" do
+      stubbed = [[{ "admin" => "" }], [{ "admin" => "" }]]
+      setup_stubbed_update_status!(stubbed: stubbed)
+
+      post :create
+      expect(response.content_type).to eq "application/json"
+    end
+
     it "does nothing if no update was needed" do
       stubbed = [[{ "admin" => "" }], [{ "admin" => "" }]]
       setup_stubbed_update_status!(stubbed: stubbed)
 
       post :create
-      expect(flash[:error]).to eq "There's no need to update"
+      json = JSON.parse(response.body)
+      expect(json["status"]).to eq Minion.statuses[:unknown]
     end
 
+    # rubocop:disable RSpec/ExampleLength
     it "allows the node to reboot if an update is needed" do
       stubbed = [[{ "admin" => true }], [{ "admin" => "" }]]
       setup_stubbed_update_status!(stubbed: stubbed)
 
       post :create
-      expect(flash[:info]).to eq "Rebooting..."
+      json = JSON.parse(response.body)
+      expect(json["status"]).to eq Minion.statuses[:rebooting]
       expect(::Velum::Salt).to have_received(:call).once
     end
 
@@ -34,8 +45,10 @@ RSpec.describe UpdatesController, type: :controller do
       setup_stubbed_update_status!(stubbed: stubbed)
 
       post :create
-      expect(flash[:info]).to eq "Rebooting..."
+      json = JSON.parse(response.body)
+      expect(json["status"]).to eq Minion.statuses[:rebooting]
       expect(::Velum::Salt).to have_received(:call).once
     end
+    # rubocop:enable RSpec/ExampleLength
   end
 end

--- a/spec/features/admin_node_update_feature_spec.rb
+++ b/spec/features/admin_node_update_feature_spec.rb
@@ -42,7 +42,6 @@ feature "Manage nodes updates feature" do
     end
     # rubocop:enable RSpec/MultipleExpectations
 
-    # rubocop:disable RSpec/ExampleLength
     scenario "User clicks on 'Reboot to update'", js: true do
       allow(::Velum::Salt).to receive(:call).and_return(true)
 
@@ -50,13 +49,12 @@ feature "Manage nodes updates feature" do
       find(".update-admin-btn").click
 
       # wait modal to appear
-      wait_until { page.has_text?("Reboot to update") }
+      expect(page).to have_content("Reboot to update")
 
       # clicks on "Reboot to update"
       find(".reboot-update-btn").click
 
-      wait_until { page.has_text?("Rebooting...") }
-      expect(page).to have_content("Rebooting...")
+      expect(page).to have_content("Rebooting...", wait: 10)
 
       # NOTE: The check below is flaky: sometimes it passes and sometimes it
       # doesn't. We believe that this is Capybara/Poltergeist to blame. Since we
@@ -65,7 +63,6 @@ feature "Manage nodes updates feature" do
       # the controller was reached, we have simply commented out the line below.
       # expect(::Velum::Salt).to have_received(:call).once
     end
-    # rubocop:enable RSpec/ExampleLength
   end
 
   scenario "Admin node has an update available (failed to update)", js: true do


### PR DESCRIPTION
After clicking "Reboot to update", fixed wrong button text and locked modal until admin node is rebooted.

bsc#1045380, bsc#1045730

![peek 2017-06-26 18-41](https://user-images.githubusercontent.com/188554/27562016-f4d30e68-5aa0-11e7-96dc-d2e55bb68f14.gif)

- [X] Implementation
- [X] Update specs
- [x] GIF