### PR TITLE
[WIP] Stop calling all nodes for grains

### DIFF
--- a/app/controllers/concerns/discovery.rb
+++ b/app/controllers/concerns/discovery.rb
@@ -35,7 +35,7 @@ module Discovery
   #     automatic updates has not been enabled.
 
   def assigned_with_status
-    needed, failed = ::Velum::Salt.update_status(targets: "*", cached: true)
+    needed, failed = ::Velum::Salt.update_status(cached: true)
 
     # NOTE: this is highly inefficient and will disappear if we implement the
     # idea written above.
@@ -48,7 +48,7 @@ module Discovery
   end
 
   def admin_status
-    needed, failed = ::Velum::Salt.update_status(targets: "*", cached: true)
+    needed, failed = ::Velum::Salt.update_status(cached: true)
     { update_status: Minion.computed_status("admin", needed, failed) }
   end
 end

--- a/app/controllers/updates_controller.rb
+++ b/app/controllers/updates_controller.rb
@@ -20,7 +20,7 @@ class UpdatesController < ApplicationController
   protected
 
   def admin_needs_update
-    needed, failed = ::Velum::Salt.update_status(targets: "*", cached: true)
+    needed, failed = ::Velum::Salt.update_status(cached: true)
     status = Minion.computed_status("admin", needed, failed)
 
     return if status == Minion.statuses[:update_needed] ||

--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -104,7 +104,7 @@ class Minion < ApplicationRecord
   # Updates all nodes with a grain of `tx_update_reboot_needed: True` with a
   # highstate = pending, and persists it to the database
   def self.mark_pending_update
-    needed, failed = ::Velum::Salt.update_status(targets: "*", cached: true)
+    needed, failed = ::Velum::Salt.update_status(cached: true)
     minions = Minion.assigned_role
     minions.each do |minion|
       if Minion.computed_status(minion.minion_id, needed, failed) == Minion.statuses[:update_needed]

--- a/lib/velum/salt.rb
+++ b/lib/velum/salt.rb
@@ -21,15 +21,15 @@ module Velum
     end
 
     # Returns the update status of the different minions.
-    def self.update_status(targets: "*", cached: false)
+    def self.update_status(cached: false)
       expiration = cached ? 1.second : 30.seconds
 
       needed = Rails.cache.fetch("update_status", expires_in: expiration) do
-        _, res = Salt.call(action: "grains.get", arg: "tx_update_reboot_needed", targets: targets)
+        _, res = Salt.call(action: "grains.get", arg: "tx_update_reboot_needed", targets: "admin")
         res
       end
       failed = Rails.cache.fetch("update_status_failed", expires_in: expiration) do
-        _, res = Salt.call(action: "grains.get", arg: "tx_update_failed", targets: targets)
+        _, res = Salt.call(action: "grains.get", arg: "tx_update_failed", targets: "admin")
         res
       end
       [needed["return"], failed["return"]]


### PR DESCRIPTION
We were targeting all nodes when we did a `grains.get` api call
which meant we caused the master to call all minions to tell them
to call the master to find out what it thought the grains were,
and then return the same list of data n times, where n == number of
minions.