### PR TITLE
Modify Velum workflow for Kubernetes external FQDN name

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,10 +14,8 @@ class ApplicationController < ActionController::Base
     redirect_to setup_path unless setup_done?
   end
 
-  # setup means minions were assigned to roles
-  # returns true if at least one minion has role != nil
-  # return false otherwise
+  # setup means the setup phase was completed
   def setup_done?
-    !Minion.assigned_role.count.zero?
+    Pillar.exists? pillar: Pillar.all_pillars[:apiserver]
   end
 end

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -9,27 +9,24 @@ require "velum/salt"
 class SetupController < ApplicationController
   include Discovery
 
-  rescue_from Minion::NonExistingNode, with: :node_not_found
-
   skip_before_action :redirect_to_setup
   before_action :redirect_to_dashboard
   before_action :check_empty_settings, only: :configure
-  before_action :check_empty_bootstrap, only: :bootstrap
+  before_action :check_empty_roles, only: :set_roles
+
+  def welcome
+    @dashboard = Pillar.value(pillar: :dashboard) || request.host
+    @http_proxy = Pillar.value pillar: :http_proxy
+    @https_proxy = Pillar.value pillar: :https_proxy
+    @no_proxy = Pillar.value(pillar: :no_proxy) || "localhost, 127.0.0.1"
+  end
 
   def configure
-    res = Pillar.apply(settings_params)
-
-    respond_to do |format|
-      if res.empty?
-        format.html { redirect_to setup_worker_bootstrap_path }
-        format.json { head :ok }
-      else
-        format.html do
-          flash[:alert] = res
-          redirect_to setup_path
-        end
-        format.json { render json: res, status: :unprocessable_entity }
-      end
+    res = Pillar.apply(settings_params, required_pillars: required_pillars)
+    if res.empty?
+      redirect_to setup_worker_bootstrap_path
+    else
+      redirect_to setup_path, alert: res
     end
   end
 
@@ -37,23 +34,39 @@ class SetupController < ApplicationController
     @controller_node = Pillar.value pillar: :dashboard
   end
 
+  def set_roles
+    # rubocop:disable Rails/SkipsModelValidations:
+    Minion.update_all role: nil
+    # rubocop:enable Rails/SkipsModelValidations:
+    assigned = Minion.assign_roles roles: update_nodes_params, remote: false
+    if assigned.values.include?(false)
+      redirect_to setup_discovery_path,
+                  flash: { error: "Failed to assign #{failed_assigned_nodes(assigned)}" }
+    else
+      redirect_to setup_bootstrap_path
+    end
+  end
+
   def bootstrap
-    assigned = Minion.assign_roles!(roles: update_nodes_params)
+    @apiserver = Pillar.value(pillar: :apiserver) ||
+      Minion.find_by(role: Minion.roles[:master]).fqdn
+  end
 
-    respond_to do |format|
-      if assigned.values.include?(false)
-        message = "Failed to assign #{failed_assigned_nodes(assigned)}"
-
-        format.html do
-          flash[:error] = message
-          redirect_to setup_discovery_path
-        end
-        format.json { render json: message, status: :unprocessable_entity }
-      else
-        Velum::Salt.orchestrate
-        format.html { redirect_to root_path }
-        format.json { head :ok }
-      end
+  def do_bootstrap
+    res = Pillar.apply(settings_params, required_pillars: required_pillars)
+    unless res.empty?
+      redirect_to setup_bootstrap_path, alert: res
+      return
+    end
+    masters = Minion.where(role: Minion.roles[:master]).pluck :id
+    workers = Minion.where(role: Minion.roles[:worker]).pluck :id
+    assigned = Minion.assign_roles roles: { master: masters, worker: workers }, remote: true
+    if assigned.values.include?(false)
+      redirect_to setup_bootstrap_path,
+                  flash: { error: "Failed to assign #{failed_assigned_nodes(assigned)}" }
+    else
+      Velum::Salt.orchestrate
+      redirect_to root_path
     end
   end
 
@@ -82,41 +95,26 @@ class SetupController < ApplicationController
     assigned.select { |_name, success| !success }.keys.join(", ")
   end
 
