### PR TITLE
[2.0] When an orchestration result is received, update failed nodes too

### DIFF
--- a/app/models/salt_handler/minion_orchestration.rb
+++ b/app/models/salt_handler/minion_orchestration.rb
@@ -38,7 +38,8 @@ class SaltHandler::MinionOrchestration
     new_highstate = Minion.highstates[orchestration_succeeded ? :applied : :failed]
 
     # rubocop:disable SkipsModelValidations
-    Minion.pending.update_all highstate: new_highstate
+    Minion.where(highstate: [Minion.highstates[:pending], Minion.highstates[:failed]])
+          .update_all(highstate: new_highstate)
     # rubocop:enable SkipsModelValidations
   end
 end


### PR DESCRIPTION
Consider all pending and failed minions when we receive a kubernetes
orchestration result. If later orchestrations succeed they should also
mark failed nodes as succeeded.

Fixes: bsc#1064281

Backport of https://github.com/kubic-project/velum/pull/350