### PR TITLE
Serve the autoyast content even when a SCC/SMT connection error happens

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -45,7 +45,9 @@ class DashboardController < ApplicationController
         @suse_regcode = suse_connect_config.regcode
         @do_registration = true
       rescue Velum::SUSEConnect::MissingRegCodeException,
-             Velum::SUSEConnect::MissingCredentialsException
+             Velum::SUSEConnect::MissingCredentialsException,
+             Velum::SUSEConnect::SCCConnectionException => e
+        @registration_error = e.to_s
         @do_registration = false
       end
       ssh_key_file = "/var/lib/misc/ssh-public-key/id_rsa.pub"
@@ -61,8 +63,6 @@ class DashboardController < ApplicationController
 
       render "autoyast.xml.erb", layout: false, content_type: "text/xml"
     end
-  rescue Velum::SUSEConnect::SCCConnectionException
-    head :service_unavailable
   end
 
   # Return the kubeconfig file that allows the customer to use the cluster using the kubectl tool.

--- a/app/views/dashboard/autoyast.xml.erb
+++ b/app/views/dashboard/autoyast.xml.erb
@@ -76,7 +76,14 @@
     </global>
   </bootloader>
   <general>
-    <ask-list config:type="list"/>
+    <% if @registration_error %>
+    <ask-list config:type="list">
+      <ask>
+        <default>This system will not be registered. Reason: <%= @registration_error %></default>
+        <type>static_text</type>
+      </ask>
+    </ask-list>
+    <% end %>
     <mode>
       <confirm config:type="boolean">false</confirm>
       <second_stage config:type="boolean">false</second_stage>

--- a/lib/velum/suse_connect.rb
+++ b/lib/velum/suse_connect.rb
@@ -6,11 +6,23 @@ module Velum
   # This class handles interaction with the SUSE Connect service (whether is the SCC or SMT).
   class SUSEConnect
     # Raised when there is a connection exception with the SMT/SCC service
-    class SCCConnectionException < StandardError; end
+    class SCCConnectionException < StandardError
+      def initialize
+        super "Error connecting to SCC/SMT"
+      end
+    end
     # Raised when an active registration code for CaaSP is missing
-    class MissingRegCodeException < StandardError; end
+    class MissingRegCodeException < StandardError
+      def initialize
+        super "Missing registration code"
+      end
+    end
     # Raised when no credentials were found for SCC service
-    class MissingCredentialsException < StandardError; end
+    class MissingCredentialsException < StandardError
+      def initialize
+        super "Missing credentials for SCC/SMT"
+      end
+    end
 
     DEFAULT_SMT_URL = "https://scc.suse.com".freeze
 

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -91,6 +91,8 @@ RSpec.describe DashboardController, type: :controller do
   end
 
   describe "GET /autoyast" do
+    render_views
+
     before do
       Pillar.create pillar: "dashboard", value: "localhost"
       allow(Velum::SUSEConnect).to receive(:config).and_return(
@@ -141,6 +143,7 @@ RSpec.describe DashboardController, type: :controller do
         VCR.use_cassette("suse_connect/caasp_registration_active", record: :none) do
           get :autoyast
           expect(response.status).to eq 200
+          expect(response.body).to include("Missing credentials for SCC/SMT")
         end
       end
     end
@@ -156,6 +159,7 @@ RSpec.describe DashboardController, type: :controller do
         VCR.use_cassette("suse_connect/caasp_registration_active", record: :none) do
           get :autoyast
           expect(response.status).to eq 200
+          expect(response.body).to include("Missing registration code")
         end
       end
     end
@@ -167,11 +171,11 @@ RSpec.describe DashboardController, type: :controller do
         )
       end
 
-      it "renders a 503 status and a blank page" do
+      it "serves the autoyast content" do
         VCR.use_cassette("suse_connect/caasp_registration_active", record: :none) do
           get :autoyast
-          expect(response.body).to be_blank
-          expect(response.status).to eq 503
+          expect(response.status).to eq 200
+          expect(response.body).to include("Error connecting to SCC/SMT")
         end
       end
     end


### PR DESCRIPTION
The service unavailable http error code (503) will only be returned now
until the first page of the setup is completed (so we have the dashboard
address to serve the autoyast profile).

When one of the following exceptions happens:
  - Missing registration code
  - Missing credentials for SCC/SMT
  - Any HTTP error while connecting to SCC/SMT

We will still serve the autoyast content with a comment explaining why
the system cannot be registered. The returned http error code will be
success (200), but the XML will contain a comment stating why the system
cannot be registered.

Fixes: bsc#1049948

Backport of https://github.com/kubic-project/velum/pull/270