### PR TITLE
ux/ui: added title to bootstrap button

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -101,6 +101,8 @@ MinionPoller = {
 
         MinionPoller.handleAdminUpdate(data.admin || {});
 
+        handleBootstrapButtonTitle();
+
         // show/hide "update all nodes" link
         $("#update-all-nodes").toggleClass('hidden', !(updateAvailable && allApplied));
 
@@ -382,11 +384,40 @@ function selectedNodesLength() {
   return $('input[name="roles[worker][]"]:checked').length;
 }
 
+// handle bootstra button title
+function handleBootstrapButtonTitle() {
+  var masterSelected = isMasterSelected();
+  var hasMinimumNodes = selectedNodesLength() > 1;
+  var canBootstrap = masterSelected && hasMinimumNodes;
+  var title = 'Select ';
+
+  if (canBootstrap) {
+    title = 'Bootstrap cluster';
+  } else {
+    if (!masterSelected) {
+      title += 'the master';
+    }
+
+    if (!hasMinimumNodes) {
+      if (!masterSelected) {
+        title += ' and ';
+      }
+
+      title += 'nodes';
+    }
+  }
+
+  $('#bootstrap').prop('title', title);
+}
+
 // disable/enable button if it has 1 master and 1 worker at least
 function toggleBootstrapButton() {
-  var hasMinimumAmountToEnable = isMasterSelected() && selectedNodesLength() > 1;
+  var canBootstrap = isMasterSelected() && selectedNodesLength() > 1;
 
-  $('#bootstrap').prop('disabled', !hasMinimumAmountToEnable);
+  $('#bootstrap').prop('disabled', !canBootstrap);
+
+  // also call bootstrap title handler
+  handleBootstrapButtonTitle();
 }
 
 // hide minimum nodes alert


### PR DESCRIPTION
Helps the user to understand what he has to do to enable `Bootstrap cluster` button.

Code doesn't look good but strings builds like that are always ugly. Ideas are more than welcome.

<img width="1163" alt="screenshot 2017-06-30 10 26 10" src="https://user-images.githubusercontent.com/188554/27737566-f873194c-5d7e-11e7-9c3e-fc4e2fd6a0c1.png">
<img width="1174" alt="screenshot 2017-06-30 10 26 28" src="https://user-images.githubusercontent.com/188554/27737567-f87a2e80-5d7e-11e7-9884-b5707fc943aa.png">
<img width="1227" alt="screenshot 2017-06-30 10 26 40" src="https://user-images.githubusercontent.com/188554/27737569-f87f0eaa-5d7e-11e7-99c4-c9ed1c3e116d.png">
<img width="1170" alt="screenshot 2017-06-30 10 26 50" src="https://user-images.githubusercontent.com/188554/27737568-f87c00e8-5d7e-11e7-92f0-23d6c95bae34.png">

