### PR TITLE
WIP: Modify Velum workflow for Kubernetes external FQDN name

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,10 +14,8 @@ class ApplicationController < ActionController::Base
     redirect_to setup_path unless setup_done?
   end
 
-  # setup means minions were assigned to roles
-  # returns true if at least one minion has role != nil
-  # return false otherwise
+  # setup means the setup phase was completed
   def setup_done?
-    !Minion.assigned_role.count.zero?
+    Pillar.exists? pillar: Pillar.all_pillars[:apiserver]
   end
 end

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -9,27 +9,17 @@ require "velum/salt"
 class SetupController < ApplicationController
   include Discovery
 
-  rescue_from Minion::NonExistingNode, with: :node_not_found
-
   skip_before_action :redirect_to_setup
   before_action :redirect_to_dashboard
   before_action :check_empty_settings, only: :configure
-  before_action :check_empty_bootstrap, only: :bootstrap
+  before_action :check_empty_roles, only: :set_roles
 
   def configure
-    res = Pillar.apply(settings_params)
-
-    respond_to do |format|
-      if res.empty?
-        format.html { redirect_to setup_worker_bootstrap_path }
-        format.json { head :ok }
-      else
-        format.html do
-          flash[:alert] = res
-          redirect_to setup_path
-        end
-        format.json { render json: res, status: :unprocessable_entity }
-      end
+    res = Pillar.apply(settings_params, required_pillars: required_pillars)
+    if res.empty?
+      redirect_to setup_worker_bootstrap_path
+    else
+      redirect_to setup_path, alert: res
     end
   end
 
@@ -37,23 +27,34 @@ class SetupController < ApplicationController
     @controller_node = Pillar.value pillar: :dashboard
   end
 
-  def bootstrap
-    assigned = Minion.assign_roles!(roles: update_nodes_params)
+  def set_roles
+    # rubocop:disable Rails/SkipsModelValidations:
+    Minion.update_all role: nil
+    # rubocop:enable Rails/SkipsModelValidations:
+    assigned = Minion.assign_roles roles: update_nodes_params, remote: false
+    if assigned.values.include?(false)
+      redirect_to setup_discovery_path,
+                  flash: { error: "Failed to assign #{failed_assigned_nodes(assigned)}" }
+    else
+      redirect_to setup_bootstrap_path
+    end
+  end
 
-    respond_to do |format|
-      if assigned.values.include?(false)
-        message = "Failed to assign #{failed_assigned_nodes(assigned)}"
-
-        format.html do
-          flash[:error] = message
-          redirect_to setup_discovery_path
-        end
-        format.json { render json: message, status: :unprocessable_entity }
-      else
-        Velum::Salt.orchestrate
-        format.html { redirect_to root_path }
-        format.json { head :ok }
-      end
+  def do_bootstrap
+    res = Pillar.apply(settings_params, required_pillars: required_pillars)
+    unless res.empty?
+      redirect_to setup_bootstrap_path, alert: res
+      return
+    end
+    masters = Minion.where(role: Minion.roles[:master]).pluck :id
+    workers = Minion.where(role: Minion.roles[:worker]).pluck :id
+    assigned = Minion.assign_roles roles: { master: masters, worker: workers }, remote: true
+    if assigned.values.include?(false)
+      redirect_to setup_bootstrap_path,
+                  flash: { error: "Failed to assign #{failed_assigned_nodes(assigned)}" }
+    else
+      Velum::Salt.orchestrate
+      redirect_to root_path
     end
   end
 
@@ -82,41 +83,26 @@ class SetupController < ApplicationController
     assigned.select { |_name, success| !success }.keys.join(", ")
   end
 
-  def node_not_found(exception)
-    respond_to do |format|
-      format.html do
-        flash[:error] = exception.message
-        redirect_to setup_path
-      end
-      format.json { render json: exception.message, status: :not_found }
-    end
-  end
-
   def check_empty_settings
     return if valid_settings?
-
-    respond_to do |format|
-      msg = "Please fill out all necessary form fields"
-      format.html do
-        redirect_to setup_path, alert: msg
-      end
-      format.json { render json: msg, status: :unprocessable_entity }
-    end
+    redirect_to setup_path, alert: "Please fill out all necessary form fields"
   end
 
