### PR TITLE
Be consistent and rename `upgrade` to `update`.

### DIFF
--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -55,7 +55,7 @@ h1 Cluster Status
 
       = link_to orchestrations_upgrade_path, method: :post, id: "retry-cluster-upgrade", class: "hidden btn btn-sm btn-primary pull-right" do
         i.fa.fa-refresh.fa-fw
-        | Retry cluster upgrade
+        | Retry cluster update
 
     .panel-body
       .row.nodes-loading


### PR DESCRIPTION
I didn't refactor down the line because ultimately we cannot have an
enum with a :update status (rails will complain, so at least the enum
on the Orchestration model would need to be called :upgrade).

For that reason, keep everything as it is (call internally `upgrade`,
but just show "Retry cluster update" on the button label).