### PR TITLE
Fix db/seeds creation of SUSE registry URL record

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ def seed_development
 end
 
 def seed_production
-  Registry.where(name: "SUSE").find_or_initialize.tap do |r|
+  Registry.where(name: "SUSE").first_or_initialize.tap do |r|
     r.url = "https://registry.suse.com"
     r.save
   end


### PR DESCRIPTION
This currently fails, as the method does not exist:

    NoMethodError: undefined method `find_or_initialize' for #<ActiveRecord::Relation []>