### PR TITLE
Add migration to change the pillar value column to text

### DIFF
--- a/db/migrate/20180118103201_change_pillar_value_to_text.rb
+++ b/db/migrate/20180118103201_change_pillar_value_to_text.rb
@@ -1,0 +1,8 @@
+class ChangePillarValueToText < ActiveRecord::Migration
+  def up
+    change_column :pillars, :value, :text
+  end
+  def down
+    change_column :pillars, :value, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180110112210) do
+ActiveRecord::Schema.define(version: 20180118103201) do
 
   create_table "certificate_services", force: :cascade do |t|
     t.integer  "certificate_id", limit: 4
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 20180110112210) do
   create_table "pillars", force: :cascade do |t|
     t.string   "minion_id",  limit: 255
     t.string   "pillar",     limit: 255
-    t.string   "value",      limit: 255
+    t.text     "value",      limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
This migration changes the pillar `value` column from `string` to `text` so we keep in sync with the 2.0 branch where we need this column to allow bigger contents (to store certificates, for example).