### PR TITLE
Notify user when not able to fetch data from Velum API

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -192,7 +192,10 @@ MinionPoller = {
 
         handleBootstrapErrors();
         toggleMinimumNodesAlert();
+        $('.connection-failed-alert').fadeOut(100);
       }
+    }).fail(function() {
+      $('.connection-failed-alert').fadeIn(100);
     }).always(function() {
       // make another request only after the last one finished
       MinionPoller.pollingTimeoutId = setTimeout(MinionPoller.request, 5000);

--- a/app/assets/stylesheets/authentication.scss
+++ b/app/assets/stylesheets/authentication.scss
@@ -7,6 +7,8 @@
 @import 'authentication_variables.scss';
 @import 'bootstrap';
 
+@import 'components/**/*';
+
 
 html {
   min-height: 100%;
@@ -138,7 +140,7 @@ html {
 
       .footer-links {
         margin-top: 35px;
-      
+
         & a {
           color: #ccc;
           font-size: 13px;
@@ -148,7 +150,7 @@ html {
           &:hover {
             color: $suse-brand-green;
           }
-          
+
         }
 
       }

--- a/app/assets/stylesheets/components/notifications.scss
+++ b/app/assets/stylesheets/components/notifications.scss
@@ -1,0 +1,21 @@
+.alert-danger a,
+.alert-info a,
+.alert-success a {
+  font-weight: bold;
+}
+
+.alert-danger a {
+  color: $state-danger-text;
+}
+
+.alert-info a {
+  color: $state-danger-text;
+}
+
+.alert-success a {
+  color: $state-danger-text;
+}
+
+.connection-failed-alert {
+  display: none;
+}

--- a/app/views/shared/_notification.html.slim
+++ b/app/views/shared/_notification.html.slim
@@ -1,4 +1,4 @@
-div [id="#{float == true ? 'float' : 'fixed'}-alert" class="#{messages && messages.first ? '' : 'collapse'}"]
+div [id="#{float == true ? 'float' : 'fixed'}-alert" class="#{klass} #{messages && messages.first ? '' : 'collapse'}"]
   .alert.alert-dismissible.fade.in.text-left[class="alert-#{alert == 'alert' ? 'danger' : 'info'} #{float == true ? 'float-alert' : ''}"]
     button.close class="alert-hide" type="button" data-dismiss="alert"
       span aria-hidden="true" &times;

--- a/app/views/shared/_notifications.html.slim
+++ b/app/views/shared/_notifications.html.slim
@@ -1,7 +1,7 @@
 - flash.each do |key, value|
   - if key == 'notice' || key == 'alert'
     = render template: 'shared/_notification.html.slim',
-        locals: { messages: value, alert: key, float: flash[:float] }
+        locals: { messages: value, alert: key, float: flash[:float], klass: "" }
 
 = render template: 'shared/_notification.html.slim',
-    locals: { messages: nil, alert: 'info', float: true }
+    locals: { messages: "Could not connect with Velum API. Please, try #{link_to "reloading the session", root_path}.".html_safe, alert: "alert", klass: "connection-failed-alert", float: false }


### PR DESCRIPTION
We are regenerating Velum's certificate by adding the external
dashboard fqdn/ip to the Velum certificate. For this certificate
to be reloaded we are currently doing a `docker restart` on Velum
while the orchestration is being executed.

This has a bad effect on the user session as he/she is waiting
for the polling to finish. Without them noticing, the polling will
start failing as the certificate changed under them, and they need
to accept it, but ajax requests will just fail because of this.

With this patch we are notifying the user that the browser cannot
connect with Velum API and suggests he/she to try to reload the session.

Fixes bsc#1064641

<img width="1200" alt="screenshot 2017-10-23 10 12 17" src="https://user-images.githubusercontent.com/188554/31888402-ae7ab6ae-b7da-11e7-8822-1e5f9fa5f909.png">
