### PR TITLE
Set database name via environment variable

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -13,4 +13,4 @@ default: &default
 
 <%= Rails.env.downcase %>:
   <<: *default
-  database: velum_<%= Rails.env.downcase %>
+  database: <%= ENV['VELUM_DB_NAME'] || "velum_#{Rails.env.downcase}" %>


### PR DESCRIPTION
Allow to specify a custom database name using the `VELUM_DB_NAME` environment variable.

The code falls back to the old value when the environment variable is not set.

This is needed to solve some issues with the new CI system.