-  def node_not_found(exception)
-    respond_to do |format|
-      format.html do
-        flash[:error] = exception.message
-        redirect_to setup_path
-      end
-      format.json { render json: exception.message, status: :not_found }
-    end
-  end
-
   def check_empty_settings
     return if valid_settings?
-
-    respond_to do |format|
-      msg = "Please fill out all necessary form fields"
-      format.html do
-        redirect_to setup_path, alert: msg
-      end
-      format.json { render json: msg, status: :unprocessable_entity }
-    end
+    redirect_to setup_path, alert: "Please fill out all necessary form fields"
   end
 
-  def check_empty_bootstrap
+  def check_empty_roles
     return if params.try(:[], "roles").try(:[], "master")
-    respond_to do |format|
-      msg = "Please select a master node"
-      format.html do
-        redirect_to setup_discovery_path, alert: msg
-      end
-      format.json { render json: msg, status: :unprocessable_entity }
-    end
+    redirect_to setup_discovery_path, alert: "Please select a master node"
   end
 
   def valid_settings?
-    required_pillars = (Pillar.all_pillars.keys - Pillar::OPTIONAL_PILLARS).map(&:to_s)
     required_pillars.none? { |param| settings_params[param].blank? }
+  end
+
+  def required_pillars
+    case action_name
+    when "configure"
+      [:dashboard]
+    when "do_bootstrap"
+      [:apiserver]
+    end
   end
 end

--- a/app/views/setup/bootstrap.html.slim
+++ b/app/views/setup/bootstrap.html.slim
@@ -1,0 +1,18 @@
+h1 Confirm bootstrap
+
+= form_for :settings, url: setup_bootstrap_path, method: :post do |f|
+  .panel.panel-default
+    .panel-heading
+      h3.panel-title Cluster specific settings
+    .panel-body
+      .form-group
+        = f.label :apiserver, "External Kubernetes API server FQDN"
+        .input-group
+          = f.text_field :apiserver, value: @apiserver, class: "form-control", required: true
+          span class="input-group-addon"
+            a data-toggle="tooltip" data-placement="left" title="Fully qualified domain name used to reach the cluster from the outside. In a simple, single master deployment this will be the FQDN of the node you are about to select as master. For advanced options refer to the documentation."
+              i class='glyphicon glyphicon-info-sign'
+
+  .clearfix.text-right.steps-container
+    = link_to "Back", setup_discovery_path, class: "btn btn-danger"
+    = submit_tag "Bootstrap cluster", id: "bootstrap", class: "btn btn-primary pull-right"

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -1,9 +1,9 @@
-.alert.alert-warning.discovery-minimum-nodes-alert role="alert"
+.alert.alert-warning.discovery-minimum-nodes-alert role="alert" hidden="true"
   i.fa.fa-4x.pull-left aria-hidden="true"
   span
     | A supported deployment of SUSE Container as a Service Platform requires a minimum of three nodes. Please select a minimum of three nodes.
 
-h1 Bootstrap Cluster
+h1 Select nodes and roles
 
 .panel.panel-default.discovery-empty-panel class=('hide' if any_minion?)
   .panel-heading
@@ -15,7 +15,7 @@ h1 Bootstrap Cluster
 
     .text-right.steps-container
       = link_to "Back", setup_worker_bootstrap_path, class: "btn btn-danger"
-      = submit_tag "Bootstrap cluster", class: "btn btn-primary", disabled: true
+      = submit_tag "Next", class: "btn btn-primary", disabled: true
 
 .panel.panel-default.discovery-nodes-panel class=('hide' unless any_minion?)
   .panel-heading
@@ -29,9 +29,9 @@ h1 Bootstrap Cluster
       i.fa.fa-times.fa-fw
       | Deselect all nodes
   .panel-body
-    p After choosing the master and clicking "Bootstrap cluster" all the other selected nodes will be set to the worker role.
+    p After choosing the master and clicking "Next" all the other selected nodes will be set to the worker role.
 
