### PR TITLE
[WIP] Prevent node update if the admin needs updates

### DIFF
--- a/app/controllers/concerns/admin_updates.rb
+++ b/app/controllers/concerns/admin_updates.rb
@@ -1,0 +1,15 @@
+require "velum/salt"
+
+# AdminUpdates is a concern that encapsulates shared methods related to updates
+# of the admin node.
+module AdminUpdates
+  extend ActiveSupport::Concern
+
+  # Returns true if the admin node has needed updates, or some older update has
+  # failed, false otherwise.
+  def admin_needs_update?
+    needed, failed = ::Velum::Salt.update_status(targets: "*", cached: true)
+    status = Minion.computed_status("admin", needed, failed)
+    status == Minion.statuses[:update_needed] || status == Minion.statuses[:update_failed]
+  end
+end

--- a/app/controllers/salt_controller.rb
+++ b/app/controllers/salt_controller.rb
@@ -1,6 +1,10 @@
 require "velum/salt"
+
 # SaltController holds methods for triggering updates of nodes
 class SaltController < ApplicationController
+  include AdminUpdates
+
+  before_action :admin_needs_update_hook, only: :update
   skip_before_action :redirect_to_setup
 
   def update
@@ -24,5 +28,14 @@ class SaltController < ApplicationController
 
   def minion_id_param
     params.require(:minion_id)
+  end
+
+  protected
+
+  # It does nothing if the admin node does *not* need to be updated. Otherwise
+  # it will render a JSON with an `unknown` minion status.
+  def admin_needs_update_hook
+    return unless admin_needs_update?
+    render json: { status: Minion.statuses[:unknown] }
   end
 end


### PR DESCRIPTION
This is the same idea as #262, but on the backend.

See bsc#1049165

- [ ] Add tests (that's why it's marked as WIP)
- [ ] Let the frontend react for errors (e.g. clicked to update node link but the admin needs an update).