### PR TITLE
Install `bundler` after `bundle clean`.

### DIFF
--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -72,9 +72,6 @@ __PATCHEXECS__
 install -d vendor/cache
 cp %{_libdir}/ruby/gems/%{rb_ver}/cache/*.gem vendor/cache
 
-# install bundler
-gem install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
-
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 
 # deploy gems
@@ -92,6 +89,9 @@ bundle install --retry=3 --local --deployment --without development test assets
 
 # clean unused gems
 bundle clean
+
+# install bundler
+gem install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
 
 rm -rf vendor/cache
 


### PR DESCRIPTION
`bundle clean` also removes stale executables under `bin`. It is fine that
bundler thinks that `bundler` executable is stale, but it's not, we are just
installing it as a separate gem, so do that at the end of the spec, after
we have executed `bundle clean`.