### PR TITLE
Remove unneeded unprotected pillars

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -148,8 +148,7 @@ class SetupController < ApplicationController
   def unprotected_pillars
     case action_name
     when "configure"
-      [:proxy_systemwide, :http_proxy, :https_proxy, :no_proxy, :cluster_cidr, :cluster_cidr_min,
-       :cluster_cidr_max, :cluster_cidr_len, :services_cidr, :api_cluster_ip, :dns_cluster_ip]
+      [:proxy_systemwide, :http_proxy, :https_proxy, :no_proxy]
     when "do_bootstrap"
       []
     end


### PR DESCRIPTION
There's no possible use case for these pillars in which they were
filled with information and then the customer will clear them (as they
are required).

Keep things as simple as possible until we refactor this part.

Without this change, a specially crafted HTTP request could be made to
remove the content of those pillar values, when this is not ideal.