### PR TITLE
Add networking settings to the setup UI

### DIFF
--- a/app/assets/javascripts/setup.js
+++ b/app/assets/javascripts/setup.js
@@ -1,6 +1,20 @@
-$('.btn-group-toggle').click(function() {
-  var $btnGroup = $(this);
-  $btnGroup.find('.btn').toggleClass('active');
-  $btnGroup.find('.btn').toggleClass('btn-primary');
-  $btnGroup.find('.btn').toggleClass('btn-default');
+$(function() {
+  $('.btn-group-toggle').click(function() {
+    var $btnGroup = $(this);
+    $btnGroup.find('.btn').toggleClass('active');
+    $btnGroup.find('.btn').toggleClass('btn-primary');
+    $btnGroup.find('.btn').toggleClass('btn-default');
+  });
+
+
+  $(document).on('click', '.js-toggle-overlay-settings-btn', function() {
+    var targetId = $(this).data('target');
+    var collapsed = $(targetId).attr('aria-expanded') === 'true';
+
+    if (collapsed) {
+      $(this).text('Hide');
+    } else {
+      $(this).text('Show');
+    }
+  });
 });

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -6,6 +6,7 @@ require "velum/salt"
 # process:
 # welcoming, setting certain general settings, master selection, discovery and
 # bootstrapping
+# rubocop:disable Metrics/ClassLength
 class SetupController < ApplicationController
   include Discovery
 
@@ -14,12 +15,21 @@ class SetupController < ApplicationController
   before_action :check_empty_settings, only: :configure
   before_action :check_empty_roles, only: :set_roles
 
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def welcome
     @dashboard = Pillar.value(pillar: :dashboard) || request.host
     @http_proxy = Pillar.value pillar: :http_proxy
     @https_proxy = Pillar.value pillar: :https_proxy
     @no_proxy = Pillar.value(pillar: :no_proxy) || "localhost, 127.0.0.1"
+    @cluster_cidr = Pillar.value(pillar: :cluster_cidr) || "172.16.0.0/13"
+    @cluster_cidr_min = Pillar.value(pillar: :cluster_cidr_min) || "172.16.0.0"
+    @cluster_cidr_max = Pillar.value(pillar: :cluster_cidr_max) || "172.23.255.255"
+    @cluster_cidr_len = Pillar.value(pillar: :cluster_cidr_len) || "23"
+    @services_cidr = Pillar.value(pillar: :services_cidr) || "172.24.0.0/16"
+    @api_cluster_ip = Pillar.value(pillar: :api_cluster_ip) || "172.24.0.1"
+    @dns_cluster_ip = Pillar.value(pillar: :dns_cluster_ip) || "172.24.0.2"
   end
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   def configure
     res = Pillar.apply(settings_params, required_pillars: required_pillars)
@@ -121,3 +131,4 @@ class SetupController < ApplicationController
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -48,6 +48,13 @@ class Pillar < ApplicationRecord
       {
         dashboard:        "dashboard",
         apiserver:        "api:server:external_fqdn",
+        cluster_cidr:     "cluster_cidr",
+        cluster_cidr_min: "cluster_cidr_min",
+        cluster_cidr_max: "cluster_cidr_max",
+        cluster_cidr_len: "cluster_cidr_len",
+        services_cidr:    "services_cidr",
+        api_cluster_ip:   "api:cluster_ip",
+        dns_cluster_ip:   "dns:cluster_ip",
         proxy_systemwide: "proxy:systemwide",
         http_proxy:       "proxy:http",
         https_proxy:      "proxy:https",

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -16,6 +16,77 @@ h1 Initial CaaSP Configuration
 
   .panel.panel-default
     .panel-heading.clearfix
+      h3.panel-title Overlay network settings
+      .pull-right
+        = label_tag :cluster_network_settings_toggle, nil, class: "btn btn-default btn-sm js-toggle-overlay-settings-btn", data: {toggle: "collapse", target: "#cluster-network-settings-panel"}
+          | Show
+
+    #cluster-network-settings-panel.panel-collapse.collapse
+      .panel-body
+        p The Cluster Network is used interally within Kubernetes for pod to pod communications. Each master and worker node will receive a slice of this range, from which each Kubernetes pod will be allocated an IP. This network range will not be accessible from outside the cluster, however, conflicts with preexisting address ranges used elsewhere should be avoided.
+
+        .form-group
+          = f.label :cluster_cidr, "Cluster CIDR"
+          .input-group
+            = f.text_field :cluster_cidr, value: @cluster_cidr, class: "form-control", required: true
+            span class="input-group-addon"
+              a data-toggle="tooltip" data-placement="left" title="Cluster CIDR"
+                i class='glyphicon glyphicon-info-sign'
+
+        .form-group
+          = f.label :cluster_cidr_min, "Cluster CIDR (lower bound)"
+          .input-group
+            = f.text_field :cluster_cidr_min, value: @cluster_cidr_min, class: "form-control", required: true
+            span class="input-group-addon"
+              a data-toggle="tooltip" data-placement="left" title="Cluster CIDR (lower bound)"
+                i class='glyphicon glyphicon-info-sign'
+
+        .form-group
+          = f.label :cluster_cidr_max, "Cluster CIDR (upper bound)"
+          .input-group
+            = f.text_field :cluster_cidr_max, value: @cluster_cidr_max, class: "form-control", required: true
+            span class="input-group-addon"
+              a data-toggle="tooltip" data-placement="left" title="Cluster CIDR (upper bound)"
+                i class='glyphicon glyphicon-info-sign'
+
+        .form-group
+          = f.label :cluster_cidr_len, "Node allocation size (CIDR length per worker node)"
+          .input-group
+            = f.text_field :cluster_cidr_len, value: @cluster_cidr_len, class: "form-control", required: true
+            span class="input-group-addon"
+              a data-toggle="tooltip" data-placement="left" title="Node allocation size (CIDR length per worker node)"
+                i class='glyphicon glyphicon-info-sign'
+
+        hr
+
+        p The Service Network is used internally within Kubernetes for pod to service communications. Each Kubernetes service will be allocated an IP from this range, this IP will be independant of any single master or worker. This network range will not be accessible from outside the cluster, however, conflicts with preexisting address ranges used elsewhere should be avoided.
+
+        .form-group
+          = f.label :services_cidr, "Services CIDR"
+          .input-group
+            = f.text_field :services_cidr, value: @services_cidr, class: "form-control", required: true
+            span class="input-group-addon"
+              a data-toggle="tooltip" data-placement="left" title="Services CIDR"
+                i class='glyphicon glyphicon-info-sign'
+
+        .form-group
+          = f.label :api_cluster_ip, "API IP address"
+          .input-group
+            = f.text_field :api_cluster_ip, value: @api_cluster_ip, class: "form-control", required: true
+            span class="input-group-addon"
+              a data-toggle="tooltip" data-placement="left" title="API IP address (must be inside the Services CIDR)"
+                i class='glyphicon glyphicon-info-sign'
+
+        .form-group
+          = f.label :dns_cluster_ip, "DNS IP address"
+          .input-group
+            = f.text_field :dns_cluster_ip, value: @dns_cluster_ip, class: "form-control", required: true
+            span class="input-group-addon"
+              a data-toggle="tooltip" data-placement="left" title="DNS IP address (must be inside the Services CIDR)"
+                i class='glyphicon glyphicon-info-sign'
+
+  .panel.panel-default
+    .panel-heading.clearfix
       h3.panel-title Proxy settings
       .btn-group.btn-group-sm.btn-group-toggle.pull-right data-toggle="buttons"
         = label_tag :proxy_toggle, nil, class: "btn btn-default", data: {toggle: "collapse", target: "#proxy-settings-panel"}

--- a/db/migrate/20170911102046_add_missing_container_networking_pillars.rb
+++ b/db/migrate/20170911102046_add_missing_container_networking_pillars.rb
@@ -1,0 +1,29 @@
+class AddMissingContainerNetworkingPillars < ActiveRecord::Migration
+  def up
+    Pillar.find_or_create_by pillar: :cluster_cidr do |pillar|
+      pillar.value = "172.20.0.0/16"
+    end
+    Pillar.find_or_create_by pillar: :cluster_cidr_min do |pillar|
+      pillar.value = "172.20.50.0"
+    end
+    Pillar.find_or_create_by pillar: :cluster_cidr_max do |pillar|
+      pillar.value = "172.20.199.0"
+    end
+    Pillar.find_or_create_by pillar: :cluster_cidr_len do |pillar|
+      pillar.value = "24"
+    end
+    Pillar.find_or_create_by pillar: :services_cidr do |pillar|
+      pillar.value = "172.21.0.0/16"
+    end
+    Pillar.find_or_create_by pillar: "api:cluster_ip" do |pillar|
+      pillar.value = "172.21.0.1"
+    end
+    Pillar.find_or_create_by pillar: "dns:cluster_ip" do |pillar|
+      pillar.value = "172.21.0.2"
+    end
+  end
+  def down
+    Pillar.where(pillar: [:cluster_cidr, :cluster_cidr_min, :cluster_cidr_max, :cluster_cidr_len,
+                          :services_cidr, "api:cluster_ip", "dns:cluster_ip"]).destroy_all
+  end
+end


### PR DESCRIPTION
* Add to the pillar the old settings. This migration will only be executed
  on existing installations (as the `schema.rb` defines the up to date version and
  this last migration will be excluded)