### PR TITLE
`force_ssl` is documented to be executed from the class context

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 
 # ApplicationController is the superclass of all controllers.
 class ApplicationController < ActionController::Base
-  before_action :redirect_to_secure
+  before_action :force_ssl_redirect, unless: -> { Rails.env.test? }
   before_action :authenticate_user!
   before_action :redirect_to_setup
   protect_from_forgery with: :exception
@@ -19,11 +19,5 @@ class ApplicationController < ActionController::Base
   # return false otherwise
   def setup_done?
     !Minion.assigned_role.count.zero?
-  end
-
-  # TODO: (mssola) remove once we have a reverse-proxy setup in place.
-  def redirect_to_secure
-    self.class.force_ssl unless Rails.env.test?
-    true
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -13,7 +13,7 @@ class DashboardController < ApplicationController
   # authenticated (as login/password -- since it's machines requesting this endpoint). It would
   # never get redirected to setup the cluster, and it should actually read some security setting for
   # only serving the autoyast profile to a set of IP ranges (provided by the customer).
-  skip_before_action :redirect_to_secure, only: :autoyast
+  skip_before_action :force_ssl_redirect, only: :autoyast
   skip_before_action :authenticate_user!, only: :autoyast
   skip_before_action :redirect_to_setup, only: :autoyast
 

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,6 +1,6 @@
 # HealthController holds methods for checking the readiness of the application.
 class HealthController < ApplicationController
-  skip_before_action :redirect_to_secure
+  skip_before_action :force_ssl_redirect
   skip_before_action :authenticate_user!
   skip_before_action :redirect_to_setup
 


### PR DESCRIPTION
Not all redirections to `https` were properly handled. By making this
change we manually redirect to `https` as a `before_action` as before,
but handling a `redirect_to` in the chain (effectively stopping the
chain and in the expected order).

The reason behind this is that `force_ssl` called from our own filter:
https://github.com/rails/rails/blob/03925dc26a747075ff37660d1f0a060a8178bf66/actionpack/lib/action_controller/metal/force_ssl.rb#L62-L68
installs a `before_action`, but it's already too late for that very
request (we are already in the `before_actions` for that request).

Also, with the current implementation the filter gets installed after
our other `before_action` filters, what implies that the redirection
to `https` is not the very first filter in the chain, as it should
be.

By calling to the method itself:
https://github.com/rails/rails/blob/03925dc26a747075ff37660d1f0a060a8178bf66/actionpack/lib/action_controller/metal/force_ssl.rb#L76-L96
from our filter, we ensure all requests are redirected to TLS.

Fixes: bsc#1048134