### PR TITLE
Remove dev vs prod kubeconfig download difference

### DIFF
--- a/app/controllers/oidc_controller.rb
+++ b/app/controllers/oidc_controller.rb
@@ -87,14 +87,7 @@ class OidcController < ApplicationController
 
     lookup_config
 
-    # TODO: phantomjs does not download files (https://github.com/ariya/phantomjs/issues/10052), so
-    #       we only set the content-disposition as attachment in production.
-    #
-    # :nocov:
-    if Rails.env.production?
-      response.headers["Content-Disposition"] = "attachment; filename=kubeconfig"
-    end
-    # :nocov:
+    response.headers["Content-Disposition"] = "attachment; filename=kubeconfig"
 
     render "kubeconfig.erb", layout: false, content_type: "text/yaml"
   end


### PR DESCRIPTION
This was needed to workaround capybara + poltergeist being unable to download
files, this workarond is now down in the velum-interactions tooling, rather than
in a shiped part of the codebase.

Depends-On: https://github.com/kubic-project/automation/pull/198