### PR TITLE
Fixed proxy settings when revisiting the page

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -21,6 +21,8 @@ class SetupController < ApplicationController
     @http_proxy = Pillar.value pillar: :http_proxy
     @https_proxy = Pillar.value pillar: :https_proxy
     @no_proxy = Pillar.value(pillar: :no_proxy) || "localhost, 127.0.0.1"
+    @proxy_systemwide = Pillar.value(pillar: :proxy_systemwide) || "false"
+    @enable_proxy = proxy_enabled
     @cluster_cidr = Pillar.value(pillar: :cluster_cidr) || "172.16.0.0/13"
     @cluster_cidr_min = Pillar.value(pillar: :cluster_cidr_min) || "172.16.0.0"
     @cluster_cidr_max = Pillar.value(pillar: :cluster_cidr_max) || "172.23.255.255"
@@ -98,6 +100,13 @@ class SetupController < ApplicationController
 
   def update_nodes_params
     params.require(:roles)
+  end
+
+  def proxy_enabled
+    (!@http_proxy.blank? &&
+     !@https_proxy.blank? &&
+     !@no_proxy.blank?) ||
+      @proxy_systemwide == "true"
   end
 
   def redirect_to_dashboard

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -89,14 +89,14 @@ h1 Initial CaaSP Configuration
     .panel-heading.clearfix
       h3.panel-title Proxy settings
       .btn-group.btn-group-sm.btn-group-toggle.pull-right data-toggle="buttons"
-        = label_tag :proxy_toggle, nil, class: "btn btn-default", data: {toggle: "collapse", target: "#proxy-settings-panel"}
-          = f.radio_button :enable_proxy, "enable", checked: false
+        = label_tag :proxy_toggle, nil, class: "btn btn-default #{'btn-primary active' if @enable_proxy}", data: {toggle: "collapse", target: "#proxy-settings-panel"}
+          = f.radio_button :enable_proxy, "enable", checked: @enable_proxy
           | Enable
-        = label_tag :proxy_toggle, nil, class: "btn btn-primary active", data: {toggle: "collapse", target: "#proxy-settings-panel"}
-          = f.radio_button :enable_proxy, "disable", checked: true
+        = label_tag :proxy_toggle, nil, class: "btn btn-default #{'btn-primary active' unless @enable_proxy}", data: {toggle: "collapse", target: "#proxy-settings-panel"}
+          = f.radio_button :enable_proxy, "disable", checked: !@enable_proxy
           | Disable
 
-    #proxy-settings-panel.panel-collapse.collapse
+    #proxy-settings-panel.panel-collapse.collapse class="#{'in' if @enable_proxy}"
       .panel-body
         .form-group
           = f.label :http_proxy, "HTTP proxy"
@@ -116,11 +116,11 @@ h1 Initial CaaSP Configuration
           p Choose whether the proxy settings should apply only to the container
             engine or to all the processes running on the cluster nodes.
           .btn-group.btn-group-toggle data-toggle="buttons"
-            = label_tag :proxy_systemwide, nil, class: "btn btn-primary active"
-              = f.radio_button :proxy_systemwide, "false", checked: true
+            = label_tag :proxy_systemwide, nil, class: "btn btn-default #{'btn-primary active' if @proxy_systemwide == "false"}"
+              = f.radio_button :proxy_systemwide, "false", checked: @proxy_systemwide == "false"
               | Container Engine only
-            = label_tag :proxy_systemwide, nil, class: "btn btn-default"
-              = f.radio_button :proxy_systemwide, "true", checked: false
+            = label_tag :proxy_systemwide, nil, class: "btn btn-default #{'btn-primary active' if @proxy_systemwide == "true"}"
+              = f.radio_button :proxy_systemwide, "true", checked: @proxy_systemwide == "true"
               | Entire node
 
   .clearfix.steps-container

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -22,18 +22,58 @@ RSpec.describe SetupController, type: :controller do
       expect(response.status).to eq 302
     end
 
-    context "HTML rendering" do
-      it "returns a 200 if logged in" do
+    context "previous configure with proxy settings" do
+      let(:pillars) do
+        {
+          dashboard:        "dashboard.example.com",
+          http_proxy:       "squid.corp.net:3128",
+          https_proxy:      "squid.corp.net:3128",
+          no_proxy:         "localhost",
+          proxy_systemwide: "true"
+        }
+      end
+
+      before do
+        Pillar.apply(pillars, required_pillars: [:dashboard])
+
         sign_in user
 
         get :welcome
+      end
+
+      it "assigns @enable_proxy" do
+        expect(assigns(:enable_proxy)).to eq(true)
+      end
+
+      it "assigns @proxy_systemwide" do
+        expect(assigns(:proxy_systemwide)).to eq("true")
+      end
+
+      it "assigns @http_proxy" do
+        expect(assigns(:http_proxy)).to eq("squid.corp.net:3128")
+      end
+
+      it "assigns @https_proxy" do
+        expect(assigns(:https_proxy)).to eq("squid.corp.net:3128")
+      end
+
+      it "assigns @no_proxy" do
+        expect(assigns(:no_proxy)).to eq("localhost")
+      end
+    end
+
+    context "HTML rendering" do
+      before do
+        sign_in user
+
+        get :welcome
+      end
+
+      it "returns a 200 if logged in" do
         expect(response.status).to eq 200
       end
 
       it "renders with HTML if no format was specified" do
-        sign_in user
-
-        get :welcome
         expect(response["Content-Type"].include?("text/html")).to be true
       end
     end


### PR DESCRIPTION
After the first step of setting up the proxy settings,
when the user goes back to that initial page, the proxy
settings were lost. This can not only confuse the user
but also introduce undesired changes.

With this fix it doesn't happen anymore.

Fixes #300