### PR TITLE
Add missing indexes for `salt_events` table

### DIFF
--- a/app/models/salt_event.rb
+++ b/app/models/salt_event.rb
@@ -57,7 +57,7 @@ class SaltEvent < ApplicationRecord
     return false if taken_event.zero?
 
     SaltEvent.where(worker_id: worker_id, processed_at: nil)
-             .where.not(taken_at: nil).limit(1).first.process!
+             .where.not(taken_at: nil).limit(1).each(&:process!)
   end
 
   # Memoizes the @handler instance which is responsible to process this event.

--- a/app/models/salt_handler/minion_start.rb
+++ b/app/models/salt_handler/minion_start.rb
@@ -26,6 +26,7 @@ class SaltHandler::MinionStart
     return false if id == "ca" || id == "admin"
 
     minion_info = Velum::Salt.minions[id]
+    return false if minion_info.blank?
 
     # false if a minion with this minion_id or fqdn already exists (uniqueness validation)
     Minion.new(minion_id: id, fqdn: minion_info["fqdn"]).save

--- a/db/migrate/20170710081011_add_processed_at_worker_id_taken_at_indexes_to_salt_events.rb
+++ b/db/migrate/20170710081011_add_processed_at_worker_id_taken_at_indexes_to_salt_events.rb
@@ -1,0 +1,6 @@
+class AddProcessedAtWorkerIdTakenAtIndexesToSaltEvents < ActiveRecord::Migration
+  def change
+    add_index :salt_events, :processed_at
+    add_index :salt_events, [:worker_id, :taken_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170512100610) do
+ActiveRecord::Schema.define(version: 20170710081011) do
 
   create_table "jids", id: false, force: :cascade do |t|
     t.string "jid",  limit: 255,      null: false
@@ -53,7 +53,9 @@ ActiveRecord::Schema.define(version: 20170512100610) do
     t.string   "worker_id",    limit: 255
   end
 
+  add_index "salt_events", ["processed_at"], name: "index_salt_events_on_processed_at", using: :btree
   add_index "salt_events", ["tag"], name: "tag", using: :btree
+  add_index "salt_events", ["worker_id", "taken_at"], name: "index_salt_events_on_worker_id_and_taken_at", using: :btree
 
   create_table "salt_returns", id: false, force: :cascade do |t|
     t.string   "fun",        limit: 50,       null: false


### PR DESCRIPTION
Fix some slow queries that we were having due to missing indexes.

Increase batch job size.

Fixes: bsc#1046862