### PR TITLE
[2.0] When roles are set, set `not_applied` if it's a local assignment.

### DIFF
--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -73,9 +73,10 @@ class Minion < ApplicationRecord
   # to salt subsystem if remote is true.
   def assign_role(new_role, remote: false)
     Minion.transaction do
-      # We set highstate to pending since we just assigned a new role
-      success = update_columns role:      Minion.roles[new_role],
-                               highstate: Minion.highstates[:pending]
+      # We set highstate to pending only if we are gonna call salt
+      highstate = remote ? :pending : :not_applied
+      success   = update_columns role:      Minion.roles[new_role],
+                                 highstate: Minion.highstates[highstate]
       if success && remote
         salt.assign_role
       else

--- a/app/views/dashboard/_pending_nodes.html.slim
+++ b/app/views/dashboard/_pending_nodes.html.slim
@@ -16,7 +16,7 @@
         p.empty-text
           | You currently have no nodes to be accepted for bootstrapping.
         .has-content.hidden
-          p Accepting nodes into the cluster might take a while.
+          p Accepting nodes into the cluster might take a while. Be aware that it's not possible to accept a new node while another node is being bootstrapped.
 
           table.table
             thead

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -44,7 +44,7 @@ h1 Select nodes and roles
           thead
             tr
               th
-                | Id
+                | ID
               th
                 | Hostname
               th width="235"

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -67,6 +67,36 @@ feature "Bootstrap cluster feature" do
       expect(page).not_to have_content(minions[3].fqdn)
     end
 
+    scenario "A user set roles, go next, then back and can still accept new nodes", js: true do
+      setup_stubbed_pending_minions!(stubbed: [minions[3].minion_id])
+
+      # select master minion0.k8s.local
+      find(".minion_#{minions[0].id} .master-btn").click
+      # select node minion1.k8s.local
+      find(".minion_#{minions[1].id} .worker-btn").click
+      # select node minion2.k8s.local
+      find(".minion_#{minions[2].id} .worker-btn").click
+
+      expect(page).to have_content(minions[3].minion_id)
+      expect(page).to have_content("Accept Node")
+
+      click_on_when_enabled "#set-roles"
+
+      # means it went to the confirmation page
+      expect(page).to have_content("Confirm bootstrap")
+      click_on "Back"
+
+      # means it went back to discovery page
+      expect(page).to have_content("Select nodes and roles")
+      expect(page).to have_content(minions[0].fqdn)
+      expect(page).to have_content(minions[1].fqdn)
+      expect(page).to have_content(minions[2].fqdn)
+
+      # means it can accept pending node
+      expect(page).to have_content(minions[3].minion_id)
+      expect(page).to have_content("Accept Node")
+    end
+
     scenario "A user selects a subset of nodes to be bootstrapped", js: true do
       # select master minion0.k8s.local
       find(".minion_#{minions[0].id} .master-btn").click

--- a/spec/models/minion_spec.rb
+++ b/spec/models/minion_spec.rb
@@ -194,9 +194,16 @@ describe Minion do
       expect(minion.reload.role).to eq("master")
     end
 
-    it "updates the highstate column to 'pending' in the database" do
+    it "updates the highstate column to 'not_applied' if not remote" do
       minion.update!(highstate: :applied)
       expect { minion.assign_role(:master) }
+        .to change { minion.reload.highstate }.from("applied")
+        .to("not_applied")
+    end
+
+    it "updates the highstate column to 'pending' if remote" do
+      minion.update!(highstate: :applied)
+      expect { minion.assign_role(:master, remote: true) }
         .to change { minion.reload.highstate }.from("applied")
         .to("pending")
     end


### PR DESCRIPTION
If we are setting the role locally only (on the database), set the
minion status to `not_applied`. If we are also setting the remote role
(set on salt too), set the minion status to `pending`.

Since there's no Orchestration model yet, there's no entity to control
this assignments, and Minion model will set one or the other depending
on the `remote` attribute of `assign_role`.

Fixes: bsc#1063977