### PR TITLE
WIP: Print `log/test.log` upon failure in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,3 +49,6 @@ addons:
 
 after_success:
   - bundle exec codeclimate-test-reporter
+
+after_failure:
+  - cat log/test.log


### PR DESCRIPTION
This file might have valuable content to identify a flaky test or
any other problem.

**Currently forcing failure to test**