### PR TITLE
Remove `restart.txt` puma functionality

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -40,9 +40,6 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 #   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
 # end
 
-# Allow puma to be restarted by `rails restart` command.
-plugin :tmp_restart
-
 pidfile "/tmp/puma.pid"
 state_path "/tmp/puma.state"
 


### PR DESCRIPTION
Puma allows you to restart the server based on the `mtime` of a file
`tmp/restart.txt`. We won't be using this functionality as the server
runs in a container and we have other means for restarting it.

This makes e2e-tests stable again.