### PR TITLE
Reduce salt-api timeout from 60 sec, to 30 sec

### DIFF
--- a/lib/velum/salt_api.rb
+++ b/lib/velum/salt_api.rb
@@ -77,7 +77,14 @@ module Velum
           req.body = data.to_json if data.present?
         end
 
-        opts = { use_ssl: true, ca_file: "/etc/pki/ca.crt", ssl_version: :TLSv1, open_timeout: 2 }
+        opts = {
+          use_ssl:      true,
+          ca_file:      "/etc/pki/ca.crt",
+          ssl_version:  :TLSv1,
+          open_timeout: 2,
+          read_timeout: 30
+        }
+
         Net::HTTP.start(uri.hostname, uri.port, opts) { |http| http.request(req) }
       rescue *HTTPExceptions::EXCEPTIONS => e
         raise SaltConnectionException, e


### PR DESCRIPTION
HAProxy has a 50 sec timeout, meaning HAProxy will kill the connection before Velum times out waiting for salt-api when there are issues.