### PR TITLE
Enforce the velum_test db to be used when needed

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -13,4 +13,4 @@ default: &default
 
 <%= Rails.env.downcase %>:
   <<: *default
-  database: <%= ENV['VELUM_DB_NAME'] || "velum_#{Rails.env.downcase}" %>
+  database: <%= Rails.env.downcase == 'test' ? 'velum_test' : (ENV['VELUM_DB_NAME'] || "velum_#{Rails.env.downcase}") %>


### PR DESCRIPTION
Ensure the velum_test database is being used when running rspec tests inside of a live container.

This is required by PR: https://github.com/kubic-project/automation/pull/180