### PR TITLE
Reject `nil` values on the Velum pillar.

### DIFF
--- a/app/controllers/internal_api/v1/pillars_controller.rb
+++ b/app/controllers/internal_api/v1/pillars_controller.rb
@@ -8,7 +8,9 @@ class InternalApi::V1::PillarsController < InternalApiController
 
   def pillar_contents
     pillar_struct = {}.tap do |h|
-      Pillar.all_pillars.collect { |k, v| h[v] = Pillar.value(pillar: k.to_sym) }
+      Pillar.all_pillars.each do |k, v|
+        h[v] = Pillar.value(pillar: k.to_sym) unless Pillar.value(pillar: k.to_sym).nil?
+      end
     end
     {}.tap do |json_response|
       pillar_struct.each do |key, value|

--- a/spec/controllers/internal_api/v1/pillars_controller_spec.rb
+++ b/spec/controllers/internal_api/v1/pillars_controller_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
   end
 
   describe "GET /pillar" do
+    before do
+      Pillar.create pillar: "dashboard", value: "dashboard.example.com"
+    end
+
     it "retrieves the pillar contents" do
       get :show
       expect(response.status).to eq 200


### PR DESCRIPTION
This gives a chance for default salt pillars to be used.