### PR TITLE
skip bundler during spec file creation

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -78,7 +78,7 @@ pushd build/$packagename-$safe_branch/
     diff Gemfile.lock Gemfile.lock.orig
     exit -1
   fi
-  extracted_requires=$(ruby -rbundler -e 'Bundler.definition.specs_for([:default, :production]).any? { |s| puts "BuildRequires:  %{rubygem #{s.name} = #{s.version}}" }')
+  extracted_requires=$(ruby -rbundler -e 'Bundler.definition.specs_for([:default, :production]).any? { |s| puts "BuildRequires:  %{rubygem #{s.name} = #{s.version}}" unless s.name == "bundler" }')
   echo "get requirements from Gemfile.lock"
   IFS=$'\n' # do not split on spaces
   build_requires=""


### PR DESCRIPTION
a bundler BuildRequire is already hardcoded

other than that it prevents a false strict dependency on bundler, e.g.
if i run make_spec.sh on openSUSE 42.1 it will render bundler 1.10.6
whatever is installed on the system. this happened in our concourse
build container that uses 42.1 as a base system

Signed-off-by: Maximilian Meister <mmeister@suse.de>

Follow up of https://github.com/kubic-project/velum/pull/428