### PR TITLE
ux: improved messages for 'Next' button on nodes selection

### DIFF
--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -3,6 +3,13 @@
   span
     | A supported deployment of SUSE CaaS Platform requires a minimum of three nodes. Please select a minimum of three nodes.
 
+.alert.alert-danger.discovery-bootstrap-alert role="alert" hidden="true"
+  i.fa.fa-4x.pull-left aria-hidden="true"
+  span
+    p Unable to bootstrap cluster:
+
+    ul.list
+
 h1 Select nodes and roles
 
 .panel.panel-default.discovery-empty-panel class=('hide' if any_minion?)
@@ -53,7 +60,7 @@ h1 Select nodes and roles
 
         .clearfix.text-right.steps-container
           = link_to "Back", setup_worker_bootstrap_path, class: "btn btn-danger"
-          = submit_tag "Next", id: "set-roles", class: "btn btn-primary", disabled: true
+          = submit_tag "Next", id: "set-roles", class: "btn btn-primary"
 
 = render "dashboard/pending_nodes"
 = render "setup/warn_minimum_nodes_modal"

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -138,7 +138,7 @@ feature "Bootstrap cluster feature" do
       expect(page).to have_content(minions[4].fqdn)
     end
 
-    scenario "A user cannot bootstap an even multiple master configuration", js: true do
+    scenario "A user cannot bootstrap an even multiple master configuration", js: true do
       # select master minion0.k8s.local
       find(".minion_#{minions[0].id} .master-btn").click
       # select node minion1.k8s.local
@@ -148,6 +148,29 @@ feature "Bootstrap cluster feature" do
       # select node minion3.k8s.local
       find(".minion_#{minions[3].id} .worker-btn").click
 
+      click_on_when_enabled "#set-roles"
+
+      expect(page).to have_content("The number of masters has to be an odd number")
+      expect(page).to have_button(value: "Next", disabled: true)
+    end
+
+    scenario "A user cannot bootstap if no worker is selected", js: true do
+      # select master minion0.k8s.local
+      find(".minion_#{minions[0].id} .master-btn").click
+
+      click_on_when_enabled "#set-roles"
+
+      expect(page).to have_content("You haven't selected one worker at least")
+      expect(page).to have_button(value: "Next", disabled: true)
+    end
+
+    scenario "A user cannot bootstap if no master is selected", js: true do
+      # select master minion0.k8s.local
+      find(".minion_#{minions[0].id} .worker-btn").click
+
+      click_on_when_enabled "#set-roles"
+
+      expect(page).to have_content("You haven't selected one master at least")
       expect(page).to have_button(value: "Next", disabled: true)
     end
   end


### PR DESCRIPTION
The title message for the 'Next' button on the nodes selection
page were out of date and weren't helping the user understand
what was wrong.

For each rule we use to validate the 'Next' button we
are adding a dedicated message to show to the user. This way
the user will know exactly what's wrong with the cluster
configuration.

I also fixed the "minimum of three nodes" alert to only be displayed
if the user didn't select 3 nodes (dones't matter if master was not
selected). The previous behavior was making it display if the
configuration wasn't supported even having 4 nodes selected. This
info now goes on the 'Next' button title message.

See bsc#1058915

(cherry picked from commit 1df8e6e761774863297544eb9d4ee33c0f99b2c7)