### PR TITLE
Remove warnings from within autoyast installation

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -43,7 +43,8 @@ class DashboardController < ApplicationController
         @suse_regcode = suse_connect_config.regcode
         @do_registration = true
       rescue Velum::SUSEConnect::MissingRegCodeException,
-             Velum::SUSEConnect::MissingCredentialsException
+             Velum::SUSEConnect::MissingCredentialsException,
+             Velum::SUSEConnect::SCCConnectionException
         @do_registration = false
       end
       ssh_key_file = "/var/lib/misc/ssh-public-key/id_rsa.pub"
@@ -59,8 +60,6 @@ class DashboardController < ApplicationController
 
       render "autoyast.xml.erb", layout: false, content_type: "text/xml"
     end
-  rescue Velum::SUSEConnect::SCCConnectionException
-    head :service_unavailable
   end
 
   # Return the kubeconfig file that allows the customer to use the cluster using the kubectl tool.

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -43,9 +43,7 @@ class DashboardController < ApplicationController
         @suse_regcode = suse_connect_config.regcode
         @do_registration = true
       rescue Velum::SUSEConnect::MissingRegCodeException,
-             Velum::SUSEConnect::MissingCredentialsException,
-             Velum::SUSEConnect::SCCConnectionException => e
-        @registration_error = e.to_s
+             Velum::SUSEConnect::MissingCredentialsException
         @do_registration = false
       end
       ssh_key_file = "/var/lib/misc/ssh-public-key/id_rsa.pub"
@@ -61,6 +59,8 @@ class DashboardController < ApplicationController
 
       render "autoyast.xml.erb", layout: false, content_type: "text/xml"
     end
+  rescue Velum::SUSEConnect::SCCConnectionException
+    head :service_unavailable
   end
 
   # Return the kubeconfig file that allows the customer to use the cluster using the kubectl tool.

--- a/app/views/dashboard/autoyast.xml.erb
+++ b/app/views/dashboard/autoyast.xml.erb
@@ -76,14 +76,7 @@
     </global>
   </bootloader>
   <general>
-    <% if @registration_error %>
-    <ask-list config:type="list">
-      <ask>
-        <default>This system will not be registered. Reason: <%= @registration_error %></default>
-        <type>static_text</type>
-      </ask>
-    </ask-list>
-    <% end %>
+    <ask-list config:type="list"/>
     <mode>
       <confirm config:type="boolean">false</confirm>
       <second_stage config:type="boolean">false</second_stage>

--- a/lib/velum/suse_connect.rb
+++ b/lib/velum/suse_connect.rb
@@ -6,23 +6,11 @@ module Velum
   # This class handles interaction with the SUSE Connect service (whether is the SCC or SMT).
   class SUSEConnect
     # Raised when there is a connection exception with the SMT/SCC service
-    class SCCConnectionException < StandardError
-      def initialize
-        super "Error connecting to SCC/SMT"
-      end
-    end
+    class SCCConnectionException < StandardError; end
     # Raised when an active registration code for CaaSP is missing
-    class MissingRegCodeException < StandardError
-      def initialize
-        super "Missing registration code"
-      end
-    end
+    class MissingRegCodeException < StandardError; end
     # Raised when no credentials were found for SCC service
-    class MissingCredentialsException < StandardError
-      def initialize
-        super "Missing credentials for SCC/SMT"
-      end
-    end
+    class MissingCredentialsException < StandardError; end
 
     DEFAULT_SMT_URL = "https://scc.suse.com".freeze
 
@@ -150,8 +138,8 @@ module Velum
       else
         return response, nil
       end
-    rescue *HTTPExceptions::EXCEPTIONS
-      raise SCCConnectionException
+    rescue *HTTPExceptions::EXCEPTIONS => e
+      raise SCCConnectionException, e
     end
   end
 end

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -90,8 +90,6 @@ RSpec.describe DashboardController, type: :controller do
   end
 
   describe "GET /autoyast" do
-    render_views
-
     before do
       Pillar.create pillar: "dashboard", value: "localhost"
       allow(Velum::SUSEConnect).to receive(:config).and_return(
@@ -142,7 +140,6 @@ RSpec.describe DashboardController, type: :controller do
         VCR.use_cassette("suse_connect/caasp_registration_active", record: :none) do
           get :autoyast
           expect(response.status).to eq 200
-          expect(response.body).to include("Missing credentials for SCC/SMT")
         end
       end
     end
@@ -158,7 +155,6 @@ RSpec.describe DashboardController, type: :controller do
         VCR.use_cassette("suse_connect/caasp_registration_active", record: :none) do
           get :autoyast
           expect(response.status).to eq 200
-          expect(response.body).to include("Missing registration code")
         end
       end
     end
@@ -170,11 +166,11 @@ RSpec.describe DashboardController, type: :controller do
         )
       end
 
-      it "serves the autoyast content" do
+      it "renders a 503 status and a blank page" do
         VCR.use_cassette("suse_connect/caasp_registration_active", record: :none) do
           get :autoyast
-          expect(response.status).to eq 200
-          expect(response.body).to include("Error connecting to SCC/SMT")
+          expect(response.body).to be_blank
+          expect(response.status).to eq 503
         end
       end
     end

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -90,6 +90,8 @@ RSpec.describe DashboardController, type: :controller do
   end
 
   describe "GET /autoyast" do
+    render_views
+
     before do
       Pillar.create pillar: "dashboard", value: "localhost"
       allow(Velum::SUSEConnect).to receive(:config).and_return(
@@ -166,11 +168,10 @@ RSpec.describe DashboardController, type: :controller do
         )
       end
 
-      it "renders a 503 status and a blank page" do
+      it "serves the autoyast content" do
         VCR.use_cassette("suse_connect/caasp_registration_active", record: :none) do
           get :autoyast
-          expect(response.body).to be_blank
-          expect(response.status).to eq 503
+          expect(response.status).to eq 200
         end
       end
     end


### PR DESCRIPTION
Revert https://github.com/kubic-project/velum/pull/270 partially, so we still support the air-gapped installations (bsc#1049948)

Fixes: bsc#1058999