-    = form_tag(setup_bootstrap_path, method: "post")
+    = form_tag(setup_discovery_path, method: "post")
       .nodes-container data-url=setup_discovery_path
         table.table
           thead
@@ -43,29 +43,17 @@ h1 Bootstrap Cluster
               th width="235"
                 | Role
           tbody
-            - Minion.all.each do |m|
-              tr class="minion_#{m.id}"
-                td
-                  | #{m.minion_id}
-                td
-                  | #{m.fqdn}
-                td.role-column
-                  = check_box_tag "roles[worker][]", m.id
-                  = check_box_tag "roles[master][]", m.id
-
-                  .btn-group.role-btn-group
-                    button type="button" class="btn btn-default master-btn" data-minion-id="#{m.id}" data-minion-role="master"
-                      | Master
-                    button type="button" class="btn btn-default worker-btn" data-minion-id="#{m.id}" data-minion-role="worker"
-                      | Worker
-                    button type="button" class="btn btn-default btn-primary unused-btn" data-minion-id="#{m.id}"
-                      | Unused
+            tr
+              th colspan=4
+                p.text-center
+                  i class="fa fa-spinner fa-pulse fa-3x fa-fw"
+                  span class="sr-only" Loading...
 
         hr
 
         .clearfix.text-right.steps-container
           = link_to "Back", setup_worker_bootstrap_path, class: "btn btn-danger"
-          = submit_tag "Bootstrap cluster", id: "bootstrap", class: "btn btn-primary", disabled: true
+          = submit_tag "Next", id: "set-roles", class: "btn btn-primary", disabled: true
 
 = render "dashboard/pending_nodes"
 = render "setup/warn_minimum_nodes_modal"

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -9,16 +9,9 @@ h1 Initial CaaSP Configuration
       .form-group
         = f.label :dashboard, "Dashboard location"
         .input-group
-          = f.text_field :dashboard, value: (Pillar.value(pillar: :dashboard) || request.host), class: "form-control", required: true
+          = f.text_field :dashboard, value: @dashboard, class: "form-control", required: true
           span class="input-group-addon"
             a data-toggle="tooltip" data-placement="left" title="Hostname or IP of the node running this web interface."
-              i class='glyphicon glyphicon-info-sign'
-      .form-group
-        = f.label :apiserver, "External Kubernetes API server FQDN"
-        .input-group
-          = f.text_field :apiserver, value: Pillar.value(pillar: :apiserver), class: "form-control", required: true
-          span class="input-group-addon"
-            a data-toggle="tooltip" data-placement="left" title="Fully qualified domain name used to reach the cluster from the outside. In a simple, single master deployment this will be the FQDN of the node you are about to select as master. For advanced options refer to the documentation."
               i class='glyphicon glyphicon-info-sign'
 
   .panel.panel-default
@@ -36,14 +29,14 @@ h1 Initial CaaSP Configuration
       .panel-body
         .form-group
           = f.label :http_proxy, "HTTP proxy"
-          = f.url_field :http_proxy, value: Pillar.value(pillar: :http_proxy), class: "form-control"
+          = f.url_field :http_proxy, value: @http_proxy, class: "form-control"
         .form-group
           = f.label :https_proxy, "HTTPS proxy"
-          = f.url_field :https_proxy, value: Pillar.value(pillar: :https_proxy), class: "form-control"
+          = f.url_field :https_proxy, value: @https_proxy, class: "form-control"
         .form-group
           = f.label :no, "No-proxy"
           .input-group
-            = f.text_field :no_proxy, value: (Pillar.value(pillar: :no_proxy) || "localhost, 127.0.0.1"), class: "form-control"
+            = f.text_field :no_proxy, value: @no_proxy, class: "form-control"
             span class="input-group-addon"
               a data-toggle="tooltip" data-placement="left" title="Comma separated list of sites or domains that should not be accessed via the proxy server."
                 i class='glyphicon glyphicon-info-sign'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   get "/autoyast", to: "dashboard#autoyast"
 
@@ -31,6 +32,9 @@ Rails.application.routes.draw do
     match "/", action: :configure, via: [:put, :patch]
     get :"worker-bootstrap"
     get :discovery
