### PR TITLE
bsc#1045734: fix show/hide update link based on update/highstate

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -42,6 +42,7 @@ MinionPoller = {
         var pendingRendered = "";
         var allApplied = true;
         var updateAvailable = false;
+        var hasPendingStateNode = false;
         var updateAvailableNodeCount = 0;
 
         // In discovery, the minions to be rendered are unassigned, while on the
@@ -81,12 +82,21 @@ MinionPoller = {
           if (minions[i].highstate != "applied") {
             allApplied = false;
           }
+
+          if (minions[i].highstate === "pending") {
+            hasPendingStateNode = true;
+          }
+
           if (minions[i].update_status == 1 || minions[i].update_status == 3) {
             updateAvailable = true;
             updateAvailableNodeCount++;
           }
         }
         $(".nodes-container tbody").html(rendered);
+
+        // `hasPendingStateNode` variable aux to determine if
+        // update is possible, not used anywhere else
+        updateAvailable = updateAvailable && !hasPendingStateNode;
 
         // Build Pending Nodes display table
         if (pendingMinions.length) {
@@ -112,7 +122,7 @@ MinionPoller = {
         handleBootstrapButtonTitle();
 
         // show/hide "update all nodes" link
-        $("#update-all-nodes").toggleClass('hidden', !(updateAvailable && allApplied));
+        $("#update-all-nodes").toggleClass('hidden', !updateAvailable);
 
         MinionPoller.enable_kubeconfig(minions.length > 0 && allApplied);
 

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -2,9 +2,9 @@
 require "rails_helper"
 
 feature "Dashboard" do
-  describe "Downloading kubeconfig" do
-    let!(:user) { create(:user) }
+  let!(:user) { create(:user) }
 
+  describe "Downloading kubeconfig" do
     before do
       login_as user, scope: :user
       Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master")
@@ -25,6 +25,59 @@ feature "Dashboard" do
       visit authenticated_root_path
 
       expect(page).to have_css("#download-kubeconfig:not(:disabled)")
+    end
+  end
+
+  describe "Updating nodes" do
+    let!(:minions) do
+      Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master" },
+                      { minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local", role: "worker" },
+                      { minion_id: SecureRandom.hex, fqdn: "minion2.k8s.local", role: "worker" }]
+    end
+
+    before do
+      login_as user, scope: :user
+      setup_stubbed_update_status!
+      setup_stubbed_pending_minions!
+      # rubocop:disable Rails/SkipsModelValidations
+      Minion.update_all(highstate: Minion.highstates[:applied])
+      # rubocop:enable Rails/SkipsModelValidations
+
+      visit authenticated_root_path
+    end
+
+    scenario "A user see the update link if update is available", js: true do
+      expect(page).not_to have_content("update all nodes")
+
+      # minion[1].highstate == :applied
+      stubbed = [[{ minions[1].minion_id => true }], [{ minions[1].minion_id => "" }]]
+      setup_stubbed_update_status!(stubbed: stubbed)
+
+      expect(page).to have_content("update all nodes")
+    end
+
+    scenario "A user see the update link if update is available (retryable)", js: true do
+      expect(page).not_to have_content("update all nodes")
+
+      minions[1].update(highstate: Minion.highstates[:failed])
+      stubbed = [[{ minions[1].minion_id => true }], [{ minions[1].minion_id => "" }]]
+      setup_stubbed_update_status!(stubbed: stubbed)
+
+      expect(page).to have_content("update all nodes")
+    end
+
+    scenario "A user doesn't see link if there's a pending state", js: true do
+      # update is available and all minions has applied state
+      stubbed = [[{ minions[1].minion_id => true }], [{ minions[1].minion_id => "" }]]
+      setup_stubbed_update_status!(stubbed: stubbed)
+
+      expect(page).to have_content("update all nodes")
+
+      # one of the minions is pending (bootstrapping or update in progress)
+      minions[2].update(highstate: Minion.highstates[:pending])
+
+      # hide update link since
+      expect(page).not_to have_content("update all nodes")
     end
   end
 end


### PR DESCRIPTION
`Update all nodes` link should be shown if all nodes are in applied
state and there's an update available/retryable. If for some reason a node
goes to a different state than "applied" or there's no update,
link becomes unavailable.