### PR TITLE
Consistent naming of the product

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  # The version used at CaaSP
+  # The version used at CaaS Platform
   - 2.1.9
 
   # Other ruby versions

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 |--------|--------------|
 | [![Build Status](https://travis-ci.org/kubic-project/velum.svg?branch=master)](https://travis-ci.org/kubic-project/velum) | [![Code Climate](https://codeclimate.com/github/kubic-project/velum/badges/gpa.svg)](https://codeclimate.com/github/kubic-project/velum) [![Test Coverage](https://codeclimate.com/github/kubic-project/velum/badges/coverage.svg)](https://codeclimate.com/github/kubic-project/velum/coverage) |
 
-Velum is a dashboard that manages your SUSE CaaSP cluster. With Velum, you will
+Velum is a dashboard that manages your SUSE CaaS Platform cluster. With Velum, you will
 be able to:
 
 - Bootstrap a Kubernetes cluster with a simple click.
 - Manage your Kubernetes cluster: adding and removing nodes from your cluster,
   monitoring faulty nodes, etc.
-- Setup an update policy that suits your needs. SUSE CaaSP already provides a
+- Setup an update policy that suits your needs. SUSE CaaS Platform already provides a
   transparent and sensible procedure for updates that guarantees no downtime,
   but with Velum you will be able to further tune this.
 
-The architecture of CaaSP uses [Salt](https://saltstack.com/) quite heavily,
+The architecture of CaaS Platform uses [Salt](https://saltstack.com/) quite heavily,
 and worker nodes are supposed to run as
 [Salt minions](https://docs.saltstack.com/en/latest/ref/cli/salt-minion.html). These
 Salt minions should then register to Velum, which acts as a Salt master. As an

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -3,9 +3,9 @@
     h1.Raleway-font
       | SUSE
       br
-      small Container as a Service Platform
+      small CaaS Platform
     .margins-updown
-      p SUSE Container as a Service Platform allows you to provision, manage, and scale container-based applications.
+      p SUSE CaaS Platform allows you to provision, manage, and scale container-based applications.
       p It automates your tedious management tasks allowing you to focus on development and writing apps to meet business goals.
     p
       | I already have an account.

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -3,9 +3,9 @@
     h1.Raleway-font
       | SUSE
       br
-      small Container as a Service Platform
+      small CaaS Platform
     .margins-updown
-      p SUSE Container as a Service Platform allows you to provision, manage, and scale container-based applications.
+      p SUSE CaaS Platform allows you to provision, manage, and scale container-based applications.
       p It automates your tedious management tasks allowing you to focus on development and writing apps to meet business goals.
     p
       - if User.count.zero?

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -25,7 +25,7 @@ html(lang='en')
         .col-xs-12
           p.text-center
             span
-              'SUSE CaaSP&reg; #{Rails.root.join("VERSION").read} | &copy; SUSE Linux #{Time.now.year}
+              'SUSE&reg; CaaS Platform #{Rails.root.join("VERSION").read} | &copy; SUSE Linux #{Time.now.year}
 
     = javascript_include_tag 'application'
     = yield :page_javascript

--- a/app/views/layouts/authentication.html.slim
+++ b/app/views/layouts/authentication.html.slim
@@ -1,7 +1,7 @@
 doctype html
 html
   head
-    title SUSE CaaSP: Velum
+    title SUSE CaaS Platform: Velum
     = stylesheet_link_tag 'authentication', media: 'all'
     = javascript_include_tag 'application'
     = csrf_meta_tags
@@ -26,7 +26,7 @@ html
         .row
           .col-sm-9
             .copyright
-              | SUSE CaaSP&reg; #{Rails.root.join("VERSION").read} | &copy; SUSE Linux #{Time.now.year}
+              | SUSE&reg; CaaS Platform #{Rails.root.join("VERSION").read} | &copy; SUSE Linux #{Time.now.year}
           .col-sm-3
             = image_tag "logo-footer.png", class: "suse-logo-footer pull-right"
       .bottom-line

--- a/app/views/setup/_warn_minimum_nodes_modal.html.erb
+++ b/app/views/setup/_warn_minimum_nodes_modal.html.erb
@@ -12,7 +12,7 @@
       <div class="modal-body">
         <p>You are going to deploy a cluster made by only one master and one worker node.</p>
 
-        <p>This kind of clusters is meant to be used only for development/testing/evaluation of SUSE Container as a Service Platform and is not a supported topology</p>
+        <p>This kind of clusters is meant to be used only for development/testing/evaluation of SUSE CaaS Platform and is not a supported topology</p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -1,7 +1,7 @@
 .alert.alert-warning.discovery-minimum-nodes-alert role="alert" hidden="true"
   i.fa.fa-4x.pull-left aria-hidden="true"
   span
-    | A supported deployment of SUSE Container as a Service Platform requires a minimum of three nodes. Please select a minimum of three nodes.
+    | A supported deployment of SUSE CaaS Platform requires a minimum of three nodes. Please select a minimum of three nodes.
 
 h1 Select nodes and roles
 

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -1,5 +1,5 @@
 = content_for :body_class, "welcome"
-h1 Initial CaaSP Configuration
+h1 Initial CaaS Platform Configuration
 
 = form_for :settings, url: setup_path, method: :put do |f|
   .panel.panel-default

--- a/app/views/setup/worker_bootstrap.html.slim
+++ b/app/views/setup/worker_bootstrap.html.slim
@@ -1,6 +1,6 @@
 = content_for :body_class, "worker_bootstrap"
 
-h1 Bootstrap your Container as a Service Platform
+h1 Bootstrap your CaaS Platform
 
 p
   | In order to complete the installation, it is necessary to bootstrap a few additional nodes, those will be the Kubernetes Master and Workers.

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,7 +1,7 @@
 header.row
   .col-xs-12
     .page-header.col-xs-6
-        h2 SUSE&reg; Container as a Service Platform
+        h2 SUSE&reg; CaaS Platform
     .col-xs-6
       - if user_signed_in?
       = link_to('Logout', destroy_user_session_path, class: "btn btn-logout pull-right", :method => :delete)

--- a/public/503_database_not_ready.html
+++ b/public/503_database_not_ready.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>SUSE Container as a Service Platform is initializing</title>
+  <title>SUSE CaaS Platform is initializing</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
   <style>
@@ -61,7 +61,7 @@
   <!-- This file lives in public/500.html -->
   <div class="dialog">
     <div>
-      <h1>SUSE Container as a Service Platform is initializing</h1>
+      <h1>SUSE CaaS Platform is initializing</h1>
     </div>
     <p>If you just finished the installation, it may take some seconds for the database to be available. Should the error persist check the logs for more information.</p>
   </div>

--- a/spec/lib/velum/suse_connect_spec.rb
+++ b/spec/lib/velum/suse_connect_spec.rb
@@ -105,7 +105,7 @@ describe Velum::SUSEConnect do
     end
   end
 
-  context "when requesting the regcode for CaaSP product" do
+  context "when requesting the regcode for CaaS Platform product" do
     let(:suse_connect_client) do
       described_class.new credentials: {
         username: "valid_username",
@@ -133,7 +133,7 @@ describe Velum::SUSEConnect do
       end
     end
 
-    context "with valid login information if there a CaaSP activation active" do
+    context "with valid login information if there a CaaS Platform activation active" do
       it "returns the regcode for the product" do
         VCR.use_cassette("suse_connect/caasp_activation_active", record: :none) do
           expect(suse_connect_client.regcode).to eq "valid_regcode"


### PR DESCRIPTION
- SUSE CaaSP
- SUSE Container as a Service Platform

both should be SUSE CaaS Platform.

Fixes: bsc#1058720