### PR TITLE
ux: changed color of pending status icon

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -267,7 +267,7 @@ MinionPoller = {
       case "pending":
         statusHtml = '\
           <span class="fa-stack" aria-hidden="true">\
-            <i class="fa fa-circle fa-stack-2x text-success" aria-hidden="true"></i>\
+            <i class="fa fa-circle fa-stack-2x text-muted" aria-hidden="true"></i>\
             <i class="fa fa-refresh fa-stack-1x fa-spin fa-inverse" aria-hidden="true"></i>\
           </span>';
         break;


### PR DESCRIPTION
Changed from green to gray. The reason behind this is that green
is usually associated with a success operation and gray is a
more neutral color that doesn't add much meaning.

This change was a quick suggestion from Cynthia when I showed her Velum. 

### before

<img width="77" alt="screenshot 2017-11-03 16 21 13" src="https://user-images.githubusercontent.com/188554/32391157-338a2c0e-c0b8-11e7-9ca0-4011016c170e.png">

### after

<img width="96" alt="screenshot 2017-11-03 16 19 41" src="https://user-images.githubusercontent.com/188554/32391156-3367ea40-c0b8-11e7-9fc9-b8cffe912547.png">
