### PR TITLE
Handle failures of the update orchestration

### DIFF
--- a/app/models/salt_event.rb
+++ b/app/models/salt_event.rb
@@ -13,7 +13,7 @@ class SaltEvent < ApplicationRecord
   ENABLED_EVENT_HANDLERS = [
     SaltHandler::MinionStart,
     SaltHandler::MinionHighstate,
-    SaltHandler::BootstrapOrchestration
+    SaltHandler::MinionOrchestration
   ].freeze
 
   scope :not_processed, -> { where(processed_at: nil) }

--- a/spec/models/salt_event_spec.rb
+++ b/spec/models/salt_event_spec.rb
@@ -108,22 +108,68 @@ describe SaltEvent do
       expect(salt_event.handler).to be_an_instance_of(SaltHandler::MinionHighstate)
     end
 
-    it "must return an instance of SaltHandler::BootstrapOrchestration when mods is not provided" do
+    # rubocop:disable RSpec/ExampleLength
+    it "must return an instance of SaltHandler::MinionOrchestration when mods is not provided"\
+      " for orch.kubernetes" do
       salt_event = described_class.new(
         tag:  "salt/run/12345/ret",
         data: { fun: "runner.state.orchestrate", fun_args: ["orch.kubernetes"] }.to_json
       )
 
-      expect(salt_event.handler).to be_an_instance_of(SaltHandler::BootstrapOrchestration)
+      expect(salt_event.handler).to be_an_instance_of(SaltHandler::MinionOrchestration)
     end
+    # rubocop:enable RSpec/ExampleLength
 
-    it "must return an instance of SaltHandler::BootstrapOrchestration when mods is provided" do
+    # rubocop:disable RSpec/ExampleLength
+    it "must return an instance of SaltHandler::MinionOrchestration when mods is provided"\
+      " for orch.kubernetes" do
       salt_event = described_class.new(
         tag:  "salt/run/12345/ret",
         data: { fun: "runner.state.orchestrate", fun_args: [{ mods: "orch.kubernetes" }] }.to_json
       )
 
-      expect(salt_event.handler).to be_an_instance_of(SaltHandler::BootstrapOrchestration)
+      expect(salt_event.handler).to be_an_instance_of(SaltHandler::MinionOrchestration)
     end
+    # rubocop:enable RSpec/ExampleLength
+
+    # rubocop:disable RSpec/ExampleLength
+    it "must return an instance of SaltHandler::MinionOrchestration when mods is not provided"\
+      " for orch.update" do
+      salt_event = described_class.new(
+        tag:  "salt/run/12345/ret",
+        data: { fun: "runner.state.orchestrate", fun_args: ["orch.update"] }.to_json
+      )
+
+      expect(salt_event.handler).to be_an_instance_of(SaltHandler::MinionOrchestration)
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    # rubocop:disable RSpec/ExampleLength
+    it "must return an instance of SaltHandler::MinionOrchestration when mods is provided"\
+      " for orch.update" do
+      salt_event = described_class.new(
+        tag:  "salt/run/12345/ret",
+        data: { fun: "runner.state.orchestrate", fun_args: [{ mods: "orch.update" }] }.to_json
+      )
+
+      expect(salt_event.handler).to be_an_instance_of(SaltHandler::MinionOrchestration)
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    # rubocop:disable RSpec/ExampleLength
+    it "must not return an instance of SaltHandler::MinionOrchestration for"\
+      " orch.update_etc_hosts" do
+      salt_event = described_class.new(
+        tag:  "salt/run/12345/ret",
+        data: {
+          fun:      "runner.state.orchestrate",
+          fun_args: [{ mods: "orch.update_etc_hosts" }]
+        }.to_json
+      )
+
+      expect(salt_event.handler).not_to be_an_instance_of(SaltHandler::MinionOrchestration)
+    end
+    # rubocop:enable RSpec/ExampleLength
+
   end
 end

--- a/spec/models/salt_handler/minion_orchestration_spec.rb
+++ b/spec/models/salt_handler/minion_orchestration_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-describe SaltHandler::BootstrapOrchestration do
+describe SaltHandler::MinionOrchestration do
   let(:successful_orchestration_result) do
     event_data = {
       "fun_args" => [{ "mods" => "orch.kubernetes" },


### PR DESCRIPTION
Handle the failure of an update orchestration in the same way we handle
a failure for a bootstrap orchestration.

bsc#1047895