### PR TITLE
Collect the dashboard hosts external FQDN

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -65,6 +65,9 @@ class SetupController < ApplicationController
   def bootstrap
     @apiserver = Pillar.value(pillar: :apiserver) ||
       Minion.find_by(role: Minion.roles[:master]).fqdn
+    # TODO: Minion.find_by(role: Minion.roles[:admin]).fqdn ?
+    @dashboard_external_fqdn = Pillar.value(pillar: :dashboard_external_fqdn) ||
+      ""
   end
 
   def do_bootstrap
@@ -138,7 +141,7 @@ class SetupController < ApplicationController
     when "configure"
       [:dashboard]
     when "do_bootstrap"
-      [:apiserver]
+      [:apiserver, :dashboard_external_fqdn]
     end
   end
 

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -37,7 +37,7 @@ class Pillar < ApplicationRecord
 
   scope :global, -> { where minion_id: nil }
 
-  PROTECTED_PILLARS = [:dashboard, :apiserver].freeze
+  PROTECTED_PILLARS = [:dashboard, :apiserver, :dashboard_external_fqdn].freeze
 
   class << self
     def value(pillar:)
@@ -46,32 +46,33 @@ class Pillar < ApplicationRecord
 
     def all_pillars
       {
-        dashboard:             "dashboard",
-        apiserver:             "api:server:external_fqdn",
-        cluster_cidr:          "cluster_cidr",
-        cluster_cidr_min:      "cluster_cidr_min",
-        cluster_cidr_max:      "cluster_cidr_max",
-        cluster_cidr_len:      "cluster_cidr_len",
-        services_cidr:         "services_cidr",
-        api_cluster_ip:        "api:cluster_ip",
-        dns_cluster_ip:        "dns:cluster_ip",
-        proxy_systemwide:      "proxy:systemwide",
-        http_proxy:            "proxy:http",
-        https_proxy:           "proxy:https",
-        no_proxy:              "proxy:no_proxy",
-        tiller:                "addons:tiller",
-        ldap_host:             "ldap:host",
-        ldap_port:             "ldap:port",
-        ldap_bind_dn:          "ldap:bind_dn",
-        ldap_bind_pw:          "ldap:bind_pw",
-        ldap_domain:           "ldap:domain",
-        ldap_group_dn:         "ldap:group_dn",
-        ldap_people_dn:        "ldap:people_dn",
-        ldap_base_dn:          "ldap:base_dn",
-        ldap_admin_group_dn:   "ldap:admin_group_dn",
-        ldap_admin_group_name: "ldap:admin_group_name",
-        ldap_tls_method:       "ldap:tls_method",
-        ldap_mail_attribute:   "ldap:mail_attribute"
+        dashboard:               "dashboard",
+        dashboard_external_fqdn: "dashboard_external_fqdn",
+        apiserver:               "api:server:external_fqdn",
+        cluster_cidr:            "cluster_cidr",
+        cluster_cidr_min:        "cluster_cidr_min",
+        cluster_cidr_max:        "cluster_cidr_max",
+        cluster_cidr_len:        "cluster_cidr_len",
+        services_cidr:           "services_cidr",
+        api_cluster_ip:          "api:cluster_ip",
+        dns_cluster_ip:          "dns:cluster_ip",
+        proxy_systemwide:        "proxy:systemwide",
+        http_proxy:              "proxy:http",
+        https_proxy:             "proxy:https",
+        no_proxy:                "proxy:no_proxy",
+        tiller:                  "addons:tiller",
+        ldap_host:               "ldap:host",
+        ldap_port:               "ldap:port",
+        ldap_bind_dn:            "ldap:bind_dn",
+        ldap_bind_pw:            "ldap:bind_pw",
+        ldap_domain:             "ldap:domain",
+        ldap_group_dn:           "ldap:group_dn",
+        ldap_people_dn:          "ldap:people_dn",
+        ldap_base_dn:            "ldap:base_dn",
+        ldap_admin_group_dn:     "ldap:admin_group_dn",
+        ldap_admin_group_name:   "ldap:admin_group_name",
+        ldap_tls_method:         "ldap:tls_method",
+        ldap_mail_attribute:     "ldap:mail_attribute"
       }
     end
 

--- a/app/views/setup/bootstrap.html.slim
+++ b/app/views/setup/bootstrap.html.slim
@@ -6,11 +6,19 @@ h1 Confirm bootstrap
       h3.panel-title Cluster specific settings
     .panel-body
       .form-group
-        = f.label :apiserver, "External Kubernetes API server FQDN"
+        = f.label :apiserver, "External Kubernetes API FQDN"
         .input-group
           = f.text_field :apiserver, value: @apiserver, class: "form-control", required: true
           span class="input-group-addon"
             a data-toggle="tooltip" data-placement="left" title="Fully qualified domain name used to reach the cluster from the outside. In a simple, single master deployment this will be the FQDN of the node you are about to select as master. For advanced options refer to the documentation."
+              i class='glyphicon glyphicon-info-sign'
+
+      .form-group
+        = f.label :dashboard_external_fqdn, "External Dashboard FQDN"
+        .input-group
+          = f.text_field :dashboard_external_fqdn, value: @dashboard_external_fqdn, class: "form-control", required: true
+          span class="input-group-addon"
+            a data-toggle="tooltip" data-placement="left" title="Fully qualified domain name used to reach the Velum UI from the outside."
               i class='glyphicon glyphicon-info-sign'
 
   .clearfix.text-right.steps-container

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -7,7 +7,7 @@ h1 Initial CaaS Platform Configuration
       h3.panel-title Generic settings
     .panel-body
       .form-group
-        = f.label :dashboard, "Dashboard location"
+        = f.label :dashboard, "Internal Dashboard FQDN/IP"
         .input-group
           = f.text_field :dashboard, value: @dashboard, class: "form-control", required: true
           span class="input-group-addon"


### PR DESCRIPTION
This should be used by Dex to redirect back to Velum, allowing for scenarios
where the admin node's private IP is not accessible to the outside world - e.g.
as is the case on OpenStack and possibly other cloud environments.

Part of bsc#1062291

Depends-On: https://github.com/kubic-project/salt/pull/251
Depends-On: https://github.com/kubic-project/automation/pull/164