### PR TITLE
Do not add an override that will have the same value as the overriden one

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -74,9 +74,6 @@ class SetupController < ApplicationController
       redirect_to setup_bootstrap_path, alert: res
       return
     end
-    Pillar.find_or_create_by pillar: "api:etcd_version" do |pillar|
-      pillar.value = "etcd3"
-    end
     masters = Minion.where(role: Minion.roles[:master]).pluck :id
     workers = Minion.where(role: Minion.roles[:worker]).pluck :id
     assigned = Minion.assign_roles roles: { master: masters, worker: workers }, remote: true


### PR DESCRIPTION
This will only be effective on new installations, where the default pillar
value matches this value. Let's keep things simple and only override what
is in the UI or what will/can be different between versions.