-  def check_empty_bootstrap
+  def check_empty_roles
     return if params.try(:[], "roles").try(:[], "master")
-    respond_to do |format|
-      msg = "Please select a master node"
-      format.html do
-        redirect_to setup_discovery_path, alert: msg
-      end
-      format.json { render json: msg, status: :unprocessable_entity }
-    end
+    redirect_to setup_discovery_path, alert: "Please select a master node"
   end
 
   def valid_settings?
-    required_pillars = (Pillar.all_pillars.keys - Pillar::OPTIONAL_PILLARS).map(&:to_s)
     required_pillars.none? { |param| settings_params[param].blank? }
+  end
+
+  def required_pillars
+    case action_name
+    when "configure"
+      [:dashboard]
+    when "do_bootstrap"
+      [:apiserver]
+    end
   end
 end

--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -4,9 +4,6 @@ require "velum/salt_minion"
 
 # Minion represents the minions that have been registered in this application.
 class Minion < ApplicationRecord
-  # Raised when Minion doesn't exist
-  class NonExistingNode < StandardError; end
-
   scope :assigned_role, -> { where.not role: nil }
   scope :unassigned_role, -> { where role: nil }
 
@@ -28,7 +25,7 @@ class Minion < ApplicationRecord
   #     },
   #     default_role: :dns
   #   )
-  def self.assign_roles!(roles: {}, default_role: nil)
+  def self.assign_roles(roles: {}, default_role: nil, remote: false)
     # Lookup selected masters and workers
     masters = Minion.select_role_members(roles: roles, role: :master)
     minions = Minion.select_role_members(roles: roles, role: :worker)
@@ -36,35 +33,26 @@ class Minion < ApplicationRecord
     # assign roles to each master and worker
     {}.tap do |ret|
       masters.find_each do |master|
-        ret[master.minion_id] = master.assign_role(:master)
+        ret[master.minion_id] = master.assign_role(:master, remote: remote)
       end
 
       minions.find_each do |minion|
-        ret[minion.minion_id] = minion.assign_role(:worker)
+        ret[minion.minion_id] = minion.assign_role(:worker, remote: remote)
       end
 
       # assign default role if there is any minion left with no role
       if default_role
         Minion.where(role: nil).find_each do |minion|
-          ret[minion.minion_id] = minion.assign_role(default_role)
+          ret[minion.minion_id] = minion.assign_role(default_role, remote: remote)
         end
       end
     end
   end
 
   # Prepares an ActiveRecord relation which will return all the members
-  # assigned to given role. Additionally, ensures all supplied node IDs
-  # exist within the database at the time of calling.
+  # assigned to given role.
   def self.select_role_members(roles: {}, role: nil)
-    node_ids = roles.key?(role) ? roles[role].map(&:to_i) : []
-
-    node_ids.each do |node|
-      unless Minion.exists?(id: node)
-        raise NonExistingNode, "Failed to process non existing node id: #{node}"
-      end
-    end
-
-    Minion.where(id: node_ids)
+    Minion.where id: (roles.key?(role) ? roles[role].map(&:to_i) : [])
   end
 
   # Returns the update status for the given minion ID. The needed and the
@@ -82,21 +70,16 @@ class Minion < ApplicationRecord
 
   # rubocop:disable SkipsModelValidations
   # Assigns a role to this minion locally in the database, and send that role
-  # to salt subsystem.
-  def assign_role(new_role)
-    return false if role.present?
-    success = false
-
+  # to salt subsystem if remote is true.
+  def assign_role(new_role, remote: false)
     Minion.transaction do
       # We set highstate to pending since we just assigned a new role
-      success = update_columns(role:      Minion.roles[new_role],
-                               highstate: Minion.highstates[:pending])
-      break unless success
-      success = salt.assign_role new_role
+      success = update_columns role:      Minion.roles[new_role],
+                               highstate: Minion.highstates[:pending]
+      salt.assign_role if remote && success
     end
-    success
   rescue Velum::SaltApi::SaltConnectionException
-    errors.add(:base, "Failed to apply role #{new_role} to #{minion_id}")
+    errors.add :base, "Failed to apply role #{new_role} to #{minion_id}"
     false
   end
   # rubocop:enable SkipsModelValidations
