### PR TITLE
AutoYaST: disable creation of swap [bsc#1043813]

### DIFF
--- a/app/views/dashboard/autoyast.xml.erb
+++ b/app/views/dashboard/autoyast.xml.erb
@@ -103,10 +103,6 @@
           <size>30gb</size>
         </partition>
         <partition>
-          <mount>swap</mount>
-          <size>auto</size>
-        </partition>
-        <partition>
           <filesystem config:type="symbol">btrfs</filesystem>
           <mount>/var/lib/docker</mount>
           <size>max</size>


### PR DESCRIPTION
Disables the creation of the swap partition on the nodes provisioned by AutoYaST.

This fixes bsc#1075001.

This is a simple rebase of PR https://github.com/kubic-project/velum/pull/194. I tested it and it works fine.