### PR TITLE
Complete proxy support [bsc#1043538]

### DIFF
--- a/app/assets/javascripts/setup.js
+++ b/app/assets/javascripts/setup.js
@@ -1,0 +1,5 @@
+$('.btn-toggle').click(function() {
+  $(this).find('.btn').toggleClass('active');
+  $(this).find('.btn').toggleClass('btn-primary');
+  $(this).find('.btn').toggleClass('btn-default');
+});

--- a/app/assets/javascripts/setup.js
+++ b/app/assets/javascripts/setup.js
@@ -1,5 +1,6 @@
-$('.btn-toggle').click(function() {
-  $(this).find('.btn').toggleClass('active');
-  $(this).find('.btn').toggleClass('btn-primary');
-  $(this).find('.btn').toggleClass('btn-default');
+$('.btn-group-toggle').click(function() {
+  var $btnGroup = $(this);
+  $btnGroup.find('.btn').toggleClass('active');
+  $btnGroup.find('.btn').toggleClass('btn-primary');
+  $btnGroup.find('.btn').toggleClass('btn-default');
 });

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -54,8 +54,8 @@ class DashboardController < ApplicationController
 
       # proxy related settings
       @proxy_systemwide = Pillar.value(pillar: :proxy_systemwide) == "true"
-      @proxy_http       = Pillar.value(pillar: :proxy_http)
-      @proxy_https      = Pillar.value(pillar: :proxy_https)
+      @proxy_http       = Pillar.value(pillar: :http_proxy)
+      @proxy_https      = Pillar.value(pillar: :https_proxy)
       @proxy_no_proxy   = Pillar.value(pillar: :no_proxy)
 
       render "autoyast.xml.erb", layout: false, content_type: "text/xml"

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -51,6 +51,13 @@ class DashboardController < ApplicationController
       # rubocop:disable Style/RescueModifier
       @ssh_public_key = File.read(ssh_key_file) rescue nil
       # rubocop:enable Style/RescueModifier
+
+      # proxy related settings
+      @proxy_systemwide = Pillar.value(pillar: :proxy_systemwide) == "true"
+      @proxy_http       = Pillar.value(pillar: :proxy_http)
+      @proxy_https      = Pillar.value(pillar: :proxy_https)
+      @proxy_no_proxy   = Pillar.value(pillar: :no_proxy)
+
       render "autoyast.xml.erb", layout: false, content_type: "text/xml"
     end
   rescue Velum::SUSEConnect::SCCConnectionException

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -60,7 +60,14 @@ class SetupController < ApplicationController
   private
 
   def settings_params
-    params.require(:settings).permit(*Pillar.all_pillars.keys)
+    settings = params.require(:settings).permit(*Pillar.all_pillars.keys)
+    if params["settings"]["enable_proxy"] == "disable"
+      settings["proxy_systemwide"] = "false"
+      settings["http_proxy"] = ""
+      settings["https_proxy"] = ""
+      settings["no_proxy"] = ""
+    end
+    settings
   end
 
   def update_nodes_params

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -46,12 +46,12 @@ class Pillar < ApplicationRecord
 
     def all_pillars
       {
-        dashboard:   "dashboard",
-        apiserver:   "api:server:external_fqdn",
+        dashboard:        "dashboard",
+        apiserver:        "api:server:external_fqdn",
         proxy_systemwide: "proxy:systemwide",
-        http_proxy:  "proxy:http",
-        https_proxy: "proxy:https",
-        no_proxy:    "proxy:no_proxy"
+        http_proxy:       "proxy:http",
+        https_proxy:      "proxy:https",
+        no_proxy:         "proxy:no_proxy"
       }
     end
 

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -48,6 +48,7 @@ class Pillar < ApplicationRecord
       {
         dashboard:   "dashboard",
         apiserver:   "api:server:external_fqdn",
+        proxy_systemwide: "proxy:systemwide",
         http_proxy:  "proxy:http",
         https_proxy: "proxy:https",
         no_proxy:    "proxy:no_proxy"

--- a/app/views/dashboard/autoyast.xml.erb
+++ b/app/views/dashboard/autoyast.xml.erb
@@ -39,6 +39,29 @@
         </source>
       </script>
 <% end %>
+<% if @proxy_systemwide %>
+      <script>
+        <chrooted config:type="boolean">true</chrooted>
+        <filename>set_proxy.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+        #!/bin/sh
+        sed -i -e 's|PROXY_ENABLED=".*"|PROXY_ENABLED="yes"|g' /etc/sysconfig/proxy
+<% unless @proxy_http.blank? %>
+        sed -i -e 's|HTTP_PROXY=".*"|HTTP_PROXY="<%= @proxy_http %>"|g' /etc/sysconfig/proxy
+        echo '--proxy "<%= @proxy_http %>"' >> /root/.curlrc
+<% end %>
+<% unless @proxy_https.blank? %>
+        sed -i -e 's|HTTPS_PROXY=".*"|HTTPS_PROXY="<%= @proxy_https %>"|g' /etc/sysconfig/proxy
+<% end %>
+<% unless @proxy_no_proxy.blank? %>
+        sed -i -e 's|NO_PROXY=".*"|NO_PROXY="<%= @proxy_no_proxy %>"|g' /etc/sysconfig/proxy
+        echo '--noproxy "<%= @proxy_no_proxy %>"' >> /root/.curlrc
+<% end %>
+        ]]>
+        </source>
+      </script>
+<% end %>
     </chroot-scripts>
   </scripts>
   <bootloader>
@@ -137,20 +160,6 @@
       <ipv4_forward config:type="boolean">false</ipv4_forward>
       <ipv6_forward config:type="boolean">false</ipv6_forward>
     </routing>
-    <% if @proxy_systemwide %>
-    <proxy>
-      <enabled config:type="boolean">true</enabled>
-      <% unless @proxy_http.blank? %>
-      <http_proxy><%= @proxy_http %></http_proxy>
-      <% end %>
-      <% unless @proxy_https.blank? %>
-      <https_proxy><%= @proxy_https %></https_proxy>
-      <% end %>
-      <% unless @proxy_no_proxy.blank? %>
-      <no_proxy><%= @proxy_no_proxy %></no_proxy>
-      <% end %>
-    </proxy>
-    <% end %>
   </networking>
   <software>
     <image/>

--- a/app/views/dashboard/autoyast.xml.erb
+++ b/app/views/dashboard/autoyast.xml.erb
@@ -137,6 +137,20 @@
       <ipv4_forward config:type="boolean">false</ipv4_forward>
       <ipv6_forward config:type="boolean">false</ipv6_forward>
     </routing>
+    <% if @proxy_systemwide %>
+    <proxy>
+      <enabled config:type="boolean">true</enabled>
+      <% unless @proxy_http.blank? %>
+      <http_proxy><%= @proxy_http %></http_proxy>
+      <% end %>
+      <% unless @proxy_https.blank? %>
+      <https_proxy><%= @proxy_https %></https_proxy>
+      <% end %>
+      <% unless @proxy_no_proxy.blank? %>
+      <no_proxy><%= @proxy_no_proxy %></no_proxy>
+      <% end %>
+    </proxy>
+    <% end %>
   </networking>
   <software>
     <image/>

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -1,5 +1,6 @@
 = content_for :body_class, "welcome"
 h1 Initial CaaSP Configuration
+
 = form_for :settings, url: setup_path, method: :put do |f|
   .panel.panel-default
     .panel-heading Generic settings
@@ -20,23 +21,43 @@ h1 Initial CaaSP Configuration
               i class='glyphicon glyphicon-info-sign'
 
   .panel.panel-default
-    .panel-heading Container engine proxy settings
-    .panel-body
-      p Proxy server the container engine will use to download images.
-      p Leave them empty if no proxy server is in place inside of your organization.
+    .panel-heading.clearfix
+      | Proxy settings
       .form-group
-        = f.label :http_proxy, "HTTP proxy"
-        = f.url_field :http_proxy, value: Pillar.value(pillar: :http_proxy), class: "form-control"
-      .form-group
-        = f.label :https_proxy, "HTTPS proxy"
-        = f.url_field :https_proxy, value: Pillar.value(pillar: :https_proxy), class: "form-control"
-      .form-group
-        = f.label :no, "No-proxy"
-        .input-group
-          = f.text_field :no_proxy, value: Pillar.value(pillar: :no_proxy), class: "form-control"
-          span class="input-group-addon"
-            a data-toggle="tooltip" data-placement="left" title="Comma separated list of sites or domains that should not be accessed via the proxy server."
-              i class='glyphicon glyphicon-info-sign'
+        .input-group.btn-group.btn-toggle.pull-right data-toggle="buttons"
+          = label_tag :proxy_toggle, nil, class: "btn btn-default", "data-toggle" => "collapse", "data-target" => "#proxy-settings-panel"
+            = f.radio_button :enable_proxy, "enable", checked: false
+            | Enable
+          = label_tag :proxy_toggle, nil, class: "btn btn-primary active", "data-toggle" => "collapse", "data-target" => "#proxy-settings-panel"
+            = f.radio_button :enable_proxy, "disable", checked: true
+            | Disable
+
+    #proxy-settings-panel.panel-collapse.collapse
+      .panel-body
+        .form-group
+          = f.label :http_proxy, "HTTP proxy"
+          = f.url_field :http_proxy, value: Pillar.value(pillar: :http_proxy), class: "form-control"
+        .form-group
+          = f.label :https_proxy, "HTTPS proxy"
+          = f.url_field :https_proxy, value: Pillar.value(pillar: :https_proxy), class: "form-control"
+        .form-group
+          = f.label :no, "No-proxy"
+          .input-group
+            = f.text_field :no_proxy, value: Pillar.value(pillar: :no_proxy), class: "form-control"
+            span class="input-group-addon"
+              a data-toggle="tooltip" data-placement="left" title="Comma separated list of sites or domains that should not be accessed via the proxy server."
+                i class='glyphicon glyphicon-info-sign'
+        .form-group
+          = f.label :proxy_systemwide, "Use proxy systemwide"
+          p Choose whether the proxy settings should apply only to the container
+            engine or to all the processes running on the cluster nodes.
+          .input-group.btn-group.btn-toggle data-toggle="buttons"
+            = label_tag :proxy_systemwide, nil, class: "btn btn-primary active"
+              = f.radio_button :proxy_systemwide, "false", checked: true
+              | Container Engine only
+            = label_tag :proxy_systemwide, nil, class: "btn btn-default"
+              = f.radio_button :proxy_systemwide, "true", checked: false
+              | Entire node
 
   .clearfix.steps-container
     = submit_tag "Next", class: "btn btn-primary pull-right"

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -22,15 +22,14 @@ h1 Initial CaaSP Configuration
 
   .panel.panel-default
     .panel-heading.clearfix
-      | Proxy settings
-      .form-group
-        .input-group.btn-group.btn-toggle.pull-right data-toggle="buttons"
-          = label_tag :proxy_toggle, nil, class: "btn btn-default", "data-toggle" => "collapse", "data-target" => "#proxy-settings-panel"
-            = f.radio_button :enable_proxy, "enable", checked: false
-            | Enable
-          = label_tag :proxy_toggle, nil, class: "btn btn-primary active", "data-toggle" => "collapse", "data-target" => "#proxy-settings-panel"
-            = f.radio_button :enable_proxy, "disable", checked: true
-            | Disable
+      h3.panel-title Proxy settings
+      .btn-group.btn-group-sm.btn-group-toggle.pull-right data-toggle="buttons"
+        = label_tag :proxy_toggle, nil, class: "btn btn-default", data: {toggle: "collapse", target: "#proxy-settings-panel"}
+          = f.radio_button :enable_proxy, "enable", checked: false
+          | Enable
+        = label_tag :proxy_toggle, nil, class: "btn btn-primary active", data: {toggle: "collapse", target: "#proxy-settings-panel"}
+          = f.radio_button :enable_proxy, "disable", checked: true
+          | Disable
 
     #proxy-settings-panel.panel-collapse.collapse
       .panel-body
@@ -43,7 +42,7 @@ h1 Initial CaaSP Configuration
         .form-group
           = f.label :no, "No-proxy"
           .input-group
-            = f.text_field :no_proxy, value: Pillar.value(pillar: :no_proxy), class: "form-control"
+            = f.text_field :no_proxy, value: (Pillar.value(pillar: :no_proxy) || "localhost, 127.0.01"), class: "form-control"
             span class="input-group-addon"
               a data-toggle="tooltip" data-placement="left" title="Comma separated list of sites or domains that should not be accessed via the proxy server."
                 i class='glyphicon glyphicon-info-sign'
@@ -51,7 +50,7 @@ h1 Initial CaaSP Configuration
           = f.label :proxy_systemwide, "Use proxy systemwide"
           p Choose whether the proxy settings should apply only to the container
             engine or to all the processes running on the cluster nodes.
-          .input-group.btn-group.btn-toggle data-toggle="buttons"
+          .btn-group.btn-group-toggle data-toggle="buttons"
             = label_tag :proxy_systemwide, nil, class: "btn btn-primary active"
               = f.radio_button :proxy_systemwide, "false", checked: true
               | Container Engine only

--- a/spec/models/pillar_spec.rb
+++ b/spec/models/pillar_spec.rb
@@ -9,8 +9,8 @@ describe Pillar do
   describe "#apply" do
     let(:settings_params) do
       {
-        dashboard: "dashboard.example.com",
-        apiserver: "apiserver.example.com"
+        dashboard:        "dashboard.example.com",
+        apiserver:        "apiserver.example.com",
         proxy_systemwide: "false"
       }
     end
@@ -29,20 +29,22 @@ describe Pillar do
         proxy_enabled
       end
 
+      let(:proxy_pillars_that_can_be_blank) do
+        [:http_proxy, :https_proxy, :no_proxy]
+      end
+
       before do
         described_class.apply(proxy_enabled_settings_params)
+
+        proxy_pillars_that_can_be_blank.each do |key|
+          expect(settings_params[key]).to be_nil
+        end
       end
 
       it "removes proxy pillars when blank" do
-        keys = [:http_proxy, :https_proxy, :no_proxy]
-
-        keys.each do |key|
-          expect(settings_params[key]).to be_nil
-        end
-
         described_class.apply(settings_params)
 
-        keys.each do |key|
+        proxy_pillars_that_can_be_blank.each do |key|
           expect(described_class.find_by(pillar: key)).to be_nil
         end
       end

--- a/spec/models/pillar_spec.rb
+++ b/spec/models/pillar_spec.rb
@@ -19,5 +19,34 @@ describe Pillar do
       res = described_class.apply(settings_params)
       expect(res).to be_empty
     end
+
+    context "disable proxy settings" do
+      let(:proxy_enabled_settings_params) do
+        proxy_enabled = settings_params.dup
+        proxy_enabled[:http_proxy]  = "squid.corp.net:3128"
+        proxy_enabled[:https_proxy] = "squid.corp.net:3128"
+        proxy_enabled[:no_proxy]    = "localhost"
+        proxy_enabled
+      end
+
+      before do
+        described_class.apply(proxy_enabled_settings_params)
+      end
+
+      it "removes proxy pillars when blank" do
+        keys = [:http_proxy, :https_proxy, :no_proxy]
+
+        keys.each do |key|
+          expect(settings_params[key]).to be_nil
+        end
+
+        described_class.apply(settings_params)
+
+        keys.each do |key|
+          expect(described_class.find_by(pillar: key)).to be_nil
+        end
+      end
+    end
+
   end
 end

--- a/spec/models/pillar_spec.rb
+++ b/spec/models/pillar_spec.rb
@@ -11,6 +11,7 @@ describe Pillar do
       {
         dashboard: "dashboard.example.com",
         apiserver: "apiserver.example.com"
+        proxy_systemwide: "false"
       }
     end
 

--- a/spec/views/dashboard/autoyast.xml.slim_spec.rb
+++ b/spec/views/dashboard/autoyast.xml.slim_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe "dashboard/autoyast" do
+  context "when proxy is enabled" do
+    before do
+      assign(:proxy_systemwide, true)
+    end
+
+    it "generates a post partitioning script" do
+      render
+
+      matches = assert_select("scripts/chroot-scripts/script")
+      expect(matches.find { |m| m.to_s.include?("set_proxy.sh") }).not_to be_nil
+    end
+  end
+
+  context "when proxy is not enabled" do
+    before do
+      assign(:proxy_systemwide, false)
+    end
+
+    it "does not generate a proxy script" do
+      render
+
+      matches = assert_select("scripts/chroot-scripts/script")
+      expect(matches.find { |m| m.to_s.include?("set_proxy.sh") }).to be_nil
+    end
+
+  end
+
+end

--- a/spec/views/dashboard/index.html.slim_spec.rb
+++ b/spec/views/dashboard/index.html.slim_spec.rb
@@ -12,3 +12,31 @@ describe "dashboard/index" do
     end
   end
 end
+
+describe "dashboard/autoyast" do
+  context "when proxy is enabled" do
+    let(:http_proxy) { "squid.corp.net:3128"}
+    let(:https_proxy) { "squid.corp.net:3443"}
+    let(:no_proxy) { "localhost" }
+
+    before do
+      assign(:proxy_http, http_proxy)
+      assign(:proxy_https, https_proxy)
+      assign(:proxy_no_proxy, no_proxy)
+      assign(:proxy_systemwide, true)
+    end
+
+    it "generates a proxy section" do
+      render
+
+      section = assert_select "profile/networking/proxy/http_proxy"
+      expect(section.children.text).to eq(http_proxy)
+
+      section = assert_select "profile/networking/proxy/https_proxy"
+      expect(section.children.text).to eq(https_proxy)
+
+      section = assert_select "profile/networking/proxy/no_proxy"
+      expect(section.children.text).to eq(no_proxy)
+    end
+  end
+end

--- a/spec/views/dashboard/index.html.slim_spec.rb
+++ b/spec/views/dashboard/index.html.slim_spec.rb
@@ -12,31 +12,3 @@ describe "dashboard/index" do
     end
   end
 end
-
-describe "dashboard/autoyast" do
-  context "when proxy is enabled" do
-    let(:http_proxy) { "squid.corp.net:3128"}
-    let(:https_proxy) { "squid.corp.net:3443"}
-    let(:no_proxy) { "localhost" }
-
-    before do
-      assign(:proxy_http, http_proxy)
-      assign(:proxy_https, https_proxy)
-      assign(:proxy_no_proxy, no_proxy)
-      assign(:proxy_systemwide, true)
-    end
-
-    it "generates a proxy section" do
-      render
-
-      section = assert_select "profile/networking/proxy/http_proxy"
-      expect(section.children.text).to eq(http_proxy)
-
-      section = assert_select "profile/networking/proxy/https_proxy"
-      expect(section.children.text).to eq(https_proxy)
-
-      section = assert_select "profile/networking/proxy/no_proxy"
-      expect(section.children.text).to eq(no_proxy)
-    end
-  end
-end


### PR DESCRIPTION
This pull request completes the work around handling proxy settings from velum.

It implements missing features like:

  * Handle the `proxy:systemwide` pillar that was introduced by [this](https://github.com/kubic-project/salt/pull/107) pull request inside of the salt repository.
  * Handle proxy settings inside of AutoYaST, fixing [bsc#1043538](https://bugzilla.suse.com/show_bug.cgi?id=1043538).

It also fixes previously uncovered bugs:
  * Not being able to unset certain pillars from velum (see [this](https://github.com/kubic-project/velum/commit/1e877bafc44a00b3c301e511e4b868dc5c20524a) specific commit).

Finally it changes the UI to allow an easy way to enable/disable proxy settings. See the video below:

![velum-proxy-2017-06-28_08 29 03](https://user-images.githubusercontent.com/22728/27623418-b5cd0114-5bdc-11e7-8292-4c0604828648.gif)