### PR TITLE
Add fallback link to fetch kubeconfig if redirect fails

### DIFF
--- a/app/views/oidc/done.html.slim
+++ b/app/views/oidc/done.html.slim
@@ -4,6 +4,8 @@ p
   | You will see a download dialog that will allow you to download your kubeconfig file. Please,
   |  accept it and save it in a known location.
 
+p= link_to "Click here if that did not happen.", @redirect_target
+
 p
   | You can refer to it using kubectl by setting the <strong>KUBECONFIG</strong> environment variable,
   |  like <strong>KUBECONFIG=~/Downloads/kubeconfig kubectl get nodes</strong>.


### PR DESCRIPTION
This allows a user to proceed, even if the JS redirect does not execute.