### PR TITLE
Reuse filter logic for known hosts.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,10 @@ class ApplicationController < ActionController::Base
     [
       Pillar.value(pillar: :dashboard),
       Pillar.value(pillar: :dashboard_external_fqdn)
-    ]
+    ].uniq
+  end
+
+  def known_host?
+    accessible_hosts.include? request.host
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -14,7 +14,7 @@ class DashboardController < ApplicationController
   skip_before_action :authenticate_user!, only: :autoyast
   skip_before_action :redirect_to_setup, only: :autoyast
   # make sure that access comes from a registered host
-  before_action :host_warning
+  before_action :host_warning, unless: :known_host?
 
   # The index method is provided through the Discovery concern.
   alias index discovery
@@ -95,7 +95,6 @@ class DashboardController < ApplicationController
   end
 
   def host_warning
-    return true if accessible_hosts.include? request.host
     flash[:alert] = "You are accessing velum from an unregistered host (#{request.host}). " \
                     "It is advised to access velum via one of the registered hosts " \
                     "#{accessible_hosts.join(" or ")}"

--- a/app/controllers/oidc_controller.rb
+++ b/app/controllers/oidc_controller.rb
@@ -17,7 +17,7 @@ class OidcController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   # make sure that the request comes from a registered host
-  before_action :verify_host
+  before_action :verify_host, unless: :known_host?
 
   def new_nonce
     session[:nonce] = SecureRandom.hex(16)
@@ -140,7 +140,6 @@ class OidcController < ApplicationController
   end
 
   def verify_host
-    return true if accessible_hosts.include? request.host
     sign_out(current_user)
     redirect_to root_path,
                 alert: "You have been logged out as #{request.host} " \


### PR DESCRIPTION
Also, do not repeat the allowed hosts if they match.

Fixes: bsc#1071500

Backport of https://github.com/kubic-project/velum/pull/354