### PR TITLE
js: fixed alert color being overridden

### DIFF
--- a/app/assets/javascripts/alert.js
+++ b/app/assets/javascripts/alert.js
@@ -1,0 +1,31 @@
+function showAlert(message, type, klass) {
+  var $container = $('.alerts-container');
+
+  klass = klass || '';
+  icon = type === 'alert' ? 'fa-exclamation-circle' : 'fa-info-circle';
+  type = type === 'alert' ? 'danger' : 'info';
+
+  var dom = createAlertDOM(message, type, icon, klass);
+  var $alert = $(dom);
+
+  $container.append($alert);
+  $alert.fadeIn(100);
+
+  return $alert;
+}
+
+function createAlertDOM(text, type, icon, klass) {
+  return '\
+    <div class="alert alert-dismissible fade in text-left ' + klass + ' alert-' + type + '" style="display: none">\
+      <button class="close alert-hide" data-dismiss="alert" type="button">\
+        <span aria-hidden="true">×</span>\
+        <span class="sr-only">Close</span>\
+      </button>\
+      <div class="alert-message">\
+        <div class="alert-icon pull-left"> \
+          <i class="fa fa-3x pull-left icon ' + icon + '"></i> \
+        </div>\
+        <span class="text">' + text + '</span> \
+      </div>\
+    </div>';
+}

--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -247,12 +247,10 @@ MinionPoller = {
     $("#download-kubeconfig").attr("disabled", !enabled);
   },
 
-  alertFailedBootstrap: function(message) {
-    if ($('.alert-message span').is(':empty')) {
-      $('.alert-message span').append(message);
+  alertFailedBootstrap: function() {
+    if (!$('.failed-bootstrap-alert').length) {
+      showAlert('At least one of the nodes is in a failed state. Please run "supportconfig" on the failed node(s) to gather the logs.', 'alert', 'failed-bootstrap-alert');
     }
-    $('#float-alert').removeClass('collapse');
-    $('.alert-info').addClass('alert-danger').removeClass('alert-info');
   },
 
   renderDashboard: function(minion) {
@@ -273,7 +271,7 @@ MinionPoller = {
         break;
       case "failed":
         statusHtml = '<i class="fa fa-times-circle text-danger fa-2x" aria-hidden="true"></i>';
-        MinionPoller.alertFailedBootstrap('At least one of the nodes is in a failed state. Please run "supportconfig" on the failed node(s) to gather the logs.');
+        MinionPoller.alertFailedBootstrap();
         break;
       case "applied":
         statusHtml = '<i class="fa fa-check-circle-o text-success fa-2x" aria-hidden="true"></i>';

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -16,7 +16,7 @@ html(lang='en')
     .container
       = render :partial => "shared/header"
       .row
-        .col-xs-12
+        .col-xs-12.alerts-container
           = render :partial => "shared/notifications"
       .row
         .col-xs-12

--- a/app/views/shared/_notification.html.slim
+++ b/app/views/shared/_notification.html.slim
@@ -1,19 +1,18 @@
-div [id="#{float == true ? 'float' : 'fixed'}-alert" class="#{klass} #{messages && messages.first ? '' : 'collapse'}"]
-  .alert.alert-dismissible.fade.in.text-left[class="alert-#{alert == 'alert' ? 'danger' : 'info'} #{float == true ? 'float-alert' : ''}"]
-    button.close class="alert-hide" type="button" data-dismiss="alert"
-      span aria-hidden="true" &times;
-      span.sr-only Close
-    .alert-message
-      .alert-icon.pull-left
-        i.fa.fa-3x.pull-left class=(alert == 'alert' ? 'fa-exclamation-circle' : 'fa-info-circle')
-      span
-        - if messages.is_a?(String)
-          = messages
-        - elsif messages.is_a?(Array)
-          - if messages.size == 1
-            = messages[0]
-          - else
-            ul
-              - messages.each do |c|
-                li
-                  = c
+.alert.alert-dismissible.fade.in.text-left[class="#{klass} alert-#{alert == 'alert' ? 'danger' : 'info'}"]
+  button.close class="alert-hide" type="button" data-dismiss="alert"
+    span aria-hidden="true" &times;
+    span.sr-only Close
+  .alert-message
+    .alert-icon.pull-left
+      i.fa.fa-3x.pull-left class=(alert == 'alert' ? 'fa-exclamation-circle' : 'fa-info-circle')
+    span
+      - if messages.is_a?(String)
+        = messages
+      - elsif messages.is_a?(Array)
+        - if messages.size == 1
+          = messages[0]
+        - else
+          ul
+            - messages.each do |c|
+              li
+                = c

--- a/app/views/shared/_notifications.html.slim
+++ b/app/views/shared/_notifications.html.slim
@@ -1,7 +1,7 @@
 - flash.each do |key, value|
   - if key == 'notice' || key == 'alert'
     = render template: 'shared/_notification.html.slim',
-        locals: { messages: value, alert: key, float: flash[:float], klass: "" }
+        locals: { messages: value, alert: key, klass: "" }
 
 = render template: 'shared/_notification.html.slim',
-    locals: { messages: "Could not connect with Velum API. If you're bootstrapping for the first time, this is expected due to an update of our certificate. Please, try #{link_to "reloading the session", root_path}.".html_safe, alert: "alert", klass: "connection-failed-alert", float: false }
+    locals: { messages: "Could not connect with Velum API. If you're bootstrapping for the first time, this is expected due to an update of our certificate. Please, try #{link_to "reloading the session", root_path}.".html_safe, alert: "alert", klass: "connection-failed-alert" }


### PR DESCRIPTION
The alert notifying the user that the bootstrap has failed was
overriding the type of any previous alert that were on the page.
This was causing some confusing to some users.

Now it creates an alert everytime we check if there's a failed
bootstrapped node without interfering other alerts.

Also removed unnecessary stuff from the notification partial.

Fixes bsc#1069258