### PR TITLE
alert the user when bootstrap failed

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -247,6 +247,14 @@ MinionPoller = {
     $("#download-kubeconfig").attr("disabled", !enabled);
   },
 
+  alertFailedBootstrap: function(message) {
+    if ($('.alert-message span').is(':empty')) {
+      $('.alert-message span').append(message);
+    }
+    $('#float-alert').removeClass('collapse');
+    $('.alert-info').addClass('alert-danger').removeClass('alert-info');
+  },
+
   renderDashboard: function(minion) {
     var statusHtml;
     var checked;
@@ -265,6 +273,7 @@ MinionPoller = {
         break;
       case "failed":
         statusHtml = '<i class="fa fa-times-circle text-danger fa-2x" aria-hidden="true"></i>';
+        MinionPoller.alertFailedBootstrap('At least one of the nodes is in a failed state. Please run "supportconfig" on the failed node(s) to gather the logs.');
         break;
       case "applied":
         statusHtml = '<i class="fa fa-check-circle-o text-success fa-2x" aria-hidden="true"></i>';


### PR DESCRIPTION
otherwise the user is left without any clue what to do

Signed-off-by: Maximilian Meister <mmeister@suse.de>

@vitoravelino could you please have a look if this makes sense, or if it can be done better?

@kiall @ereslibre would it be easy to get the error(s) of the orchestration to be more specific in the flash message what happened? i believe it might be not that trivial to filter the responsible error and then condense it in a message that fits into a flash message...