@@ -115,6 +98,6 @@ class Minion < ApplicationRecord
 
   # Returns the proxy for the salt minion
   def salt
-    @salt ||= Velum::SaltMinion.new minion_id: minion_id
+    @salt ||= Velum::SaltMinion.new minion: self
   end
 end

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -37,7 +37,7 @@ class Pillar < ApplicationRecord
 
   scope :global, -> { where minion_id: nil }
 
-  OPTIONAL_PILLARS = [:http_proxy, :https_proxy, :no_proxy].freeze
+  PROTECTED_PILLARS = [:dashboard, :apiserver].freeze
 
   class << self
     def value(pillar:)
@@ -57,25 +57,34 @@ class Pillar < ApplicationRecord
 
     # Apply the given pillars into the database. It returns an array with the
     # encountered errors.
-    def apply(pillars)
+    def apply(pillars, required_pillars: [])
       errors = []
 
       Pillar.all_pillars.each do |key, pillar_key|
-        # The following pillar keys can be blank, delete them if they are.
-        if [:http_proxy, :https_proxy, :no_proxy].include?(key) && pillars[key].blank?
-          pillar = Pillar.find_by pillar: pillar_key
-          pillar.destroy if pillar
-        else
-          pillar = Pillar.find_or_initialize_by pillar: pillar_key
-          pillar.value = pillars[key]
-          next if pillar.save
+        next if PROTECTED_PILLARS.include?(key) && pillars[key].blank?
+        set_pillar key: key, pillar_key: pillar_key, value: pillars[key],
+                   required_pillars: required_pillars
+      end
 
+      errors
+    end
+
+    private
+
+    def set_pillar(key:, pillar_key:, value:, required_pillars:)
+      optional_pillars = Pillar.all_pillars.keys - required_pillars
+      # The following pillar keys can be blank, delete them if they are.
+      if optional_pillars.include?(key) && value.blank?
+        Pillar.destroy_all pillar: pillar_key
+      else
+        pillar = Pillar.find_or_initialize_by(pillar: pillar_key).tap do |pillar_|
+          pillar_.value = value
+        end
+        unless pillar.save
           exp = pillar.errors.empty? ? "" : ": #{pillar.errors.messages[:value].first}"
           errors << "'#{key}' could not be saved#{exp}."
         end
       end
-
-      errors
     end
   end
 end

--- a/app/views/setup/bootstrap.html.slim
+++ b/app/views/setup/bootstrap.html.slim
@@ -1,0 +1,18 @@
+h1 Confirm bootstrap
+
+= form_for :settings, url: setup_bootstrap_path, method: :post do |f|
+  .panel.panel-default
+    .panel-heading
+      h3.panel-title Cluster specific settings
+    .panel-body
+      .form-group
+        = f.label :apiserver, "External Kubernetes API server FQDN"
+        .input-group
+          = f.text_field :apiserver, value: (Pillar.value(pillar: :apiserver) || Minion.find_by(role: Minion.roles[:master]).fqdn), class: "form-control", required: true
+          span class="input-group-addon"
+            a data-toggle="tooltip" data-placement="left" title="Fully qualified domain name used to reach the cluster from the outside. In a simple, single master deployment this will be the FQDN of the node you are about to select as master. For advanced options refer to the documentation."
+              i class='glyphicon glyphicon-info-sign'
+
+  .clearfix.text-right.steps-container
+    = link_to "Back", setup_discovery_path, class: "btn btn-danger"
+    = submit_tag "Bootstrap cluster", class: "btn btn-primary pull-right"

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -1,9 +1,9 @@
-.alert.alert-warning.discovery-minimum-nodes-alert role="alert"
+.alert.alert-warning.discovery-minimum-nodes-alert role="alert" hidden="true"
   i.fa.fa-4x.pull-left aria-hidden="true"
   span
     | A supported deployment of SUSE Container as a Service Platform requires a minimum of three nodes. Please select a minimum of three nodes.
 
-h1 Bootstrap Cluster
+h1 Select nodes and roles
 
 .panel.panel-default.discovery-empty-panel class=('hide' if any_minion?)
   .panel-heading
