### PR TITLE
WIP: disable signup feature

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -15,7 +15,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
 
   # Restrict the amount of admin users to 1, see bsc#1040831
   def restrict_admin_users
-    return if User.count.zero?
+    return if User.count.zero? && APP_CONFIG.enabled?("signup")
     flash[:alert] = "Admin user already exists."
     redirect_to root_path
   end

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -8,7 +8,7 @@
       p SUSE Container as a Service Platform allows you to provision, manage, and scale container-based applications.
       p It automates your tedious management tasks allowing you to focus on development and writing apps to meet business goals.
     p
-      - if User.count.zero?
+      - if User.count.zero? && APP_CONFIG.enabled?("signup")
         | Don't have an account?
         a.btn.btn-default[href="/users/sign_up"]
           | Create an account

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,5 +12,8 @@ module Velum
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.autoload_paths << Rails.root.join("lib")
+    config.eager_load_paths << Rails.root.join("lib")
   end
 end

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,0 +1,6 @@
+# If enabled, then users can signup with the signup form. Otherwise, user
+# creation is completely disabled.
+#   - Using the "portus:create_user" rake task.
+# FIXME: should we create the velum:create_user task too?
+signup:
+  enabled: true

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,0 +1,4 @@
+default    = File.join(Rails.root, "config", "config.yml")
+local      = ENV["VELUM_LOCAL_CONFIG_PATH"] || File.join(Rails.root, "config", "config-local.yml")
+cfg        = Velum::Config.new(default, local)
+APP_CONFIG = cfg.fetch

--- a/lib/velum/config.rb
+++ b/lib/velum/config.rb
@@ -1,0 +1,62 @@
+# Based on https://github.com/SUSE/Portus/blob/master/lib/portus/config.rb
+
+module Velum
+  # The Config class is a convenient wrapper around the different configuration
+  # files that provides a simple way to retrieve the evaluated app config.
+  class Config
+    # The default file corresponds to the default config of the app. The local
+    # file can overwrite values from the default file.
+    def initialize(default, local)
+      @default = default
+      @local   = local
+    end
+
+    # Returns a hash with the app configuration contained in it.
+    def fetch
+      cfg = {}
+      cfg = YAML.load_file(@default) if File.file?(@default)
+
+      local = {}
+      if File.file?(@local)
+        # Check for bad user input in the local config.yml file.
+        local = YAML.load_file(@local)
+        unless local.is_a?(Hash)
+          raise StandardError, "Wrong format for the config-local file!"
+        end
+      end
+
+      hsh = strict_merge_with_env(cfg, local)
+      add_enabled(hsh)
+    end
+
+    # Returns a string representation of the evaluated configuration.
+    def to_s
+      hide_password(fetch.dup).to_yaml
+    end
+
+    protected
+
+    include ::Velum::HashUtils
+
+    # Add the `enabled?` method to the given object. The `enabled?` method is
+    # a convenient method that checks whether a specific feature is enabled or
+    # not. This method takes advantage of the convention that each feature has
+    # the "enabled" key inside of it. This also works for nested options by
+    # separating the nodes with a period, e.g. `enabled?("foo.bar")`. If this
+    # key exists in the checked feature, and it's set to true, then this method
+    # will return true. It returns false otherwise.
+    def add_enabled(obj)
+      obj.define_singleton_method(:enabled?) do |feature|
+        objs = feature.split(".")
+        if objs.length == 2
+          return false if !self[objs[0]][objs[1]] || self[objs[0]][objs[1]].empty?
+          self[objs[0]][objs[1]]["enabled"].eql?(true)
+        else
+          return false if !self[feature] || self[feature].empty?
+          self[feature]["enabled"].eql?(true)
+        end
+      end
+      obj
+    end
+  end
+end

--- a/lib/velum/hash_utils.rb
+++ b/lib/velum/hash_utils.rb
@@ -1,0 +1,81 @@
+# Based on https://github.com/SUSE/Portus/blob/master/lib/portus/hash_utils.rb
+
+module Velum
+  # The HashUtils modules include some helper methods that can be useful for
+  # some hashes (e.g. the ones that deal with configuration management).
+  module HashUtils
+    # Applies a deep merge while respecting the values from environment
+    # variables. A deep merge consists of a merge of all the nested elements of
+    # the two given hashes `cfg` and `local`. The `cfg` hash is supposed to
+    # contain all the accepted keys, and the `local` hash is a subset of it.
+    #
+    # Moreover, let's say that we have the following hash:
+    # { "ldap" => { "enabled" => true } }. An environment variable that can
+    # modify the value of the previous hash has to be named
+    # `VELUM_LDAP_ENABLED`. The `prefix` argument specifies how all the
+    # environment variables have to start. It defaults to "VELUM".
+    #
+    # Returns the merged hash, where the precedence of the merge is as follows:
+    #   1. The value of the related environment variable if set.
+    #   2. The value from the `local` hash.
+    #   3. The value from the `cfg` hash.
+    def strict_merge_with_env(cfg, local, prefix = "velum")
+      hsh = {}
+
+      cfg.each do |k, v|
+        # The corresponding environment variable. If it's not the final value,
+        # then this just contains the partial prefix of the env. variable.
+        env = "#{prefix}_#{k}"
+
+        # If the current value is a hash, then go deeper to perform a deep
+        # merge, otherwise we merge the final value by respecting the order as
+        # specified in the documentation.
+        if v.is_a?(Hash)
+          l = local[k] || {}
+          hsh[k] = strict_merge_with_env(cfg[k], l, env)
+        else
+          hsh[k] = first_non_nil(get_env(env), local[k], v)
+        end
+      end
+      hsh
+    end
+
+    # Hide any sensitive value, replacing it with "*" characters.
+    def hide_password(hsh)
+      hsh.each do |k, v|
+        if v.is_a?(Hash)
+          hsh[k] = hide_password(v)
+        elsif k == "password"
+          hsh[k] = "****"
+        end
+      end
+      hsh
+    end
+
+    private
+
+    # Get the typed value of the specified environment variable. If it doesn't
+    # exist, it will return nil. Otherwise, it will try to cast the fetched
+    # value into the proper type and return it.
+    def get_env(key)
+      env = ENV[key.upcase]
+      return nil if env.nil?
+
+      # Try to convert it into a boolean value.
+      return true if env.casecmp("true").zero?
+      return false if env.casecmp("false").zero?
+
+      # Try to convert it into an integer. Otherwise just keep the string.
+      begin
+        Integer(env)
+      rescue ArgumentError
+        env
+      end
+    end
+
+    # Returns the first value that is not nil from the given argument list.
+    def first_non_nil(*values)
+      values.each { |v| return v unless v.nil? }
+    end
+  end
+end


### PR DESCRIPTION
This PR allows a velum administrator to completely disable the signup feature. This is a requirement of the public cloud team, they want to perform the user creation only through a local command (this is coming after with another PR).

The PR also introduces the configuration mechanism used by Portus:
  * we provide sane settings inside of a `config/config.yml` file
  * users can override/extend them by doing any combination of:
     * provide a custom `config/config-local.yml` file
     * use environment variables

For example, to disable entirely the signup page the admin can start the velum container setting `VELUM_SIGNUP_ENABLED` to `"false"`.

This PR is a WIP, tests have not been extended yet.