### PR TITLE
disable codeclimate check that rubocop already does

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,3 +2,7 @@
 engines:
   rubocop:
     enabled: false
+checks:
+  # disable checks already done by rubocop
+  method-complexity:
+    enabled: false


### PR DESCRIPTION
this is one example of overlapping checks that are performed
by rubocop and therefore can be disabled, otherwise it shows
up on the github status always

Signed-off-by: Maximilian Meister <mmeister@suse.de>