### PR TITLE
Fixed 'Accept All Nodes' button ajax request

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -320,7 +320,7 @@ function setPendingAcceptance(minionId) {
 
 function requestMinionApproval(selector) {
   $.ajax({
-    url: '/accept-minion',
+    url: '/accept-minion.json',
     method: 'POST',
     data: { minion_id: selector }
   });

--- a/app/views/dashboard/_pending_nodes.html.slim
+++ b/app/views/dashboard/_pending_nodes.html.slim
@@ -3,7 +3,7 @@
     .panel-heading
       h3.panel-title Pending Nodes
 
-      button#accept-all.btn.btn-sm.btn-default.pull-right.accept-minion disabled="disabled"
+      button#accept-all.btn.btn-sm.btn-default.pull-right disabled="disabled"
         i.fa.fa-check.fa-fw
         | Accept All Nodes
 


### PR DESCRIPTION
The 'Accept All Nodes' button had the class '.accept-minion' that
is used to accept individually a node. When clicking on it the wrong
event listener callback was being called instead of the correct one.

Now it calls the expected event listener callback and makes the request
passing the expected arguments for all the nodes to be accepted.

For some reason I'm not aware, even not passing `minion_id` Salt was still able to accept all minions.