### PR TITLE
packaging: mention velum-rpmlintrc in the sources

### DIFF
--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -29,6 +29,7 @@ License:        Apache-2.0
 Summary:        Dashboard for CaasP
 Url:            https://github.com/kubic-project/velum
 Source:         %{branch}.tar.gz
+Source2:        velum-rpmlintrc
 __PATCHSOURCES__
 
 Group:          System/Management


### PR DESCRIPTION
openSUSE Factory review bot is declining requests because of that

Signed-off-by: Maximilian Meister <mmeister@suse.de>