### PR TITLE
Only override blank pillars on the page they are shown

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -32,7 +32,9 @@ class SetupController < ApplicationController
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   def configure
-    res = Pillar.apply(settings_params, required_pillars: required_pillars)
+    res = Pillar.apply(settings_params,
+                       required_pillars:    required_pillars,
+                       unprotected_pillars: unprotected_pillars)
     if res.empty?
       redirect_to setup_worker_bootstrap_path
     else
@@ -63,7 +65,9 @@ class SetupController < ApplicationController
   end
 
   def do_bootstrap
-    res = Pillar.apply(settings_params, required_pillars: required_pillars)
+    res = Pillar.apply(settings_params,
+                       required_pillars:    required_pillars,
+                       unprotected_pillars: unprotected_pillars)
     unless res.empty?
       redirect_to setup_bootstrap_path, alert: res
       return
@@ -128,6 +132,16 @@ class SetupController < ApplicationController
       [:dashboard]
     when "do_bootstrap"
       [:apiserver]
+    end
+  end
+
+  def unprotected_pillars
+    case action_name
+    when "configure"
+      [:proxy_systemwide, :http_proxy, :https_proxy, :no_proxy, :cluster_cidr, :cluster_cidr_min,
+       :cluster_cidr_max, :cluster_cidr_len, :services_cidr, :api_cluster_ip, :dns_cluster_ip]
+    when "do_bootstrap"
+      []
     end
   end
 end

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -37,8 +37,6 @@ class Pillar < ApplicationRecord
 
   scope :global, -> { where minion_id: nil }
 
-  PROTECTED_PILLARS = [:dashboard, :apiserver].freeze
-
   class << self
     def value(pillar:)
       Pillar.find_by(pillar: all_pillars[pillar]).try(:value)
@@ -65,11 +63,11 @@ class Pillar < ApplicationRecord
 
     # Apply the given pillars into the database. It returns an array with the
     # encountered errors.
-    def apply(pillars, required_pillars: [])
+    def apply(pillars, required_pillars: [], unprotected_pillars: [])
       errors = []
 
       Pillar.all_pillars.each do |key, pillar_key|
-        next if PROTECTED_PILLARS.include?(key) && pillars[key].blank?
+        next if !unprotected_pillars.include?(key) && pillars[key].blank?
         set_pillar key: key, pillar_key: pillar_key, value: pillars[key],
                    required_pillars: required_pillars, errors: errors
       end


### PR DESCRIPTION
Before this change the last step of the setup would remove the pillar
information for the first step proxy values (since they were not
protected pillars).

Instead, explicitly say what unprotected pillars there are in each step
and allow the controller to override them with blank if they were provided
blank after having some other value.