### PR TITLE
bsc#1062728: correctly render redirect_url

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,4 +21,11 @@ class ApplicationController < ActionController::Base
   def setup_done?
     Pillar.exists? pillar: Pillar.all_pillars[:apiserver]
   end
+
+  def accessible_hosts
+    [
+      Pillar.value(pillar: :dashboard),
+      Pillar.value(pillar: :dashboard_external_fqdn)
+    ]
+  end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -13,6 +13,8 @@ class DashboardController < ApplicationController
   skip_before_action :force_ssl_redirect, only: :autoyast
   skip_before_action :authenticate_user!, only: :autoyast
   skip_before_action :redirect_to_setup, only: :autoyast
+  # make sure that access comes from a registered host
+  before_action :host_warning
 
   # The index method is provided through the Discovery concern.
   alias index discovery
@@ -90,5 +92,12 @@ class DashboardController < ApplicationController
 
   def failed_assigned_nodes(assigned)
     assigned.select { |_name, success| !success }.keys.join(", ")
+  end
+
+  def host_warning
+    return true if accessible_hosts.include? request.host
+    flash[:alert] = "You are accessing velum from an unregistered host (#{request.host}). " \
+                    "It is advised to access velum via one of the registered hosts " \
+                    "#{accessible_hosts.join(" or ")}"
   end
 end


### PR DESCRIPTION
a url_for renders a url with from wherever you have requested from

make sure to include the known dashboard url in the redirect_url
otherwise dex will render a Bad Request as it doesn't know the
dns entry

bsc#1062728

Signed-off-by: Maximilian Meister <mmeister@suse.de>