### PR TITLE
Increase the poll timeout to 30s

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -132,7 +132,7 @@ MinionPoller = {
       }
     }).always(function() {
       // make another request only after the last one finished
-      setTimeout(MinionPoller.request, 5000);
+      setTimeout(MinionPoller.request, 30000);
     });
   },
 


### PR DESCRIPTION
Currently velum makes a lot of calls to the salt-api which get
logged as events

This is causing MySQL and the Velum event processor to get
swampped, which is causing delays in showing node status.

30 seconds is a good number as it allows for information to be
updated, and if a user is impatient, they can refresh the page.