### PR TITLE
[2.0] Fixed not being able to accept new nodes on discovery page

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -202,7 +202,7 @@ MinionPoller = {
   renderPendingNodes: function(pendingMinionId, hasPendingStateNode) {
     var acceptHtml;
 
-    if (hasPendingStateNode) {
+    if (hasPendingStateNode && !isSetRolesPage()) {
       acceptHtml = '';
     } else if (hasPendingAcceptance(pendingMinionId)) {
       acceptHtml = 'Acceptance in progress';
@@ -369,6 +369,10 @@ MinionPoller = {
       </tr>";
   }
 };
+
+function isSetRolesPage() {
+  return window.location.pathname === '/setup/discovery';
+}
 
 function hasPendingAcceptance(minionId) {
   return sessionStorage.getItem(minionId) === 'true';

--- a/app/views/dashboard/_pending_nodes.html.slim
+++ b/app/views/dashboard/_pending_nodes.html.slim
@@ -16,7 +16,7 @@
         p.empty-text
           | You currently have no nodes to be accepted for bootstrapping.
         .has-content.hidden
-          p Accepting nodes into the cluster might take a while.
+          p Accepting nodes into the cluster might take a while. Be aware that it's not possible to accept a new node while a node is being bootstrapped.
 
           table.table
             thead

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -67,6 +67,36 @@ feature "Bootstrap cluster feature" do
       expect(page).not_to have_content(minions[3].fqdn)
     end
 
+    scenario "A user set roles, go next, then back and can still accept new nodes", js: true do
+      setup_stubbed_pending_minions!(stubbed: [minions[3].minion_id])
+
+      # select master minion0.k8s.local
+      find(".minion_#{minions[0].id} .master-btn").click
+      # select node minion1.k8s.local
+      find(".minion_#{minions[1].id} .worker-btn").click
+      # select node minion2.k8s.local
+      find(".minion_#{minions[2].id} .worker-btn").click
+
+      expect(page).to have_content(minions[3].minion_id)
+      expect(page).to have_content("Accept Node")
+
+      click_on_when_enabled "#set-roles"
+
+      # means it went to the confirmation page
+      expect(page).to have_content("Confirm bootstrap")
+      click_on "Back"
+
+      # means it went back to discovery page
+      expect(page).to have_content("Select nodes and roles")
+      expect(page).to have_content(minions[0].fqdn)
+      expect(page).to have_content(minions[1].fqdn)
+      expect(page).to have_content(minions[2].fqdn)
+
+      # means it can accept pending node
+      expect(page).to have_content(minions[3].minion_id)
+      expect(page).to have_content("Accept Node")
+    end
+
     scenario "A user selects a subset of nodes to be bootstrapped", js: true do
       # select master minion0.k8s.local
       find(".minion_#{minions[0].id} .master-btn").click


### PR DESCRIPTION
Previously the next step after the discovery page was the cluster
bootstrap. It used to take a while and the user was still able to
accept new nodes while the bootstrap was happening. This behavior was
causing the bootstrap process to crash and we had to prevent the user
from accepting new nodes.

After we changed the behaviour of the setup wizard, user can now go
back and forth through the discovery page and change the nodes roles
for example. Now it's safe for the user to accept pending nodes to be
set for bootstrapping.

This fix only changes the behavior of accepting a new pending node
only on the discovery page. The previous rule of preventing a node
to be accepted is still valid for the dashboard page.

Fixes bsc#1063977

(cherry picked from commit e0535ca842862cb88b8cda2edd1fd95950aab642)

Backport of https://github.com/kubic-project/velum/pull/343