### PR TITLE
Add rake task to import CPI options

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -61,6 +61,16 @@ setup_database() {
   set -e
 }
 
+setup_cpi() {
+  # Check if Cloud Provider config exists
+  CPI_CONFIG="/etc/caasp/cpi/openstack.conf"
+  if [ -f "${CPI_CONFIG}" ]; then
+    # Import Cloud Provider config
+    bundle exec rake cpi:openstack['${CPI_CONFIG}']
+  fi
+}
+
 setup_root_ca
 setup_database
+setup_cpi
 bundle exec "puma -C config/puma.rb"

--- a/lib/tasks/cpi.rake
+++ b/lib/tasks/cpi.rake
@@ -3,7 +3,7 @@
 namespace :cpi do
   desc "Import OpenStack Cloud Proivider options"
   task :openstack, [:config] => :environment do |_, args|
-    config_file = args[:config] || "/etc/caasp/openstack.conf"
+    config_file = args[:config] || "/etc/caasp/cpi/openstack.conf"
     unless File.exist?(config_file)
       puts "OpenStack Cloud Provider config file doesn't exist"
       exit(1)

--- a/lib/tasks/cpi.rake
+++ b/lib/tasks/cpi.rake
@@ -1,0 +1,38 @@
+# rubocop:disable Metrics/BlockLength
+
+namespace :cpi do
+  desc "Import OpenStack Cloud Proivider options"
+  task :openstack, [:config] => :environment do |_, args|
+    config_file = args[:config] || "/etc/caasp/openstack.conf"
+    unless File.exist?(config_file)
+      puts "OpenStack Cloud Provider config file doesn't exist"
+      exit(1)
+    end
+    cfg = {}
+    File.open(config_file, "r").each do |line|
+      cfg["cloud:provider"] = "openstack"
+      line.chomp!
+      key, value = line.delete('"').split("=")
+      case key
+      when /^[\[#]/ then              puts "Skipping the line"
+      when "auth-url" then            cfg["cloud:openstack:auth_url"] = value
+      when "domain-name" then         cfg["cloud:openstack:domain_name"] = value
+      when "tenant-name" then         cfg["cloud:openstack:tenant_name"] = value
+      when "region" then              cfg["cloud:openstack:region"] = value
+      when "username" then            cfg["cloud:openstack:username"] = value
+      when "password" then            cfg["cloud:openstack:password"] = value
+      when "subnet-id" then           cfg["cloud:openstack:subnet_id"] = value
+      when "floating-network-id" then cfg["cloud:openstack:floating_id"] = value
+      when "monitor-max-retries" then cfg["cloud:openstack:lb_mon_retries"] = value
+      when "bs-version" then          cfg["cloud:openstack:bs_version"] = value
+      when /^./ then                  puts "Unknown option: #{key}"
+      end
+    end
+    cfg.each do |pillar, value|
+      Pillar.find_or_create_by!(pillar: pillar) do |p|
+        p.value = value
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
This task can be called:
```
docker exec -it $(docker ps | grep "velum-dashboard" | awk '{print $1}') entrypoint.sh bash -c "export RAILS_ENV=production; bundle exec rake velum:cpi_openstack['/etc/caasp/openstack.conf']
```

Example `openstack.conf` file which can be inject by cloud-init
```
[Global]
auth-url="http://prvcld.caasp.suse.net:5000/v3"
username="test"
password="secure"
tenant-name="caasp"
domain-name="caasp"
region="az"
[LoadBalancer]
lb-version=v2
subnet-id="e4f92380-4189-4dab-84c9-82830fe45522"
floating-network-id="e4f92380-4189-4dab-84c9-82830fe43311"
create-monitor=yes
monitor-delay=1m
monitor-timeout=30s
monitor-max-retries=3
[BlockStorage]
trust-device-path=false
bs-version=v3
```