### PR TITLE
Wait for orchestration result for marking success on minions

### DIFF
--- a/app/models/salt_handler/minion_highstate.rb
+++ b/app/models/salt_handler/minion_highstate.rb
@@ -29,9 +29,10 @@ class SaltHandler::MinionHighstate
     data = JSON.parse(salt_event.data)
 
     highstate_succeeded = data["success"] && data["retcode"].zero?
-    new_highstate = Minion.highstates[highstate_succeeded ? :applied : :failed]
     # rubocop:disable SkipsModelValidations
-    minion.update_column(:highstate, new_highstate)
+    minion.update_column(:highstate, Minion.highstates[:failed]) unless highstate_succeeded
     # rubocop:enable SkipsModelValidations
+
+    true
   end
 end

--- a/app/models/salt_handler/minion_orchestration.rb
+++ b/app/models/salt_handler/minion_orchestration.rb
@@ -35,10 +35,10 @@ class SaltHandler::MinionOrchestration
     data = JSON.parse salt_event.data
 
     orchestration_succeeded = data["success"] && data["return"]["retcode"].zero?
-    return if orchestration_succeeded
+    new_highstate = Minion.highstates[orchestration_succeeded ? :applied : :failed]
 
     # rubocop:disable SkipsModelValidations
-    Minion.pending.update_all highstate: Minion.highstates[:failed]
+    Minion.pending.update_all highstate: new_highstate
     # rubocop:enable SkipsModelValidations
   end
 end

--- a/spec/models/salt_handler/minion_orchestration_spec.rb
+++ b/spec/models/salt_handler/minion_orchestration_spec.rb
@@ -75,11 +75,11 @@ describe SaltHandler::MinionOrchestration do
 
     describe "with a successful orchestration result" do
       let(:handler) { described_class.new(successful_orchestration_result) }
-      it "does not affect pending minions" do
-        expect { handler.process_event }.not_to change { Minion.pending.count }.from(1)
+      it "does set pending minions to successful" do
+        expect { handler.process_event }.to change { Minion.pending.count }.from(1).to(0)
       end
-      it "does not affect applied minions" do
-        expect { handler.process_event }.not_to change { Minion.applied.count }.from(1)
+      it "does affect applied minions" do
+        expect { handler.process_event }.to change { Minion.applied.count }.from(1).to(2)
       end
     end
 


### PR DESCRIPTION
We are marking success depending on highstates, what makes a bit misleading
for the overall orchestration process. At this moment, orchestration will wait
for some tasks to have been completed (like some `kubectl apply` commands, which
apply immediately). We aren't waiting for the global orchestration result, and
this means that all minions might be marked as successful when we haven't really
waited for the overall orchestration to have finished.

This can have important implications, like not waiting for Dex to be completely
ready while the orchestration is waiting for it.

We just mark failed highstates as an early failure, but wait for the orchestration
result to finish and be succesful in order to mark pending nodes as successful.

This will also align with the current restritions in the UI to enable the `kubectl config`
button, since it will wait for the kubernetes master to be ready in order to be
enabled.

Fixes: bsc#1062542