### PR TITLE
Add two runs for each ruby version, one with fail fast, the other a regular one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 language: ruby
 rvm:
-  # The version used at SLE12
-  - 2.1.2
+  # The version used at CaaSP
+  - 2.1.9p490
 
-  # The version used at openSUSE 13.2
-  - 2.1.3
+  # Other ruby versions
+  - 2.4.1
+  - 2.3.4
+  - 2.2.7
 
-  # Other Ruby Versions
-  - 2.1.10
-  - 2.2.4
-  - 2.3.0
-
-  # Future versions
+  # Latest ruby
   - ruby-head
+
+env:
+  - RSPEC_FAIL_FAST=true
+  - RSPEC_FAIL_FAST=false
 
 matrix:
   allow_failures:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,4 +39,6 @@ RSpec.configure do |config|
   end
 
   config.order = :random
+
+  config.fail_fast = ENV["RSPEC_FAIL_FAST"] == "true"
 end


### PR DESCRIPTION
When we find a flaky test, the fail fast version will contain relevant information
on the tail of the `test.log` fail, while the regular run will continue to show
any other errors.