@@ -15,15 +15,15 @@ h1 Bootstrap Cluster
 
     .text-right.steps-container
       = link_to "Back", setup_worker_bootstrap_path, class: "btn btn-danger"
-      = submit_tag "Bootstrap cluster", class: "btn btn-primary", disabled: true
+      = submit_tag "Next", class: "btn btn-primary", disabled: true
 
 .panel.panel-default.discovery-nodes-panel class=('hide' unless any_minion?)
   .panel-heading
     h3.panel-title#node-count #{Minion.count} nodes found
   .panel-body
-    p After choosing the master and clicking "Bootstrap cluster" all the other selected nodes will be set to the worker role.
+    p After choosing the master and clicking "Next" all the other selected nodes will be set to the worker role.
 
-    = form_tag(setup_bootstrap_path, method: "post")
+    = form_tag(setup_discovery_path, method: "post")
       .nodes-container data-url=setup_discovery_path
         table.table
           thead
@@ -37,22 +37,17 @@ h1 Bootstrap Cluster
               th.text-center
                 | Master
           tbody
-            - Minion.all.each do |m|
-              tr
-                td
-                  = check_box_tag "roles[worker][]", m.id
-                td
-                  | #{m.minion_id}
-                td
-                  | #{m.fqdn}
-                td.text-center
-                  = radio_button_tag "roles[master][]", m.id
+            tr
+              th colspan=4
+                p.text-center
+                  i class="fa fa-spinner fa-pulse fa-3x fa-fw"
+                  span class="sr-only" Loading...
 
         hr
 
         .clearfix.text-right.steps-container
           = link_to "Back", setup_worker_bootstrap_path, class: "btn btn-danger"
-          = submit_tag "Bootstrap cluster", id: "bootstrap", class: "btn btn-primary", disabled: true
+          = submit_tag "Next", id: "set-roles", class: "btn btn-primary", disabled: true
 
 = render "dashboard/pending_nodes"
 = render "setup/warn_minimum_nodes_modal"

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -13,13 +13,6 @@ h1 Initial CaaSP Configuration
           span class="input-group-addon"
             a data-toggle="tooltip" data-placement="left" title="Hostname or IP of the node running this web interface."
               i class='glyphicon glyphicon-info-sign'
-      .form-group
-        = f.label :apiserver, "External Kubernetes API server FQDN"
-        .input-group
-          = f.text_field :apiserver, value: Pillar.value(pillar: :apiserver), class: "form-control", required: true
-          span class="input-group-addon"
-            a data-toggle="tooltip" data-placement="left" title="Fully qualified domain name used to reach the cluster from the outside. In a simple, single master deployment this will be the FQDN of the node you are about to select as master. For advanced options refer to the documentation."
-              i class='glyphicon glyphicon-info-sign'
 
   .panel.panel-default
     .panel-heading.clearfix

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   get "/autoyast", to: "dashboard#autoyast"
 
@@ -31,6 +32,9 @@ Rails.application.routes.draw do
     match "/", action: :configure, via: [:put, :patch]
     get :"worker-bootstrap"
     get :discovery
-    post :bootstrap
+    post :discovery, action: :set_roles
+    get :bootstrap
+    post :bootstrap, action: :do_bootstrap
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/lib/velum/salt.rb
+++ b/lib/velum/salt.rb
@@ -46,8 +46,7 @@ module Velum
       res = perform_request(endpoint: "/", method: "post",
                             data: { client: "wheel",
                                     fun:    "key.list",
-                                    match:  "all",
-                                    tgt:    "ca" })
+                                    match:  "all" })
       JSON.parse(res.body)["return"].first["data"]["return"]["minions_pre"]
     end
 
@@ -56,8 +55,7 @@ module Velum
       res = perform_request(endpoint: "/", method: "post",
                             data: { client: "wheel",
                                     fun:    "key.accept",
-                                    match:  minion_id,
-                                    tgt:    "ca" })
+                                    match:  minion_id })
       JSON.parse(res.body)["return"].first["data"]["return"]["minions"]
     end
 

--- a/lib/velum/salt_minion.rb
+++ b/lib/velum/salt_minion.rb
@@ -6,22 +6,22 @@ module Velum
   class SaltMinion
     include SaltApi
 
