### PR TITLE
WIP: Use `prepend_before_action` to ensure they are executed first

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,9 +2,9 @@
 
 # ApplicationController is the superclass of all controllers.
 class ApplicationController < ActionController::Base
-  before_action :redirect_to_secure
-  before_action :authenticate_user!
-  before_action :redirect_to_setup
+  prepend_before_action :redirect_to_secure
+  prepend_before_action :authenticate_user!
+  prepend_before_action :redirect_to_setup
   protect_from_forgery with: :exception
 
   private


### PR DESCRIPTION
Using `prepend_before_action` in such key actions is important to
ensure that this before actions will be executed the first thing, even
after including concerns.

Fixes: bsc#1048134