### PR TITLE
Detect orchestration results when `mods` has been provided as argument

### DIFF
--- a/app/models/salt_handler/bootstrap_orchestration.rb
+++ b/app/models/salt_handler/bootstrap_orchestration.rb
@@ -11,7 +11,8 @@ class SaltHandler::BootstrapOrchestration
     return false unless event.tag =~ TAG_MATCHER
     parsed_event_data = JSON.parse event.data
     parsed_event_data["fun"] == "runner.state.orchestrate" &&
-      parsed_event_data["fun_args"].first == "orch.kubernetes"
+      (parsed_event_data["fun_args"].first == "orch.kubernetes" ||
+       parsed_event_data["fun_args"].first["mods"] == "orch.kubernetes")
   end
 
   def initialize(salt_event)

--- a/spec/models/salt_event_spec.rb
+++ b/spec/models/salt_event_spec.rb
@@ -108,10 +108,19 @@ describe SaltEvent do
       expect(salt_event.handler).to be_an_instance_of(SaltHandler::MinionHighstate)
     end
 
-    it "must return an instance of SaltHandler::BootstrapOrchestration" do
+    it "must return an instance of SaltHandler::BootstrapOrchestration when mods is not provided" do
       salt_event = described_class.new(
         tag:  "salt/run/12345/ret",
         data: { fun: "runner.state.orchestrate", fun_args: ["orch.kubernetes"] }.to_json
+      )
+
+      expect(salt_event.handler).to be_an_instance_of(SaltHandler::BootstrapOrchestration)
+    end
+
+    it "must return an instance of SaltHandler::BootstrapOrchestration when mods is provided" do
+      salt_event = described_class.new(
+        tag:  "salt/run/12345/ret",
+        data: { fun: "runner.state.orchestrate", fun_args: [{ mods: "orch.kubernetes" }] }.to_json
       )
 
       expect(salt_event.handler).to be_an_instance_of(SaltHandler::BootstrapOrchestration)

--- a/spec/models/salt_handler/bootstrap_orchestration_spec.rb
+++ b/spec/models/salt_handler/bootstrap_orchestration_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 describe SaltHandler::BootstrapOrchestration do
   let(:successful_orchestration_result) do
     event_data = {
-      "fun_args" => ["orch.kubernetes", { "orchestration_jid" => "20170706104527757673" }],
+      "fun_args" => [{ "mods" => "orch.kubernetes" },
+                     { "orchestration_jid" => "20170706104527757673" }],
       "jid"      => "20170706104527757673",
       "return"   => { "worker1" => {}, "worker2" => {}, "retcode" => 0 },
       "success"  => true,
@@ -20,7 +21,8 @@ describe SaltHandler::BootstrapOrchestration do
 
   let(:mid_successful_orchestration_result) do
     event_data = {
-      "fun_args" => ["orch.kubernetes", { "orchestration_jid" => "20170706104527757674" }],
+      "fun_args" => [{ "mods" => "orch.kubernetes" },
+                     { "orchestration_jid" => "20170706104527757674" }],
       "jid"      => "20170706104527757674",
       "return"   => { "worker1" => {}, "worker2" => {}, "retcode" => 1 },
       "success"  => true,
@@ -36,7 +38,8 @@ describe SaltHandler::BootstrapOrchestration do
 
   let(:failed_orchestration_result) do
     event_data = {
-      "fun_args" => ["orch.kubernetes", { "orchestration_jid" => "20170706104527757675" }],
+      "fun_args" => [{ "mods" => "orch.kubernetes" },
+                     { "orchestration_jid" => "20170706104527757675" }],
       "jid"      => "20170706104527757675",
       "return"   => { "worker1" => {}, "worker2" => {}, "retcode" => 1 },
       "success"  => false,


### PR DESCRIPTION
We usually run the orchestrations manually as:
`salt-run state.orchestrate orch.kubernetes`

And this case was detected properly. This change adds support for also
detecting the orchestration result when the orchestration is called using
the `salt-api` on Velum (the general case):
`salt-run state.orchestrate mods=orch.kubernetes`

With this change we support both return results.