### PR TITLE
downgrade rake again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
-    rake (12.3.0)
+    rake (12.0.0)
     recursive-open-struct (1.0.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)


### PR DESCRIPTION
it must have accidentally be gotten updated via #390

rubocops Gemfile suggests gem 'rake', '~> 12.0' at this
point in time so we can safely stick to 12.0.0

https://github.com/bbatsov/rubocop/blob/082408/Gemfile#L9

Signed-off-by: Maximilian Meister <mmeister@suse.de>