### PR TITLE
Re-adding option to install Tiller

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -18,6 +18,7 @@ class SetupController < ApplicationController
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def welcome
     @dashboard = Pillar.value(pillar: :dashboard) || request.host
+    @tiller = Pillar.value(pillar: :tiller) == "true"
     @http_proxy = Pillar.value pillar: :http_proxy
     @https_proxy = Pillar.value pillar: :https_proxy
     @no_proxy = Pillar.value(pillar: :no_proxy) || "localhost, 127.0.0.1"

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -59,6 +59,7 @@ class Pillar < ApplicationRecord
         http_proxy:            "proxy:http",
         https_proxy:           "proxy:https",
         no_proxy:              "proxy:no_proxy",
+        tiller:                "addons:tiller"
         ldap_host:             "ldap:host",
         ldap_port:             "ldap:port",
         ldap_bind_dn:          "ldap:bind_dn",

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -59,7 +59,7 @@ class Pillar < ApplicationRecord
         http_proxy:            "proxy:http",
         https_proxy:           "proxy:https",
         no_proxy:              "proxy:no_proxy",
-        tiller:                "addons:tiller"
+        tiller:                "addons:tiller",
         ldap_host:             "ldap:host",
         ldap_port:             "ldap:port",
         ldap_bind_dn:          "ldap:bind_dn",

--- a/app/views/setup/bootstrap.html.slim
+++ b/app/views/setup/bootstrap.html.slim
@@ -12,11 +12,6 @@ h1 Confirm bootstrap
           span class="input-group-addon"
             a data-toggle="tooltip" data-placement="left" title="Fully qualified domain name used to reach the cluster from the outside. In a simple, single master deployment this will be the FQDN of the node you are about to select as master. For advanced options refer to the documentation."
               i class='glyphicon glyphicon-info-sign'
-      .checkbox
-        label
-          = f.check_box "tiller", {}, "true", "false"
-          |
-            Install Tiller (Helm's server component)
 
   .clearfix.text-right.steps-container
     = link_to "Back", setup_discovery_path, class: "btn btn-danger"

--- a/app/views/setup/bootstrap.html.slim
+++ b/app/views/setup/bootstrap.html.slim
@@ -12,6 +12,11 @@ h1 Confirm bootstrap
           span class="input-group-addon"
             a data-toggle="tooltip" data-placement="left" title="Fully qualified domain name used to reach the cluster from the outside. In a simple, single master deployment this will be the FQDN of the node you are about to select as master. For advanced options refer to the documentation."
               i class='glyphicon glyphicon-info-sign'
+      .checkbox
+        label
+          = f.check_box "tiller", {}, "true", "false"
+          |
+            Install Tiller (Helm's server component)
 
   .clearfix.text-right.steps-container
     = link_to "Back", setup_discovery_path, class: "btn btn-danger"

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -16,6 +16,17 @@ h1 Initial CaaS Platform Configuration
 
   .panel.panel-default
     .panel-heading.clearfix
+      h3.panel-title Cluster services
+
+    .panel-body
+      .form-group
+        .checkbox
+          label
+            = f.check_box "tiller", { checked: @tiller }, "true", "false"
+            | Install Tiller (Helm's server component)
+
+  .panel.panel-default
+    .panel-heading.clearfix
       h3.panel-title Overlay network settings
       .pull-right
         = label_tag :cluster_network_settings_toggle, nil, class: "btn btn-default btn-sm js-toggle-overlay-settings-btn", data: {toggle: "collapse", target: "#cluster-network-settings-panel"}


### PR DESCRIPTION
Adding back the optional checkbox to install Tiller, Helm's server
component.