### PR TITLE
Fix caching for salt `update_status` call

### DIFF
--- a/lib/velum/cache.rb
+++ b/lib/velum/cache.rb
@@ -1,0 +1,14 @@
+module Velum
+  # This class has cache utilities that can be used for the whole project
+  class Cache
+    def self.fetch(key:, use_cache: true, expires_in:, &blk)
+      if use_cache
+        Rails.cache.fetch(key, expires_in: expires_in) do
+          blk.call
+        end
+      else
+        blk.call
+      end
+    end
+  end
+end

--- a/spec/lib/velum/salt_spec.rb
+++ b/spec/lib/velum/salt_spec.rb
@@ -53,5 +53,13 @@ describe Velum::Salt do
         expect(needed.first["admin"] && failed.first["admin"]).to be_truthy
       end
     end
+    it "returns the cached update status of the given nodes" do
+      VCR.use_cassette("salt/update_status", record: :none) do
+        needed, failed = described_class.update_status cached: true
+        # In the VCR both values were set to true, so we can check this in a
+        # single 'expect' statement.
+        expect(needed.first["admin"] && failed.first["admin"]).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
Do not use the cache at all if `cache: false`, cache for 30 seconds
by default, and use the cache if `cache: true`.

Related: bsc#1046847