### PR TITLE
Improved failure alert message

### DIFF
--- a/app/views/shared/_notifications.html.slim
+++ b/app/views/shared/_notifications.html.slim
@@ -4,4 +4,4 @@
         locals: { messages: value, alert: key, float: flash[:float], klass: "" }
 
 = render template: 'shared/_notification.html.slim',
-    locals: { messages: "Could not connect with Velum API. Please, try #{link_to "reloading the session", root_path}.".html_safe, alert: "alert", klass: "connection-failed-alert", float: false }
+    locals: { messages: "Could not connect with Velum API. If you're bootstrapping for the first time, this is expected due to an update of our certificate. Please, try #{link_to "reloading the session", root_path}.".html_safe, alert: "alert", klass: "connection-failed-alert", float: false }


### PR DESCRIPTION
This is an attempt to make the experience better. We thought that
the previous message was too aggressive. Since this message will
always be shown for 2.0 at least, we want to tranquilize the user
that it's an expected behavior.