### PR TITLE
[WIP] Refuse to start Velum if a command fails during init

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -2,7 +2,7 @@
 
 # This script will setup the database and then start the rails application
 
-set -e
+set -euo pipefail
 
 : ${VELUM_PORT:=80}
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,20 +7,24 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-def seed_development
-  # nothing yet
-end
-
 def seed_production
+  # Ran for both production and developement environments
   Registry.where(name: "SUSE").find_or_initialize.tap do |r|
     r.url = "https://registry.suse.com"
     r.save
   end
 end
 
-case Rails.env
-when "test", "development"
-  seed_development
-when "production"
+def seed_development
+  # Ran after seed_production, only on development and test
+  # environments
+  # nothing yet
+end
+
+if ["production", "development"].include? Rails.env
   seed_production
+end
+
+if ["development", "test"].include? Rails.env
+  seed_development
 end


### PR DESCRIPTION
If a command in the Velum container init script fails, we should refuse
to start. Right now, we'll silently ignore failures such as seeding
the database.

Additionally, Use production DB seeds in development - if a seed is useful in
production, we should have the same seed in development, while also allowing for
development specific seeds if necessary. This reduces the likelihood of a
bad change merging and only affecting non-devenv/CI environments.

--

WIP as 1) untested and 2) this will fail CI as the production seeds are broken - see https://github.com/kubic-project/velum/pull/453