### PR TITLE
Do not require `retcode` to be 0 to detect success.

### DIFF
--- a/app/models/salt_handler/minion_highstate.rb
+++ b/app/models/salt_handler/minion_highstate.rb
@@ -26,7 +26,7 @@ class SaltHandler::MinionHighstate
 
     data = JSON.parse(salt_event.data)
 
-    highstate_succeeded = data["success"] && data["retcode"].zero?
+    highstate_succeeded = data["success"]
     # rubocop:disable SkipsModelValidations
     minion.update_column(:highstate, Minion.highstates[:failed]) unless highstate_succeeded
     # rubocop:enable SkipsModelValidations

--- a/app/models/salt_handler/orchestration_result.rb
+++ b/app/models/salt_handler/orchestration_result.rb
@@ -11,7 +11,7 @@ class SaltHandler::OrchestrationResult < SaltHandler::Orchestration
   def process_event
     event_data = JSON.parse @salt_event.data
 
-    orchestration_succeeded = event_data["success"] && event_data["return"]["retcode"].zero?
+    orchestration_succeeded = event_data["success"]
 
     update_orchestration orchestration_succeeded: orchestration_succeeded, event_data: event_data
     update_minions orchestration_succeeded: orchestration_succeeded

--- a/spec/models/salt_handler/orchestration_result_spec.rb
+++ b/spec/models/salt_handler/orchestration_result_spec.rb
@@ -85,12 +85,12 @@ describe SaltHandler::OrchestrationResult do
     describe "with a mid-successful orchestration result" do
       let(:handler) { described_class.new(mid_successful_orchestration_result) }
 
-      it "marks pending minions as failed" do
+      it "marks pending minions as applied" do
         expect { handler.process_event }.to change { pending_minion.reload.highstate }
-          .from("pending").to("failed")
+          .from("pending").to("applied")
       end
-      it "does not affect applied minions" do
-        expect { handler.process_event }.not_to change { Minion.applied.count }.from(1)
+      it "does affect applied minions" do
+        expect { handler.process_event }.to change { Minion.applied.count }.from(1).to(2)
       end
     end
 


### PR DESCRIPTION
When detecting highstate success as well as orchestration success we
are checking the result success status and also checking that the
global `retcode` is 0. This latest check is not strictly necessary and
under certain conditions it is not desirable.