### PR TITLE
Add kubeconfig tips on the download page

### DIFF
--- a/app/views/oidc/done.html.slim
+++ b/app/views/oidc/done.html.slim
@@ -1,4 +1,18 @@
 h1 Download your kubeconfig file
 
+p
+  | You will see a download dialog that will allow you to download your kubeconfig file. Please,
+  |  accept it and save it in a known location.
+
+p
+  | You can refer to it using kubectl by setting the <strong>KUBECONFIG</strong> environment variable,
+  |  like <strong>KUBECONFIG=~/Downloads/kubeconfig kubectl get nodes</strong>.
+
+p
+  | You can also save it to your home in `~/.kube/config`, `kubectl` will automatically read this
+  |  file without the need to specify the <strong>KUBECONFIG</strong> environment variable.
+
+p= link_to "You can navigate to the dashboard now, once you have downloaded your kubeconfig file", root_path
+
 javascript:
   window.location.href = "#{@redirect_target}"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,7 +1,7 @@
 header.row
   .col-xs-12
     .page-header.col-xs-6
-        = image_tag "logo.svg", class: "logo"
+        = link_to image_tag("logo.svg", class: "logo"), root_path
     .col-xs-6
       - if user_signed_in?
       = link_to('Logout', destroy_user_session_path, class: "btn btn-logout pull-right", :method => :delete)


### PR DESCRIPTION
Also, add a link to the `root_path` on the icon of CaaS Platform.

Fixes: bsc#1062728