### PR TITLE
[CNI] Set default flannel backend to UDP for old installations

### DIFF
--- a/db/migrate/20180109145421_set_udp_as_default_flannel_backend.rb
+++ b/db/migrate/20180109145421_set_udp_as_default_flannel_backend.rb
@@ -1,0 +1,10 @@
+class SetUdpAsDefaultFlannelBackend < ActiveRecord::Migration
+  def up
+    Pillar.find_or_create_by pillar: "flannel:backend" do |pillar|
+      pillar.value = "udp"
+    end
+  end
+  def down
+    Pillar.where(pillar: "flannel:backend").destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171117145421) do
+ActiveRecord::Schema.define(version: 20180109145421) do
 
   create_table "jids", id: false, force: :cascade do |t|
     t.string "jid",  limit: 255,      null: false


### PR DESCRIPTION
This migration will only be executed on old installations, while on new ones
(where we will use the default salt pillar value) this migration won't be
run, so there won't be a pillar override.

Depends on: https://github.com/kubic-project/salt/pull/201