### PR TITLE
drop workaround for old bundler versions

### DIFF
--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -82,11 +82,7 @@ done
 export IGNORE_ASSETS=yes
 
 # redo the Gemfile.lock
-%if 0%{?suse_version} > 1500
 bundle lock --local
-%else
-bundle list
-%endif
 
 # deploy gems
 bundle install --retry=3 --local --deployment


### PR DESCRIPTION
in caasp we are using the new bundler as well now

Signed-off-by: Maximilian Meister <mmeister@suse.de>