-    attr_accessor :minion_id
+    attr_accessor :minion
 
     ROLES_MAP = {
       master: ["kube-master"],
       worker: ["kube-minion"]
     }.freeze
 
-    # Initializes a new salt minion identified by mid.
-    def initialize(minion_id:)
-      @minion_id = minion_id
+    # Initializes a new salt minion backend matching minion
+    def initialize(minion:)
+      @minion = minion
     end
 
     # Return information for this minion.
     def info
-      res = perform_request(endpoint: "/minions/#{@minion_id}", method: "get")
-      JSON.parse(res.body)["return"].first[@minion_id]
+      res = perform_request(endpoint: "/minions/#{@minion.minion_id}", method: "get")
+      JSON.parse(res.body)["return"].first[@minion.minion_id]
     end
 
     # Check if this minion has any role assigned.
@@ -30,21 +30,21 @@ module Velum
     end
 
     # Assign role to this minion.
-    def assign_role(role)
-      append_grain key: "roles", val: ROLES_MAP[role]
-      role
+    def assign_role
+      set_grain key: "roles", val: ROLES_MAP[@minion.role.to_sym]
+      @minion.role.to_sym
     end
 
     protected
 
     # Appends a grain with key and val to this minion.
-    def append_grain(key:, val:)
+    def set_grain(key:, val:)
       perform_request(endpoint: "/minions",
                       method:   "post",
                       data:     {
                         client: "local",
-                        tgt:    @minion_id,
-                        fun:    "grains.append",
+                        tgt:    @minion.minion_id,
+                        fun:    "grains.setval",
                         kwarg:  { key: key, val: val }
                       })
       [key, val]

--- a/spec/features/add_unassigned_nodes_feature_spec.rb
+++ b/spec/features/add_unassigned_nodes_feature_spec.rb
@@ -17,8 +17,7 @@ feature "Add unassigned nodes" do
     setup_stubbed_pending_minions!
 
     [:worker, :master].each do |role|
-      allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
-        .and_return(role)
+      allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).and_return(role)
     end
     allow(Velum::Salt).to receive(:orchestrate)
 

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -13,7 +13,7 @@ feature "Bootstrap cluster feature" do
   end
 
   # rubocop:disable RSpec/ExampleLength
