### PR TITLE
Serve "db is not ready" static page over https [bsc#1047203]

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,3 +48,7 @@ AllCops:
     - db/schema.rb
     - db/migrate/*
     - vendor/**/*
+    # This is a patched version of ruby's core un.rb file. Upstream has
+    # a particular style that conflicts with our rules -> let's ignore
+    # this file
+    - bin/httpsd.rb

--- a/bin/httpsd.rb
+++ b/bin/httpsd.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+# This is a patched version of the `httpd` function defined inside of ruby's
+# stdlib (see the `un.rb` file shipped with your ruby distribution).
+# The upstream version cannot serve contents over https.
+# A patch is going to be sent upstream, in the meantime this code does the job.
+
+def httpd
+  require "un"
+  setup("", "BindAddress=ADDR", "Port=PORT", "MaxClients=NUM", "TempDir=DIR",
+        "DoNotReverseLookup", "RequestTimeout=SECOND", "HTTPVersion=VERSION",
+        "SSLCertificate=CERT", "SSLPrivateKey=KEY") do
+    |argv, options|
+    require 'webrick'
+
+    opt = options[:RequestTimeout] and options[:RequestTimeout] = opt.to_i
+    [:Port, :MaxClients].each do |name|
+      opt = options[name] and (options[name] = Integer(opt)) rescue nil
+    end
+    unless argv.empty?
+      options[:DocumentRoot] = argv.shift
+    end
+
+    if options[:SSLCertificate]
+      require 'webrick/https'
+      require 'openssl'
+      options[:SSLCertificate] = OpenSSL::X509::Certificate.new(File.read(options[:SSLCertificate]))
+      options[:SSLEnable] = true
+    end
+
+    if options[:SSLPrivateKey]
+      options[:SSLPrivateKey] = OpenSSL::PKey::RSA.new(File.read(options[:SSLPrivateKey]))
+    end
+    s = WEBrick::HTTPServer.new(options)
+    shut = proc {s.shutdown}
+    Signal.trap("TERM", shut)
+    Signal.trap("QUIT", shut) if Signal.list.has_key?("QUIT")
+    if STDIN.tty?
+      Signal.trap("HUP", shut) if Signal.list.has_key?("HUP")
+      Signal.trap("INT", shut)
+    end
+    s.start
+  end
+end

--- a/bin/init
+++ b/bin/init
@@ -15,7 +15,7 @@ setup_database() {
 
   # let the user know that the UI is about to start
   # https://bugzilla.suse.com/show_bug.cgi?id=1031682
-  ruby -run -e httpd public/503_database_not_ready.html -p $VELUM_PORT --request-timeout=$TIMEOUT --bind-address=0.0.0.0 &
+  ruby -r ./bin/httpsd.rb -e httpd public/503_database_not_ready.html -p $VELUM_PORT --request-timeout=$TIMEOUT --bind-address=0.0.0.0 --ssl-certificate /etc/pki/velum.crt --ssl-private-key /etc/pki/velum.key &
   export TEMPORARY_SERVER_PID=$!
 
   while [ $RETRY -ne 0 ]; do


### PR DESCRIPTION
Ensure the "db is not yet ready" is served over https too. This fixes bsc#1047203.

The fix has been tested with devenv. Everything works fine until velum comes up, then velum will be served over port 3000 but with tls disabled (this is fixed by https://github.com/kubic-project/caasp-devenv/pull/23).