### PR TITLE
spec: make coverage folder public (in development)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /**/*.swp
 /log/*
 /tmp
-/coverage
+/public/coverage
 /public/assets
 /config/config-local.yml
 /bin/pharos

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,10 @@ require "simplecov"
 require "webmock/rspec"
 require "vcr"
 
-SimpleCov.minimum_coverage 100
-SimpleCov.start "rails"
+SimpleCov.start("rails") do
+  minimum_coverage 100
+  coverage_dir "public/coverage"
+end
 
 VCR.configure do |c|
   c.cassette_library_dir = "spec/vcr_cassettes"


### PR DESCRIPTION
this has the big advantage that you can check the results directly
in velum under http(s)://$velum/coverage/index.html

since we switched the official devenv to containers within VM's the
folder is not accessible that easy anymore

Signed-off-by: Maximilian Meister <mmeister@suse.de>