-    post :bootstrap
+    post :discovery, action: :set_roles
+    get :bootstrap
+    post :bootstrap, action: :do_bootstrap
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/lib/velum/salt.rb
+++ b/lib/velum/salt.rb
@@ -46,8 +46,7 @@ module Velum
       res = perform_request(endpoint: "/", method: "post",
                             data: { client: "wheel",
                                     fun:    "key.list",
-                                    match:  "all",
-                                    tgt:    "ca" })
+                                    match:  "all" })
       JSON.parse(res.body)["return"].first["data"]["return"]["minions_pre"]
     end
 
@@ -56,8 +55,7 @@ module Velum
       res = perform_request(endpoint: "/", method: "post",
                             data: { client: "wheel",
                                     fun:    "key.accept",
-                                    match:  minion_id,
-                                    tgt:    "ca" })
+                                    match:  minion_id })
       JSON.parse(res.body)["return"].first["data"]["return"]["minions"]
     end
 

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -16,11 +16,9 @@ RSpec.describe DashboardController, type: :controller do
   end
 
   before do
+    setup_done
     # rubocop:disable RSpec/AnyInstance
-    [:minion, :master].each do |role|
-      allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
-        .and_return(role)
-    end
+    allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).and_return(true)
     # rubocop:enable RSpec/AnyInstance
     allow(Velum::Salt).to receive(:orchestrate)
     setup_stubbed_pending_minions!
@@ -33,10 +31,11 @@ RSpec.describe DashboardController, type: :controller do
     end
 
     it "gets redirected to setup initially" do
+      setup_undone
       sign_in user
       get :index
       expect(response.status).to eq 302
-      expect(response.redirect_url).to eq "http://test.host/setup"
+      expect(response.redirect_url).to eq setup_url
     end
 
     it "shows a simple monitoring when roles have already been assigned" do
@@ -215,26 +214,11 @@ RSpec.describe DashboardController, type: :controller do
       master_minion && worker_minion
       Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "worker1" },
                       { minion_id: SecureRandom.hex, fqdn: "worker2" }]
-
-      allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(:worker)
-        .and_return(:worker)
-    end
-
-    context "when the minion doesn't exist" do
-      it "renders an error with not_found" do
-        post :assign_nodes, roles: { worker: [9999999] }
-        expect(flash[:error]).to be_present
-        expect(response.redirect_url).to eq "http://test.host/assign_nodes"
-      end
     end
 
     context "when the user successfully chooses the nodes" do
       it "strips other roles different from worker" do
         worker_ids = Minion.all[2..-1].map(&:id)
-        param = { roles: { "worker" => worker_ids.map(&:to_s) } }
-        allow(Minion).to receive(:assign_roles!).with(param)
-          .and_return({})
-
         post :assign_nodes, roles: { master: [1], dns: [2], worker: worker_ids }
       end
 
@@ -250,22 +234,21 @@ RSpec.describe DashboardController, type: :controller do
 
       it "gets redirected to the list of nodes" do
         post :assign_nodes, roles: { worker: Minion.all[2..-1].map(&:id) }
-        expect(response.redirect_url).to eq "http://test.host/"
+        expect(response.redirect_url).to eq root_url
         expect(response.status).to eq 302
       end
     end
 
     context "when nodes were not able to be assigned to its role" do
       before do
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(:worker)
-          .and_return(false)
         allow(salt).to receive(:orchestrate)
+        allow_any_instance_of(Minion).to receive(:assign_role).and_return(false)
       end
 
       it "gets redirected to the discovery page" do
         post :assign_nodes, roles: { worker: Minion.all[1..-1].map(&:id) }
         expect(flash[:error]).to be_present
-        expect(response.redirect_url).to eq "http://test.host/assign_nodes"
+        expect(response.redirect_url).to eq assign_nodes_url
       end
 
       it "doesn't call the orchestration" do

--- a/spec/controllers/updates_controller_spec.rb
+++ b/spec/controllers/updates_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe UpdatesController, type: :controller do
     user = create(:user)
     create(:master_minion)
     create(:worker_minion)
