### PR TITLE
bsc#1062247 add new svg logo

### DIFF
--- a/app/assets/images/logo.svg
+++ b/app/assets/images/logo.svg
@@ -1,42 +1,101 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-     viewBox="0 0 200 80" style="enable-background:new 0 0 200 80;" xml:space="preserve">
-<style type="text/css">
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 300 80"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="logo.svg"
+   width="300"
+   height="80"><metadata
+     id="metadata4254"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs4252"><linearGradient
+       id="linearGradient5776"
+       osb:paint="solid"><stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5778" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5776"
+       id="linearGradient6257"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3.1121469,4.1668161)"
+       x1="5.0540643"
+       y1="39.750511"
+       x2="190.83907"
+       y2="39.750511" /></defs><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1080"
+     id="namedview4250"
+     showgrid="false"
+     inkscape:snap-text-baseline="true"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="179.09317"
+     inkscape:cy="50.705653"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style4224">
     .st0{fill:#FFFFFF;}
-</style>
-<g>
-    <path class="st0" d="M9.8,47.4l1-1.2c2.3,2.1,4.4,3.1,7.4,3.1c3.1,0,5.3-1.8,5.3-4.1v-0.1c0-2.2-1.2-3.5-5.9-4.4c-5-1-7-2.7-7-5.8
-        v-0.1c0-3.1,2.8-5.5,6.7-5.5c3,0,5,0.8,7.1,2.5l-1,1.2c-2-1.7-3.9-2.3-6.2-2.3c-3.1,0-5.1,1.8-5.1,3.9v0.1c0,2.2,1.1,3.5,6.1,4.5
-        C23,40.3,25,42,25,45v0.1c0,3.4-2.9,5.7-6.9,5.7C14.8,50.7,12.2,49.6,9.8,47.4z"/>
-    <path class="st0" d="M29.7,41.8V29.7h1.5v12c0,4.9,2.6,7.7,7,7.7c4.2,0,6.9-2.6,6.9-7.6V29.7h1.5v12c0,6-3.5,9.1-8.5,9.1
-        C33.3,50.8,29.7,47.6,29.7,41.8z"/>
-    <path class="st0" d="M51.3,47.4l1-1.2c2.3,2.1,4.4,3.1,7.4,3.1c3.1,0,5.3-1.8,5.3-4.1v-0.1c0-2.2-1.2-3.5-5.9-4.4c-5-1-7-2.7-7-5.8
-        v-0.1c0-3.1,2.8-5.5,6.7-5.5c3,0,5,0.8,7.1,2.5l-1,1.2c-2-1.7-3.9-2.3-6.2-2.3c-3.1,0-5.1,1.8-5.1,3.9v0.1c0,2.2,1.1,3.5,6.1,4.5
-        c4.8,1,6.8,2.7,6.8,5.7v0.1c0,3.4-2.9,5.7-6.9,5.7C56.3,50.7,53.8,49.6,51.3,47.4z"/>
-    <path class="st0" d="M71.6,29.7h14.8v1.4H73.1v8.2H85v1.4H73.1V49h13.4v1.4H71.6V29.7z"/>
-    <path class="st0" d="M99.4,40.1L99.4,40.1c0-5.9,4.4-10.8,10.4-10.8c3.7,0,5.9,1.4,8.1,3.3l-1.1,1.1c-1.8-1.8-3.9-3.1-7-3.1
-        c-5,0-8.8,4.1-8.8,9.3v0.1c0,5.2,3.8,9.3,8.8,9.3c3,0,5-1.2,7.1-3.2l1,1c-2.2,2.2-4.6,3.6-8.2,3.6C103.8,50.8,99.4,46.1,99.4,40.1z
-        "/>
-    <path class="st0" d="M120.7,46L120.7,46c0-3.2,2.7-5,6.6-5c2.1,0,3.6,0.3,5,0.7v-0.7c0-3.1-1.9-4.6-5-4.6c-1.8,0-3.4,0.5-4.7,1.2
-        l-0.5-1.3c1.7-0.8,3.3-1.3,5.4-1.3c2,0,3.7,0.6,4.8,1.7c1,1,1.5,2.4,1.5,4.3v9.4h-1.4v-2.5c-1,1.5-2.9,2.9-5.8,2.9
-        C123.7,50.8,120.7,49.2,120.7,46z M132.3,44.8V43c-1.3-0.3-3-0.7-5.1-0.7c-3.2,0-5,1.4-5,3.5V46c0,2.2,2.1,3.5,4.4,3.5
-        C129.7,49.4,132.3,47.5,132.3,44.8z"/>
-    <path class="st0" d="M137.7,46L137.7,46c0-3.2,2.7-5,6.6-5c2.1,0,3.6,0.3,5,0.7v-0.7c0-3.1-1.9-4.6-5-4.6c-1.8,0-3.4,0.5-4.7,1.2
-        l-0.5-1.3c1.7-0.8,3.3-1.3,5.4-1.3c2,0,3.7,0.6,4.8,1.7c1,1,1.5,2.4,1.5,4.3v9.4h-1.4v-2.5c-1,1.5-2.9,2.9-5.8,2.9
-        C140.7,50.8,137.7,49.2,137.7,46z M149.4,44.8V43c-1.3-0.3-3-0.7-5.1-0.7c-3.2,0-5,1.4-5,3.5V46c0,2.2,2.1,3.5,4.4,3.5
-        C146.7,49.4,149.4,47.5,149.4,44.8z"/>
-    <path class="st0" d="M155,47.4l1-1.2c2.3,2.1,4.4,3.1,7.4,3.1c3.1,0,5.2-1.8,5.2-4.1v-0.1c0-2.2-1.2-3.5-5.9-4.4c-5-1-7-2.7-7-5.8
-        v-0.1c0-3.1,2.8-5.5,6.7-5.5c3,0,5,0.8,7.1,2.5l-1,1.2c-2-1.7-3.9-2.3-6.2-2.3c-3.1,0-5.1,1.8-5.1,3.9v0.1c0,2.2,1.1,3.5,6.1,4.5
-        c4.8,1,6.8,2.7,6.8,5.7v0.1c0,3.4-2.9,5.7-6.9,5.7C160,50.7,157.4,49.6,155,47.4z"/>
-    <path class="st0" d="M175.3,29.7h7.5c4.6,0,7.7,2.3,7.7,6.3v0.1c0,4.4-3.8,6.6-8.1,6.6h-5.6v7.7h-1.5V29.7z M182.5,41.3
-        c3.9,0,6.5-2,6.5-5.1v-0.1c0-3.3-2.6-5-6.3-5h-5.9v10.2H182.5z"/>
-</g>
-<g>
-    <path class="st0" d="M94.3,47.4c0,1.8-1.4,3.2-3.3,3.2c-1.8,0-3.3-1.4-3.3-3.2c0-1.8,1.5-3.2,3.3-3.2
-        C92.9,44.2,94.3,45.6,94.3,47.4z M88.6,47.4c0,1.4,1,2.5,2.5,2.5c1.4,0,2.4-1.1,2.4-2.5c0-1.4-1-2.6-2.4-2.6
-        C89.6,44.9,88.6,46,88.6,47.4z M90.6,49.1h-0.7v-3.2c0.3-0.1,0.7-0.1,1.2-0.1c0.6,0,0.9,0.1,1.1,0.2c0.2,0.1,0.3,0.4,0.3,0.7
-        c0,0.3-0.3,0.6-0.7,0.7v0c0.3,0.1,0.5,0.3,0.6,0.8c0.1,0.5,0.2,0.7,0.2,0.8h-0.8c-0.1-0.1-0.2-0.4-0.3-0.8
-        c-0.1-0.3-0.3-0.5-0.7-0.5h-0.3V49.1z M90.6,47.3h0.3c0.4,0,0.7-0.1,0.7-0.5c0-0.3-0.2-0.5-0.7-0.5c-0.2,0-0.3,0-0.4,0V47.3z"/>
-</g>
+</style><text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="190.39999"
+     y="41.599998"
+     id="text4287"
+     sodipodi:linespacing="125%"><tspan
+       sodipodi:role="line"
+       id="tspan4289"
+       x="190.39999"
+       y="41.599998" /></text>
+<text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="12.072727"
+     y="39.563637"
+     id="text4291"
+     sodipodi:linespacing="125%"><tspan
+       sodipodi:role="line"
+       id="tspan4293"
+       x="12.072727"
+       y="39.563637" /></text>
+<text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:url(#linearGradient6257);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     x="7.8662109"
+     y="51.257324"
+     id="text4295"
+     sodipodi:linespacing="125%"><tspan
+       sodipodi:role="line"
+       id="tspan4297"
+       x="7.8662109"
+       y="51.257324"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;font-family:Roboto;-inkscape-font-specification:Roboto;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient6257);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0">SUSE<tspan
+   style="font-size:15px;stroke:url(#linearGradient6257)"
+   id="tspan6237">®</tspan> CaaS Platform</tspan></text>
 </svg>

--- a/app/assets/stylesheets/velum_general.scss
+++ b/app/assets/stylesheets/velum_general.scss
@@ -34,11 +34,8 @@ dl.side-by-side {
             margin: 0px 0px;
             padding: 0px;
 
-            h2 {
-                color: #ffffff;
-                font-size: 18px;
-                margin: 0px;
-                padding: 20px 0;
+            img {
+                height: 60px;
             }
         }
     }

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,7 +1,7 @@
 header.row
   .col-xs-12
     .page-header.col-xs-6
-        h2 SUSE&reg; CaaS Platform
+        = image_tag "logo.svg", class: "logo"
     .col-xs-6
       - if user_signed_in?
       = link_to('Logout', destroy_user_session_path, class: "btn btn-logout pull-right", :method => :delete)


### PR DESCRIPTION
with the full name SUSE® CaaS Platform

bsc#1062247

Signed-off-by: Maximilian Meister <mmeister@suse.de>

also the login page and the normal layout header will use the svg

~~there is only still one issue that the navbar in the app and in the login don't share the same css it seems, i have tweaked the image size in the application css but maybe that;'s not the best way to do it. @vitoravelino do you have an idea?~~

updated to `height: 60px` as per @vitoravelino's suggestion

![logologin](https://user-images.githubusercontent.com/5364817/31379322-2ea9a9fc-adae-11e7-831f-1b5da7cbb68c.png)
![logoapp](https://user-images.githubusercontent.com/5364817/31379329-32158174-adae-11e7-88db-27f19f913eb2.png)


