### PR TITLE
fix up feature spec use of Capybara

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,8 @@ Rails/HttpPositionalArguments:
 # expectation.
 RSpec/MultipleExpectations:
   Max: 2
+  Exclude:
+    - spec/features/**/*
 
 AllCops:
   Exclude:

--- a/spec/features/add_unassigned_nodes_feature_spec.rb
+++ b/spec/features/add_unassigned_nodes_feature_spec.rb
@@ -16,7 +16,7 @@ feature "Add unassigned nodes" do
     setup_stubbed_update_status!
     setup_stubbed_pending_minions!
 
-    [:minion, :master].each do |role|
+    [:worker, :master].each do |role|
       allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
         .and_return(role)
     end
@@ -41,10 +41,7 @@ feature "Add unassigned nodes" do
 
     click_button "Add nodes"
     using_wait_time 10 do
-      expect do
-        page.to have_content(minions[2].fqdn)
-        page.not_to have_content(minions[3].fqdn)
-      end
+      expect(page).to have_content(minions[2].fqdn).and have_no_content(minions[3].fqdn)
     end
   end
 
@@ -56,10 +53,7 @@ feature "Add unassigned nodes" do
 
     click_button "Add nodes"
     using_wait_time 10 do
-      expect do
-        page.to have_content(minions[2].fqdn)
-        page.to have_content(minions[3].fqdn)
-      end
+      expect(page).to have_content(minions[2].fqdn).and have_content(minions[3].fqdn)
     end
   end
   # rubocop:enable RSpec/ExampleLength

--- a/spec/features/admin_node_update_feature_spec.rb
+++ b/spec/features/admin_node_update_feature_spec.rb
@@ -29,7 +29,6 @@ feature "Manage nodes updates feature" do
       expect(page).to have_content("Admin node is running outdated software")
     end
 
-    # rubocop:disable RSpec/MultipleExpectations
     scenario "User clicks on admin 'Update admin node'", js: true do
       expect(page).not_to have_content("Reboot to update")
 
@@ -40,7 +39,6 @@ feature "Manage nodes updates feature" do
                                    "in order to apply the software update")
       expect(page).to have_content("Reboot to update")
     end
-    # rubocop:enable RSpec/MultipleExpectations
 
     scenario "User clicks on 'Reboot to update'", js: true do
       allow(::Velum::Salt).to receive(:call).and_return(true)

--- a/spec/features/auth/login_feature_spec.rb
+++ b/spec/features/auth/login_feature_spec.rb
@@ -49,6 +49,6 @@ feature "Login feature" do
     fill_in "user_password", with: user.password
     click_button("Log in")
 
-    expect(current_path).to eq setup_path
+    expect(page).to have_current_path(setup_path)
   end
 end

--- a/spec/features/auth/signup_feature_spec.rb
+++ b/spec/features/auth/signup_feature_spec.rb
@@ -5,7 +5,6 @@ feature "Signup feature" do
   let(:user) { build(:user) }
 
   # rubocop:disable RSpec/ExampleLength
-  # rubocop:disable RSpec/MultipleExpectations
 
   # XXX: the following tests depend on another and thus cannot be split into
   # multiple scenarios. This must be fixed as soon as multiuser support is
@@ -15,7 +14,7 @@ feature "Signup feature" do
     # account creation reachable
     visit new_user_session_path
     click_link("Create an account")
-    expect(current_path).to eq new_user_registration_path
+    expect(page).to have_current_path(new_user_registration_path)
 
     # wrong email format
     fill_in "user_email", with: "gibberish@asdasd"
@@ -45,8 +44,8 @@ feature "Signup feature" do
     # forcefully visiting the registration path must redirect to the
     # root_path and yield an alert.
     visit new_user_registration_path
+    expect(page).to have_current_path(root_path)
     expect(page).to have_content("Admin user already exists.")
-    expect(current_path).to eq root_path
   end
   # rubocop:enable RSpec/ExampleLength
 end

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -23,7 +23,7 @@ feature "Bootstrap cluster feature" do
 
     before do
       # mock salt methods
-      [:minion, :master].each do |role|
+      [:worker, :master].each do |role|
         allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
           .and_return(role)
       end
@@ -61,14 +61,12 @@ feature "Bootstrap cluster feature" do
       click_button "Proceed anyway"
 
       using_wait_time 10 do
-        expect do
-          # means it went to the overview page
-          page.to have_content("Summary")
-          page.to have_content(minions[0].fqdn)
-          page.to have_content(minions[1].fqdn)
-          page.not_to have_content(minions[2].fqdn)
-          page.not_to have_content(minions[3].fqdn)
-        end
+        # means it went to the overview page
+        expect(page).to have_content("Summary")
+        expect(page).to have_content(minions[0].fqdn)
+        expect(page).to have_content(minions[1].fqdn)
+        expect(page).not_to have_content(minions[2].fqdn)
+        expect(page).not_to have_content(minions[3].fqdn)
       end
     end
 