+    setup_done
     sign_in user
 
     allow(::Velum::Salt).to receive(:call).and_return(true)

--- a/spec/features/add_unassigned_nodes_feature_spec.rb
+++ b/spec/features/add_unassigned_nodes_feature_spec.rb
@@ -12,14 +12,12 @@ feature "Add unassigned nodes" do
   end
 
   before do
+    setup_done
     login_as user, scope: :user
     setup_stubbed_update_status!
     setup_stubbed_pending_minions!
 
-    [:worker, :master].each do |role|
-      allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
-        .and_return(role)
-    end
+    allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).and_return(true)
     allow(Velum::Salt).to receive(:orchestrate)
 
     visit assign_nodes_path

--- a/spec/features/admin_node_update_feature_spec.rb
+++ b/spec/features/admin_node_update_feature_spec.rb
@@ -5,6 +5,7 @@ feature "Manage nodes updates feature" do
   let!(:user) { create(:user) }
 
   before do
+    setup_done
     login_as user, scope: :user
     Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master")
     setup_stubbed_pending_minions!

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -13,7 +13,7 @@ feature "Bootstrap cluster feature" do
   end
 
   # rubocop:disable RSpec/ExampleLength
-  context "Nodes bootstraping" do
+  context "Nodes bootstrapping" do
     let!(:minions) do
       Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local" },
                       { minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local" },
@@ -23,11 +23,7 @@ feature "Bootstrap cluster feature" do
     end
 
     before do
-      # mock salt methods
-      [:worker, :master].each do |role|
-        allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).with(role)
-          .and_return(role)
-      end
+      allow_any_instance_of(Velum::SaltMinion).to receive(:assign_role).and_return(true)
       allow(Velum::Salt).to receive(:orchestrate)
     end
 
@@ -37,7 +33,7 @@ feature "Bootstrap cluster feature" do
       # select node minion1.k8s.local
       find(".minion_#{minions[1].id} .worker-btn").click
 
-      click_on_when_enabled "#bootstrap"
+      click_on_when_enabled "#set-roles"
 
       # means it didn't go to the overview page
       expect(page).not_to have_content("Summary")
@@ -50,12 +46,16 @@ feature "Bootstrap cluster feature" do
       # select node minion1.k8s.local
       find(".minion_#{minions[1].id} .worker-btn").click
 
-      click_on_when_enabled "#bootstrap"
+      click_on_when_enabled "#set-roles"
 
       # waits modal to appear
       expect(page).to have_content("Cluster is too small")
 
       click_button "Proceed anyway"
+
+      # means it went to the confirmation page
+      expect(page).to have_content("Confirm bootstrap")
+      click_button "Bootstrap cluster"
 
       # means it went to the overview page
       expect(page).to have_content("Summary")
@@ -73,7 +73,11 @@ feature "Bootstrap cluster feature" do
       # select node minion2.k8s.local
       find(".minion_#{minions[2].id} .worker-btn").click
 
-      click_on_when_enabled "#bootstrap"
+      click_on_when_enabled "#set-roles"
+
+      # means it went to the confirmation page
+      expect(page).to have_content("Confirm bootstrap")
+      click_button "Bootstrap cluster"
 
       # means it went to the overview page
       expect(page).to have_content("Summary")
@@ -94,7 +98,11 @@ feature "Bootstrap cluster feature" do
       # select all nodes
       find(".select-nodes-btn").click
 
-      click_on_when_enabled "#bootstrap"
+      click_on_when_enabled "#set-roles"
+
+      # means it went to the confirmation page
+      expect(page).to have_content("Confirm bootstrap")
+      click_button "Bootstrap cluster"
 
       expect(page).to have_content("Summary")
       expect(page).to have_content(minions[0].fqdn)
@@ -115,6 +123,10 @@ feature "Bootstrap cluster feature" do
       # select node minion4.k8s.local
       find(".minion_#{minions[4].id} .worker-btn").click
 
+      click_on_when_enabled "#set-roles"
+
+      # means it went to the confirmation page
+      expect(page).to have_content("Confirm bootstrap")
       click_on_when_enabled "#bootstrap"
 
       # means it went to the overview page
