### PR TITLE
WIP: If a system won't be registered, set a default timeout for that warning during the installation

### DIFF
--- a/app/views/dashboard/autoyast.xml.erb
+++ b/app/views/dashboard/autoyast.xml.erb
@@ -81,6 +81,7 @@
       <ask>
         <default>This system will not be registered. Reason: <%= @registration_error %></default>
         <type>static_text</type>
+        <timeout config:type="integer">30</timeout>
       </ask>
     </ask-list>
     <% end %>


### PR DESCRIPTION
Right now it's completely necessary for the customer to confirm the "this
system is not going to be registered" warning, or the installation won't
continue.

Make this dialog have a timeout so we show it at the very beginning, but
it's also possible to install unattended workers without further action.

Fixes: bsc#1059016