### PR TITLE
Also restrict unsafe routes on development

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   get "/autoyast", to: "dashboard#autoyast"
-  next if Rails.env.production? && ENV["VELUM_PORT"].to_i != 443
+  next unless Rails.env.test? || ENV["VELUM_PORT"].to_i == 443
   devise_for :users, controllers: { registrations: "auth/registrations",
                                     sessions:      "auth/sessions" }
 


### PR DESCRIPTION
We will only allow autoyast being served in an insecure manner, so bring
development close to production here too.

Only when running specs under a test environment is when we avoid restricting
the routes, however this would also need to be reviewed.