@@ -136,7 +148,7 @@ feature "Bootstrap cluster feature" do
       # select node minion3.k8s.local
       find(".minion_#{minions[3].id} .worker-btn").click
 
-      expect(page).to have_button(value: "Bootstrap cluster", disabled: true)
+      expect(page).to have_button(value: "Next", disabled: true)
     end
   end
 
@@ -153,7 +165,7 @@ feature "Bootstrap cluster feature" do
   scenario "A user sees 'No nodes found'", js: true do
     expect(page).to have_content("No nodes found")
     # bootstrap cluster button disabled
-    expect(page).to have_button(value: "Bootstrap cluster", disabled: true)
+    expect(page).to have_button(value: "Next", disabled: true)
   end
 end
 # rubocop:enable RSpec/AnyInstance

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 feature "Dashboard" do
   let!(:user) { create(:user) }
 
+  before do
+    setup_done
+  end
+
   describe "Downloading kubeconfig" do
     before do
       login_as user, scope: :user

--- a/spec/features/monitoring_feature_spec.rb
+++ b/spec/features/monitoring_feature_spec.rb
@@ -5,6 +5,7 @@ feature "Monitoring feature" do
   let!(:user) { create(:user) }
 
   before do
+    setup_done
     login_as user, scope: :user
     Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master")
     setup_stubbed_update_status!

--- a/spec/lib/velum/salt_minion_spec.rb
+++ b/spec/lib/velum/salt_minion_spec.rb
@@ -3,10 +3,14 @@ require "rails_helper"
 require "velum/salt_minion"
 
 describe Velum::SaltMinion do
+  let(:minion) do
+    Minion.create! minion_id: "minion1", fqdn: "minion1.example.com", role: "master"
+  end
+
   describe "minions" do
     it "fetches a single minion" do
       VCR.use_cassette("salt/fetch_minion", record: :none) do
-        expect(described_class.new(minion_id: "minion1").info).to include("kernel" => "Linux")
+        expect(described_class.new(minion: minion).info).to include("kernel" => "Linux")
       end
     end
   end
@@ -15,7 +19,7 @@ describe Velum::SaltMinion do
     context "has roles" do
       it "returns true for roles?" do
         VCR.use_cassette("salt/fetch_minion_with_roles", record: :none) do
-          expect(described_class.new(minion_id: "minion1").roles?).to be true
+          expect(described_class.new(minion: minion).roles?).to be true
         end
       end
     end
@@ -23,13 +27,13 @@ describe Velum::SaltMinion do
     context "has no roles" do
       it "return false for roles?" do
         VCR.use_cassette("salt/fetch_minion", record: :none) do
-          expect(described_class.new(minion_id: "minion1").roles?).to be false
+          expect(described_class.new(minion: minion).roles?).to be false
         end
       end
 
       it "assigns a role when called assign_role" do
         VCR.use_cassette("salt/assign_role_to_minion", record: :none) do
-          expect(described_class.new(minion_id: "minion1").assign_role(:master)).to eq :master
+          expect(described_class.new(minion: minion).assign_role).to eq true
         end
       end
     end

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -10,6 +10,16 @@ module Utils
   def setup_stubbed_pending_minions!(stubbed: [""])
     allow(::Velum::Salt).to receive(:pending_minions).and_return(stubbed)
   end
+
+  # Initializes the necessary fields for the setup to be considered completed
+  def setup_done(dashboard: true, apiserver: true)
+    Pillar.create pillar: Pillar.all_pillars[:dashboard], value: "localhost" if dashboard
+    Pillar.create pillar: Pillar.all_pillars[:apiserver], value: "api.example.com" if apiserver
+  end
+
+  def setup_undone
+    Pillar.delete_all
+  end
 end
 
 RSpec.configure { |config| config.include Utils }

--- a/spec/vcr_cassettes/salt/assign_role_to_minion.yml
+++ b/spec/vcr_cassettes/salt/assign_role_to_minion.yml
@@ -57,7 +57,7 @@ http_interactions:
     uri: http://127.0.0.1:8000/minions
     body:
       encoding: UTF-8
