### PR TITLE
[2.0] also compile svg

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,6 +23,9 @@ Rails.application.configure do
   config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
+  # include svg in the precompile
+  config.assets.precompile += %w( '.svg' )
+
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = true
 


### PR DESCRIPTION
the logo has recently changed to svg and needs to be compiled too
otherwise it wont be shown

bsc#1062878

Signed-off-by: Maximilian Meister <mmeister@suse.de>
(cherry picked from commit d871bacd098019cf2522804453af8958d325274b)