### PR TITLE
When we are back in Velum from Dex, allow for assets to be loaded

### DIFF
--- a/app/views/oidc/done.html.slim
+++ b/app/views/oidc/done.html.slim
@@ -14,5 +14,8 @@ p
 
 p= link_to "You can navigate to the dashboard now, once you have downloaded your kubeconfig file", root_path
 
-javascript:
-  window.location.href = "#{@redirect_target}"
+= content_for :page_javascript do
+  javascript:
+    $(function() {
+      window.location.href = "#{@redirect_target}"
+    });


### PR DESCRIPTION
If we forced the location directly, javascript assets were never loaded
as their loading are interrupted by the browser because of the `href` change.

This ensures we first load all the assets (so delete, put, patch links work
through jquery as usual), and then we force the redirection to happen.

Fixes: bsc#1066611

Backport of https://github.com/kubic-project/velum/pull/379