### PR TITLE
Remove `VELUM_DB_NAME` envvar

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -13,4 +13,4 @@ default: &default
 
 <%= Rails.env.downcase %>:
   <<: *default
-  database: <%= ENV['VELUM_DB_NAME'] || "velum_#{Rails.env.downcase}" %>
+  database: <%= "velum_#{Rails.env.downcase}" %>


### PR DESCRIPTION
This will be set by the default Rails environment as usual.

Depends on: https://github.com/kubic-project/automation/pull/184
Supersedes: https://github.com/kubic-project/velum/pull/372