### PR TITLE
Add `velum:migrate_users` task that will migrate database-backed users into LDAP-backed users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,6 @@ class User < ApplicationRecord
     # 2) make sure the Administrators groupOfUniqueNames exists, if not, create it
     # 3) check if the new user created is a member of the Administrators group, if not, add it
     # 4) check if the user exists, if not, add it
-    return unless new_record?
 
     # check to see if this is because the LDAP auth succeeded, or if we're coming from registration
     # we do this by performing an LDAP search for the new user. If it fails, we need to create the
@@ -139,7 +138,7 @@ class User < ApplicationRecord
       cn:           "A User",
       objectclass:  ["person", "inetOrgPerson"],
       uid:          uid,
-      userPassword: password,
+      userPassword: (password.blank? ? "{CRYPT}#{encrypted_password}" : password),
       givenName:    "A",
       sn:           "User",
       mail:         email

--- a/lib/tasks/velum.rake
+++ b/lib/tasks/velum.rake
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/BlockLength
 namespace :velum do
   desc "Create a user"
   task :create_user, [:email, :password] => :environment do |_, args|
@@ -20,4 +21,17 @@ namespace :velum do
       puts "User #{args["email"]} could not be created. Does it already exist?"
     end
   end
+
+  desc "Migrate database users to LDAP"
+  task migrate_users: :environment do
+    User.where.not(encrypted_password: [nil, ""]).each do |user|
+      begin
+        user.send :create_ldap_user
+        puts "#{user.email} has been binded to LDAP (or is already bound)"
+      rescue StandardError => e
+        puts "Could not bind #{user.email} to LDAP. Reason: #{e}"
+      end
+    end
+  end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
In 1.0 user login information was stored in the database whereas in 2.0
this information resides in LDAP.

Fixes: bsc#1065450