### PR TITLE
packaging: enhancements

### DIFF
--- a/packaging/suse/patches/0_change_versions.gem.patch
+++ b/packaging/suse/patches/0_change_versions.gem.patch
@@ -1,5 +1,5 @@
 diff --git a/Gemfile.lock b/Gemfile.lock
-index 7b0e396..4eca8ad 100644
+index 6becbab..a54b2cf 100644
 --- a/Gemfile.lock
 +++ b/Gemfile.lock
 @@ -121,7 +121,7 @@ GEM

--- a/packaging/suse/patches/1_set_default_salt_events_alter_time_column_value.rpm.patch
+++ b/packaging/suse/patches/1_set_default_salt_events_alter_time_column_value.rpm.patch
@@ -1,8 +1,8 @@
 diff --git a/db/schema.rb b/db/schema.rb
-index 0a2cdca..f41cbbe 100644
+index a86a539..d571993 100644
 --- a/db/schema.rb
 +++ b/db/schema.rb
-@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 20171117145421) do
+@@ -82,7 +82,7 @@ ActiveRecord::Schema.define(version: 20180110112210) do
    create_table "salt_events", force: :cascade do |t|
      t.string   "tag",          limit: 255,      null: false
      t.text     "data",         limit: 16777215, null: false
@@ -11,7 +11,7 @@ index 0a2cdca..f41cbbe 100644
      t.string   "master_id",    limit: 255,      null: false
      t.datetime "taken_at"
      t.datetime "processed_at"
-@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 20171117145421) do
+@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 20180110112210) do
      t.string   "id",         limit: 255,      null: false
      t.string   "success",    limit: 10,       null: false
      t.text     "full_ret",   limit: 16777215, null: false

--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -20,7 +20,7 @@ Name:           velum
 # When you release a new version, set Version and branch accordingly.
 # For example:
 # Version:      1.0.0
-# %define branch 1.0.0
+# %%define branch 1.0.0
 
 Version:        __VERSION__
 %define branch __BRANCH__
@@ -78,6 +78,8 @@ export IGNORE_ASSETS=yes
 
 # run bundle list to redo the Gemfile.lock
 bundle list
+# FIXME: once we are based on factory, which contains the new bundler, use bundle lock instead of list
+#bundle lock --local
 
 # deploy gems
 bundle install --retry=3 --local --deployment
@@ -90,26 +92,14 @@ rm -rf vendor/cache
 %install
 install -d %{buildroot}/%{velumdir}
 
-cp -av . %{buildroot}/%{velumdir}
+cp -a . %{buildroot}/%{velumdir}
 
 rm -rf %{buildroot}/%{velumdir}/log
 mkdir %{buildroot}/%{velumdir}/log
 rm -rf %{buildroot}/%{velumdir}/tmp
 mkdir %{buildroot}/%{velumdir}/tmp
 
-# remove any .orig files that might have been created by a successful patch with an offset
-# unfortunately there is no option to patch that prevents that
-rm -rf %{buildroot}/%{velumdir}/Gemfile.lock.orig
-
-%fdupes %{buildroot}/%{velumdir}
-
-%pre
-
-%post
-
-%preun
-
-%postun
+%fdupes -s %{buildroot}/%{velumdir}
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
* drop removal of .orig files
  we should keep patches rebased instead
* rebase patches
* drop empty scriptlets
  this was feedback from factory submission
* reduce verbosity
  this massively reduces the build log