### PR TITLE
Add cloud:provider to cloud_provider_contents for Salt API call

### DIFF
--- a/app/controllers/internal_api/v1/pillars_controller.rb
+++ b/app/controllers/internal_api/v1/pillars_controller.rb
@@ -112,6 +112,7 @@ class InternalApi::V1::PillarsController < InternalApiController
   def openstack_cloud_contents
     {
       cloud: {
+        provider:  "openstack",
         openstack: {
           auth_url:       Pillar.value(pillar: :cloud_openstack_auth_url),
           username:       Pillar.value(pillar: :cloud_openstack_username),

--- a/spec/controllers/internal_api/v1/pillars_controller_spec.rb
+++ b/spec/controllers/internal_api/v1/pillars_controller_spec.rb
@@ -237,6 +237,7 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
       {
         registries: [],
         cloud:      {
+          provider:  "openstack",
           openstack: {
             auth_url:       "http://keystone-test-host:5000/v3",
             username:       "testuser",


### PR DESCRIPTION
Without this change `cloud:provider` won't be saved in Salt as pillar.