### PR TITLE
bsc#1046663: added indicator when user accepts node

### DIFF
--- a/app/views/dashboard/_pending_nodes.html.slim
+++ b/app/views/dashboard/_pending_nodes.html.slim
@@ -15,11 +15,14 @@
       .nodes-content.hidden
         p.empty-text
           | You currently have no nodes to be accepted for bootstrapping.
-        table.table
-          thead
-            tr
-              th
-                | ID
-              th
-                | Actions
-          tbody
+        .has-content.hidden
+          p Accepting nodes into the cluster might take a while.
+
+          table.table
+            thead
+              tr
+                th
+                  | ID
+                th width="30%"
+                  | Actions
+            tbody


### PR DESCRIPTION
After user accepts one or more nodes, 'Accept Node' link
is replaced by 'Acceptance in progress' text. The specific
minion is marked in `sessionStorage` and even if the user
refreshes the page, the 'Accept Node' won't appear until
it gets accepted.

### None accepted

<img width="1160" alt="screenshot 2017-07-10 20 51 13" src="https://user-images.githubusercontent.com/188554/28045413-422e2464-65b3-11e7-8833-4d9ac2ccc638.png">

### Partially accepted

<img width="1166" alt="screenshot 2017-07-10 20 33 36" src="https://user-images.githubusercontent.com/188554/28045411-422ae8ee-65b3-11e7-83fe-a82a5c392825.png">

### All accepted

<img width="1170" alt="screenshot 2017-07-10 20 33 43" src="https://user-images.githubusercontent.com/188554/28045412-422cb502-65b3-11e7-9e27-83771adae535.png">