-  context "Nodes bootstraping" do
+  context "Nodes bootstrapping" do
     let!(:minions) do
       Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local" },
                       { minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local" },
@@ -36,7 +36,7 @@ feature "Bootstrap cluster feature" do
       # select node minion1.k8s.local
       find("#roles_minion_#{minions[1].id}").click
 
-      click_on_when_enabled "#bootstrap"
+      click_on_when_enabled "#set-roles"
 
       # means it didn't go to the overview page
       expect(page).not_to have_content("Summary")
@@ -49,12 +49,16 @@ feature "Bootstrap cluster feature" do
       # select node minion1.k8s.local
       find("#roles_minion_#{minions[1].id}").click
 
-      click_on_when_enabled "#bootstrap"
+      click_on_when_enabled "#set-roles"
 
       # waits modal to appear
       expect(page).to have_content("Cluster is too small")
 
       click_button "Proceed anyway"
+
+      # means it went to the confirmation page
+      expect(page).to have_content("Confirm bootstrap")
+      click_button "Bootstrap cluster"
 
       # means it went to the overview page
       expect(page).to have_content("Summary")
@@ -72,7 +76,11 @@ feature "Bootstrap cluster feature" do
       # select node minion2.k8s.local
       find("#roles_minion_#{minions[2].id}").click
 
-      click_on_when_enabled "#bootstrap"
+      click_on_when_enabled "#set-roles"
+
+      # means it went to the confirmation page
+      expect(page).to have_content("Confirm bootstrap")
+      click_button "Bootstrap cluster"
 
       # means it went to the overview page
       expect(page).to have_content("Summary")
@@ -93,7 +101,11 @@ feature "Bootstrap cluster feature" do
       # select all nodes
       find(".check-all").click
 
-      click_on_when_enabled "#bootstrap"
+      click_on_when_enabled "#set-roles"
+
+      # means it went to the confirmation page
+      expect(page).to have_content("Confirm bootstrap")
+      click_button "Bootstrap cluster"
 
       expect(page).to have_content("Summary")
       expect(page).to have_content(minions[0].fqdn)
@@ -116,7 +128,7 @@ feature "Bootstrap cluster feature" do
   scenario "A user sees 'No nodes found'", js: true do
     expect(page).to have_content("No nodes found")
     # bootstrap cluster button disabled
-    expect(page).to have_button(value: "Bootstrap cluster", disabled: true)
+    expect(page).to have_button(value: "Next", disabled: true)
   end
 end
 # rubocop:enable RSpec/AnyInstance

--- a/spec/lib/velum/salt_minion_spec.rb
+++ b/spec/lib/velum/salt_minion_spec.rb
@@ -3,10 +3,14 @@ require "rails_helper"
 require "velum/salt_minion"
 
 describe Velum::SaltMinion do
+  let(:minion) do
+    Minion.create! minion_id: "minion1", fqdn: "minion1.example.com", role: "master"
+  end
+
   describe "minions" do
     it "fetches a single minion" do
       VCR.use_cassette("salt/fetch_minion", record: :none) do
-        expect(described_class.new(minion_id: "minion1").info).to include("kernel" => "Linux")
+        expect(described_class.new(minion: minion).info).to include("kernel" => "Linux")
       end
     end
   end
@@ -15,7 +19,7 @@ describe Velum::SaltMinion do
     context "has roles" do
       it "returns true for roles?" do
         VCR.use_cassette("salt/fetch_minion_with_roles", record: :none) do
-          expect(described_class.new(minion_id: "minion1").roles?).to be true
+          expect(described_class.new(minion: minion).roles?).to be true
         end
       end
     end
@@ -23,13 +27,13 @@ describe Velum::SaltMinion do
     context "has no roles" do
       it "return false for roles?" do
         VCR.use_cassette("salt/fetch_minion", record: :none) do
-          expect(described_class.new(minion_id: "minion1").roles?).to be false
+          expect(described_class.new(minion: minion).roles?).to be false
         end
       end
 
       it "assigns a role when called assign_role" do
         VCR.use_cassette("salt/assign_role_to_minion", record: :none) do
-          expect(described_class.new(minion_id: "minion1").assign_role(:master)).to eq :master
+          expect(described_class.new(minion: minion).assign_role).to eq :master
         end
       end
     end

--- a/spec/models/minion_spec.rb
+++ b/spec/models/minion_spec.rb
@@ -5,7 +5,7 @@ describe Minion do
   it { is_expected.to validate_uniqueness_of(:minion_id) }
 
   # rubocop:disable RSpec/ExampleLength
-  describe ".assign_roles!" do
+  describe ".assign_roles" do
     let(:minions) do
       described_class.create! [
         { minion_id: SecureRandom.hex, fqdn: "master.example.com" },
@@ -14,24 +14,25 @@ describe Minion do
       ]
     end
 
-    context "when a master role cannot be assigned" do
+    context "when a master role cannot be assigned remotely" do
       before do
         minions
       end
 
       it "returns a hash with the master fqdn false" do
         # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
-          .with(:master).and_return(false)
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
-          .with(:worker).and_return(true)
+        allow_any_instance_of(described_class).to receive(:assign_role)
+          .with(:master, remote: true).and_return(false)
+        allow_any_instance_of(described_class).to receive(:assign_role)
+          .with(:worker, remote: true).and_return(true)
         # rubocop:enable RSpec/AnyInstance
         expect(
-          described_class.assign_roles!(
-            roles: {
+          described_class.assign_roles(
+            roles:  {
               master: [described_class.first.id],
               worker: described_class.all[1..-1].map(&:id)
-            }
+            },
+            remote: true
           )
         ).to eq(
           minions[0].minion_id => false,
@@ -41,24 +42,25 @@ describe Minion do
       end
     end
 
-    context "when a minion role cannot be assigned" do
+    context "when a minion role cannot be assigned remotely" do
       before do
         minions
       end
 
       it "returns a hash with the minion fqdns false" do
         # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
-          .with(:master).and_return(true)
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
-          .with(:worker).and_return(false)
+        allow_any_instance_of(described_class).to receive(:assign_role)
+          .with(:master, remote: true).and_return(true)
+        allow_any_instance_of(described_class).to receive(:assign_role)
+          .with(:worker, remote: true).and_return(false)
         # rubocop:enable RSpec/AnyInstance
         expect(
-          described_class.assign_roles!(
-            roles: {
+          described_class.assign_roles(
+            roles:  {
               master: [described_class.first.id],
               worker: described_class.all[1..-1].map(&:id)
-            }
+            },
+            remote: true
           )
         ).to eq(
           minions[0].minion_id => true,
@@ -68,26 +70,26 @@ describe Minion do
       end
     end
 
-    context "when a default role cannot be assigned" do
+    context "when a default role cannot be assigned remotely" do
       before do
         minions
       end
 
       it "returns a hash with the default_role fqdn false" do
         # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(:master)
-          .and_return(true)
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(:worker)
-          .and_return(true)
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(:another_role)
-          .and_return(false)
+        allow_any_instance_of(described_class).to receive(:assign_role)
+          .with(:master, remote: true).and_return(true)
+        allow_any_instance_of(described_class).to receive(:assign_role)
+          .with(:worker, remote: true).and_return(true)
+        allow_any_instance_of(described_class).to receive(:assign_role)
+          .with(:another_role, remote: true).and_return(false)
         # rubocop:enable RSpec/AnyInstance
         expect(
-          described_class.assign_roles!(
+          described_class.assign_roles(
             roles: {
               master: [described_class.first.id],
-              worker: described_class.all[1..-2].map(&:id)
-            }, default_role: :another_role
+              worker: [described_class.second.id],
+            }, default_role: :another_role, remote: true
           )
         ).to eq(
           minions[0].minion_id => true,
@@ -100,35 +102,29 @@ describe Minion do
     context "when default_role is set" do
       before do
         minions
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
-          .and_return(true)
-        # rubocop:enable RSpec/AnyInstance
       end
 
       it "assigns the default role to the rest of the available minions" do
-        described_class.assign_roles!(
-          roles: {
-            master: [described_class.first.id],
-            worker: described_class.all[1..-1].map(&:id)
-          }
+        described_class.assign_roles(
+          roles:        {
+            master: [described_class.first.id]
+          },
+          default_role: :worker
         )
 
-        expect(described_class.all.map(&:role).sort).to eq(["master", "worker", "worker"])
+        expect(described_class.all.map(&:role).sort).to eq(["master",
+                                                            "worker",
+                                                            "worker"])
       end
     end
 
     context "when default_role is not set" do
       before do
         minions
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
-          .and_return(true)
-        # rubocop:enable RSpec/AnyInstance
       end
 
       it "assigns the minion role to the rest of the available minions" do
-        described_class.assign_roles!(
+        described_class.assign_roles(
           roles: {
             master: [described_class.first.id],
             worker: described_class.all[1..-1].map(&:id)
@@ -142,14 +138,10 @@ describe Minion do
     context "when explicit worker role is set" do
       before do
         minions
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
-          .and_return(true)
-        # rubocop:enable RSpec/AnyInstance
       end
 
       it "assigns the worker role to specific minions" do
-        described_class.assign_roles!(
+        described_class.assign_roles(
           roles: {
             master: [described_class.first.id],
             worker: described_class.all[1..-1].map(&:id)
@@ -162,11 +154,7 @@ describe Minion do
 
     it "returns a hash of the minions that were assigned a role" do
       minions
-      # rubocop:disable RSpec/AnyInstance
-      allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role)
-        .and_return(true)
-      # rubocop:enable RSpec/AnyInstance
-      roles = described_class.assign_roles!(
+      roles = described_class.assign_roles(
         roles: { master: [described_class.first.id], worker: described_class.all[1..-1].map(&:id) }
       )
 
@@ -179,16 +167,15 @@ describe Minion do
   end
 
   context "with some roles assigned" do
-    let(:minion) { create(:minion, role: :master) }
+    let(:minion) { create(:minion, role: described_class.roles[:master]) }
 
-    before { allow(minion.salt).to receive(:assign_role) { true } }
-
-    it "returns false when calling assign_role" do
-      expect(minion.assign_role(:other_role)).to be false
+    it "returns true when calling assign_role" do
+      expect(minion.assign_role(:worker)).to be true
     end
 
-    it "does not update the role in the database" do
-      expect(minion.role).to eq("master")
+    it "updates the role in the database" do
+      minion.assign_role :worker
+      expect(minion.role).to eq("worker")
     end
   end
 
@@ -221,7 +208,7 @@ describe Minion do
       end
 
       it "does not save the role in the database" do
-        expect(minion.assign_role(:master)).to be false
+        expect(minion.assign_role(:master, remote: true)).to be false
         expect(minion.reload.role).to be_nil
       end
     end

--- a/spec/vcr_cassettes/salt/assign_role_to_minion.yml
+++ b/spec/vcr_cassettes/salt/assign_role_to_minion.yml
@@ -57,7 +57,7 @@ http_interactions:
     uri: http://127.0.0.1:8000/minions
     body:
       encoding: UTF-8
-      string: '{"client":"local","tgt":"minion1","fun":"grains.append","kwarg":{"key":"roles","val":["kube-master","etcd"]}}'
+      string: '{"client":"local","tgt":"minion1","fun":"grains.setval","kwarg":{"key":"roles","val":["kube-master","etcd"]}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/vcr_cassettes/salt/bootstrap.yml
+++ b/spec/vcr_cassettes/salt/bootstrap.yml
@@ -50,7 +50,7 @@ http_interactions:
       string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
         "start": 1485434062.916784, "token": "26f5584c6a952b50aea191d9d4902dd0cf476a63",
         "expire": 1485477262.916785, "user": "saltapi", "eauth": "pam"}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:34:22 GMT
 - request:
     method: get
@@ -149,14 +149,14 @@ http_interactions:
         "osrelease_info": [42, 2], "locale_info": {"detectedencoding": "ascii", "defaultlanguage":
         null, "defaultencoding": null}, "gpus": [], "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "machine_id": "f5c7971b6083c77151b9b992582fd51d", "os": "SUSE"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:34:23 GMT
 - request:
     method: post
     uri: http://127.0.0.1:8000/minions
     body:
       encoding: UTF-8
-      string: '{"client":"local","tgt":"master","fun":"grains.append","kwarg":{"key":"roles","val":["kube-master","etcd"]}}'
+      string: '{"client":"local","tgt":"master","fun":"grains.setval","kwarg":{"key":"roles","val":["kube-master","etcd"]}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -202,7 +202,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"_links": {"jobs": [{"href": "/jobs/20170126123423100266"}]}, "return":
         [{"jid": "20170126123423100266", "minions": ["master"]}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:34:23 GMT
 - request:
     method: get
@@ -302,14 +302,14 @@ http_interactions:
         "ascii", "defaultlanguage": null, "defaultencoding": null}, "gpus": [], "path":
         "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "machine_id":
         "f5c7971b6083c77151b9b992582fd51d", "os": "SUSE"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:34:23 GMT
 - request:
     method: post
     uri: http://127.0.0.1:8000/minions
     body:
       encoding: UTF-8
-      string: '{"client":"local","tgt":"minion0","fun":"grains.append","kwarg":{"key":"roles","val":["kube-minion"]}}'
+      string: '{"client":"local","tgt":"minion0","fun":"grains.setval","kwarg":{"key":"roles","val":["kube-minion"]}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -355,7 +355,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"_links": {"jobs": [{"href": "/jobs/20170126123423100267"}]}, "return":
         [{"jid": "20170126123423100267", "minions": ["minion0"]}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:34:23 GMT
 - request:
     method: post
@@ -400,7 +400,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"return": [{"jid": "20170126123423134992", "tag": "salt/run/20170126123423134992"}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:34:23 GMT
 - request:
     method: post
@@ -452,6 +452,6 @@ http_interactions:
       string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
         "start": 1485435250.96626, "token": "d41893c77b9d956a0f3d030b1204c2f3e33d0fc8",
         "expire": 1485478450.966261, "user": "saltapi", "eauth": "pam"}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:54:10 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Velum will now have a new setup step after the roles have been chosen,
with the selected master as the kubernetes external FQDN name that will
contain its FQDN by default, allowing the customer to modify it to fit
their needs.

TODO:
- [ ] Fix unit tests
- [ ] Fix e2e-tests
- [ ] QA needs to adapt the workflow too

Fixes: bsc#1047284