@@ -85,14 +83,12 @@ feature "Bootstrap cluster feature" do
       click_on_when_enabled "#bootstrap"
 
       using_wait_time 10 do
-        expect do
-          # means it went to the overview page
-          page.to have_content("Summary")
-          page.to have_content(minions[0].fqdn)
-          page.to have_content(minions[1].fqdn)
-          page.not_to have_content(minions[2].fqdn)
-          page.not_to have_content(minions[3].fqdn)
-        end
+        # means it went to the overview page
+        expect(page).to have_content("Summary")
+        expect(page).to have_content(minions[0].fqdn)
+        expect(page).to have_content(minions[1].fqdn)
+        expect(page).to have_content(minions[2].fqdn)
+        expect(page).not_to have_content(minions[3].fqdn)
       end
     end
 
@@ -107,39 +103,31 @@ feature "Bootstrap cluster feature" do
       click_on_when_enabled "#bootstrap"
 
       using_wait_time 10 do
-        expect do
-          page.to have_content("Summary")
-          page.to have_content(minions[0].fqdn)
-          page.to have_content(minions[1].fqdn)
-          page.to have_content(minions[2].fqdn)
-          page.to have_content(minions[3].fqdn)
-        end
+        expect(page).to have_content("Summary")
+        expect(page).to have_content(minions[0].fqdn)
+        expect(page).to have_content(minions[1].fqdn)
+        expect(page).to have_content(minions[2].fqdn)
+        expect(page).to have_content(minions[3].fqdn)
       end
     end
   end
 
   scenario "It shows the minions as soon as they register", js: true do
-    expect do
-      page.to have_content("No nodes found")
-      page.not_to have_content("minion0.k8s.local")
-    end
+    expect(page).to have_content("No nodes found")
+    expect(page).not_to have_content("minion0.k8s.local")
 
     Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local")
     using_wait_time 10 do
-      expect do
-        page.not_to have_content("No nodes found")
-        page.to have_content("minion0.k8s.local")
-      end
+      expect(page).not_to have_content("No nodes found")
+      expect(page).to have_content("minion0.k8s.local")
     end
   end
   # rubocop:enable RSpec/ExampleLength
 
   scenario "An user sees 'No nodes found'", js: true do
-    expect do
-      page.to have_content("No nodes found")
-      # bootstrap cluster button disabled
-      page.to have_css("#bootstrap[disabled]")
-    end
+    expect(page).to have_content("No nodes found")
+    # bootstrap cluster button disabled
+    expect(page).to have_button(value: "Bootstrap cluster", disabled: true)
   end
 end
 # rubocop:enable RSpec/AnyInstance

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -14,11 +14,9 @@ feature "Dashboard" do
       visit authenticated_root_path
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it "enables/disables the download button depending on the current state", js: true do
       # Bootstrapping, the button is disabled.
-      el = find("#download-kubeconfig")
-      expect(el[:disabled]).to eq "disabled"
+      expect(page).to have_css("#download-kubeconfig[disabled]")
 
       # Fake that bootstrapping ended successfully.
       # rubocop:disable Rails/SkipsModelValidations
@@ -26,10 +24,7 @@ feature "Dashboard" do
       # rubocop:enable Rails/SkipsModelValidations
       visit authenticated_root_path
 
-      el = find("#download-kubeconfig")
-      wait_until { !find("#download-kubeconfig")[:disabled] }
-      expect(el[:disabled]).to be_falsey
+      expect(page).to have_css("#download-kubeconfig:not(:disabled)")
     end
-    # rubocop:enable RSpec/ExampleLength
   end
 end

--- a/spec/features/monitoring_feature_spec.rb
+++ b/spec/features/monitoring_feature_spec.rb
@@ -22,7 +22,6 @@ feature "Monitoring feature" do
   end
 
   # rubocop:disable RSpec/ExampleLength
-  # rubocop:disable RSpec/MultipleExpectations:
   scenario "It shows the number of new minions", js: true do
     using_wait_time 10 do
       unassigned_count = find(".unassigned-count")
@@ -36,5 +35,4 @@ feature "Monitoring feature" do
     end
   end
   # rubocop:enable RSpec/ExampleLength
-  # rubocop:enable RSpec/MultipleExpectations:
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -21,8 +21,7 @@ module Helpers
   # click on `selector element when enabled
   def click_on_when_enabled(selector)
     # will wait until it becomes enabled
-    have_css("#{selector}:not([disabled])")
-    find(selector).click
+    find("#{selector}:not([disabled])").click
   end
 end
 


### PR DESCRIPTION
This fixes up some of the feature specs use of Capybara, and also fixes a number of incidences where the specs weren't actually doing anything since

    expect do
       # stuff in here gets ignored
    end

won't actually evaluate the block being passed to expect without calling .to/.not_to ...  at the end

The specs currently fail, but they're failing in master at the moment too.