-      string: '{"client":"local","tgt":"minion1","fun":"grains.append","kwarg":{"key":"roles","val":["kube-master","etcd"]}}'
+      string: '{"client":"local","tgt":"minion1","fun":"grains.setval","kwarg":{"key":"roles","val":["kube-master","etcd"]}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/vcr_cassettes/salt/bootstrap.yml
+++ b/spec/vcr_cassettes/salt/bootstrap.yml
@@ -50,7 +50,7 @@ http_interactions:
       string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
         "start": 1485434062.916784, "token": "26f5584c6a952b50aea191d9d4902dd0cf476a63",
         "expire": 1485477262.916785, "user": "saltapi", "eauth": "pam"}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:34:22 GMT
 - request:
     method: get
@@ -149,14 +149,14 @@ http_interactions:
         "osrelease_info": [42, 2], "locale_info": {"detectedencoding": "ascii", "defaultlanguage":
         null, "defaultencoding": null}, "gpus": [], "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "machine_id": "f5c7971b6083c77151b9b992582fd51d", "os": "SUSE"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:34:23 GMT
 - request:
     method: post
     uri: http://127.0.0.1:8000/minions
     body:
       encoding: UTF-8
-      string: '{"client":"local","tgt":"master","fun":"grains.append","kwarg":{"key":"roles","val":["kube-master","etcd"]}}'
+      string: '{"client":"local","tgt":"master","fun":"grains.setval","kwarg":{"key":"roles","val":["kube-master","etcd"]}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -202,7 +202,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"_links": {"jobs": [{"href": "/jobs/20170126123423100266"}]}, "return":
         [{"jid": "20170126123423100266", "minions": ["master"]}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:34:23 GMT
 - request:
     method: get
@@ -302,14 +302,14 @@ http_interactions:
         "ascii", "defaultlanguage": null, "defaultencoding": null}, "gpus": [], "path":
         "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "machine_id":
         "f5c7971b6083c77151b9b992582fd51d", "os": "SUSE"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:34:23 GMT
 - request:
     method: post
     uri: http://127.0.0.1:8000/minions
     body:
       encoding: UTF-8
-      string: '{"client":"local","tgt":"minion0","fun":"grains.append","kwarg":{"key":"roles","val":["kube-minion"]}}'
+      string: '{"client":"local","tgt":"minion0","fun":"grains.setval","kwarg":{"key":"roles","val":["kube-minion"]}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -355,7 +355,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"_links": {"jobs": [{"href": "/jobs/20170126123423100267"}]}, "return":
         [{"jid": "20170126123423100267", "minions": ["minion0"]}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:34:23 GMT
 - request:
     method: post
@@ -400,7 +400,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"return": [{"jid": "20170126123423134992", "tag": "salt/run/20170126123423134992"}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:34:23 GMT
 - request:
     method: post
@@ -452,6 +452,6 @@ http_interactions:
       string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
         "start": 1485435250.96626, "token": "d41893c77b9d956a0f3d030b1204c2f3e33d0fc8",
         "expire": 1485478450.966261, "user": "saltapi", "eauth": "pam"}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Jan 2017 12:54:10 GMT
 recorded_with: VCR 3.0.3

--- a/spec/views/setup/discovery.html.slim_spec.rb
+++ b/spec/views/setup/discovery.html.slim_spec.rb
@@ -10,12 +10,12 @@ describe "setup/discovery" do
       expect(section.attribute("data-url").value).to eq setup_discovery_path
     end
 
-    it "has a button to bootstrap the cluster" do
+    it "has a button to go to the next step" do
       render
 
       section = assert_select("input[type='submit']")
       text = section[0].attributes["value"].value
-      expect(text).to eq "Bootstrap cluster"
+      expect(text).to eq "Next"
     end
   end
 end


### PR DESCRIPTION
Velum will now have a new setup step after the roles have been chosen,
with the selected master as the kubernetes external FQDN name that will
contain its FQDN by default, allowing the customer to modify it to fit
their needs.

Fixes: bsc#1047284