### PR TITLE
re-add the patch to relax a gem requirement

### DIFF
--- a/packaging/suse/patches/1_change_versions.gem.patch
+++ b/packaging/suse/patches/1_change_versions.gem.patch
@@ -1,0 +1,22 @@
+diff --git a/Gemfile.lock b/Gemfile.lock
+index c9ed757..ddd7671 100644
+--- a/Gemfile.lock
++++ b/Gemfile.lock
+@@ -122,7 +122,7 @@ GEM
+       addressable (>= 2.4)
+     kubeclient (2.4.0)
+       http (= 0.9.8)
+-      recursive-open-struct (= 1.0.0)
++      recursive-open-struct (~> 1.0.2)
+       rest-client
+     loofah (2.1.1)
+       crass (~> 1.0.2)
+@@ -210,7 +210,7 @@ GEM
+     rb-fsevent (0.10.2)
+     rb-inotify (0.9.10)
+       ffi (>= 0.5.0, < 2)
+-    recursive-open-struct (1.0.0)
++    recursive-open-struct (1.0.2)
+     responders (2.4.0)
+       actionpack (>= 4.2.0, < 5.3)
+       railties (>= 4.2.0, < 5.3)


### PR DESCRIPTION
rubygem-kubeclient upstream meanwhile updated their requirements
as well

Signed-off-by: Maximilian Meister <mmeister@suse.de>