### PR TITLE
Improved CPI behavior with cloud frameworks

### DIFF
--- a/app/assets/javascripts/setup/setup.js
+++ b/app/assets/javascripts/setup/setup.js
@@ -21,21 +21,5 @@ $(function() {
     }
   });
 
-  $(document).on('change', '.cloud-provider-select', function () {
-    var isOpenStack = $(this).val() === 'openstack';
-
-    $('.openstack-settings').toggleClass('hidden', !isOpenStack);
-  });
-
-  $(document).on('change', '.enable-cloud', function () {
-    var isOpenStack = $('.cloud-provider-select').val() === 'openstack';
-
-    $('.openstack-settings').toggleClass('hidden', !isOpenStack);
-  });
-
-  $(document).on('change', '.disable-cloud', function () {
-    $('.openstack-settings').addClass('hidden');
-  });
-
   new SUSERegistryMirrorPanel('.suse-mirror-panel-body');
 });

--- a/app/assets/stylesheets/components/panels.scss
+++ b/app/assets/stylesheets/components/panels.scss
@@ -4,6 +4,11 @@
 
 .panel-title {
   display: inline-block;
+
+  .fa,
+  .glyphicon {
+    vertical-align: middle;
+  }
 }
 
 .panel-heading {

--- a/app/assets/stylesheets/pages/settings.scss
+++ b/app/assets/stylesheets/pages/settings.scss
@@ -12,6 +12,7 @@ $sidebar-item-highlight: #00c081;
   width: 195px;
   z-index: 10;
 }
+
 .settings-sidebar-section {
   .title {
     color: $sidebar-section-title;
@@ -83,5 +84,12 @@ $sidebar-item-highlight: #00c081;
 
   h2 {
     margin-top: 0;
+  }
+}
+
+.cloud-settings-panel-body {
+  h4 {
+    margin-top: 0;
+    margin-bottom: 15px;
   }
 }

--- a/app/helpers/setup_helper.rb
+++ b/app/helpers/setup_helper.rb
@@ -1,12 +1,6 @@
 # SetupHelper contains all the view helpers for the setup process.
 module SetupHelper
-  def cloud_provider_options
-    [
-      ["OpenStack", :openstack]
-    ]
-  end
-
-  def cloud_providers_options_for_select
-    options_for_select(cloud_provider_options, selected: @cloud_provider)
+  def cloud_provider_value
+    Pillar.value(pillar: :cloud_framework) || "openstack"
   end
 end

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -14,7 +14,7 @@ class Pillar < ApplicationRecord
     end
 
     def all_pillars
-      simple_pillars.merge(cloud_pillars)
+      simple_pillars.merge(cloud_pillars).merge(cpi_pillars)
     end
 
     def simple_pillars
@@ -47,7 +47,9 @@ class Pillar < ApplicationRecord
         ldap_tls_method:               "ldap:tls_method",
         ldap_mail_attribute:           "ldap:mail_attribute",
         dex_client_secrets_kubernetes: "dex:client_secrets:kubernetes",
-        dex_client_secrets_velum:      "dex:client_secrets:velum"
+        dex_client_secrets_velum:      "dex:client_secrets:velum",
+        cloud_framework:               "cloud:framework",
+        cloud_provider:                "cloud:provider"
       }
     end
 
@@ -62,8 +64,6 @@ class Pillar < ApplicationRecord
           "cloud:providers:azure:client_id",
         azure_secret:
           "cloud:providers:azure:secret",
-        cloud_framework:
-          "cloud:framework",
         cloud_worker_type:
           "cloud:profiles:cluster_node:size",
         cloud_worker_subnet:
@@ -73,10 +73,12 @@ class Pillar < ApplicationRecord
         cloud_worker_net:
           "cloud:profiles:cluster_node:network",
         cloud_worker_resourcegroup:
-          "cloud:profiles:cluster_node:resourcegroup",
-        # CPI
-        cloud_provider:
-          "cloud:provider",
+          "cloud:profiles:cluster_node:resourcegroup"
+      }
+    end
+
+    def cpi_pillars
+      {
         cloud_openstack_auth_url:
           "cloud:openstack:auth_url",
         cloud_openstack_domain:

--- a/app/views/setup/cloud/_openstack_configuration.html.slim
+++ b/app/views/setup/cloud/_openstack_configuration.html.slim
@@ -1,4 +1,6 @@
-.openstack-settings class="#{'hidden' if @cloud_provider != 'openstack'}"
+.openstack-settings
+  h4 OpenStack Settings
+
   .form-group
     = f.label :cloud_openstack_auth_url, "Keystone API URL"
     = f.text_field :cloud_openstack_auth_url, value: @cloud_openstack_auth_url, class: "form-control"

--- a/app/views/setup/cloud/_settings.html.slim
+++ b/app/views/setup/cloud/_settings.html.slim
@@ -1,19 +1,18 @@
 .cloud-settings-wrapper
   .cloud-settings-panel.panel.panel-default
     .panel-heading.clearfix
-      h3.panel-title Cloud provider integration
+      h3.panel-title
+        | Cloud provider integration
+        | &nbsp;
+        i class='glyphicon glyphicon-info-sign' title="If running on a supported cloud provider, this enables Kubernetes' integration features, such as load-balancing and persistent storage."
       .btn-group.btn-group-sm.btn-group-toggle.pull-right data-toggle="buttons"
-        = label_tag :cloud_toggle, nil, class: "enable-cloud btn btn-default #{'btn-primary active' if @cloud_enabled}", data: {toggle: "collapse", target: ".cloud-settings-panel-body"}
-          = f.radio_button :cloud_enabled, "enable", checked: @cloud_enabled
+        = label_tag :cloud_provider, nil, class: "enable-cpi btn btn-default #{'btn-primary active' if @cloud_provider}", data: {toggle: "collapse", target: ".cloud-settings-panel-body"}
+          = f.radio_button :cloud_provider, cloud_provider_value, checked: @cloud_provider.present?
           | Enable
-        = label_tag :cloud_toggle, nil, class: "disable-cloud btn btn-default #{'btn-primary active' unless @cloud_enabled}", data: {toggle: "collapse", target: ".cloud-settings-panel-body"}
-          = f.radio_button :cloud_enabled, "disable", checked: !@cloud_enabled
+        = label_tag :cloud_provider, nil, class: "disable-cpi btn btn-default #{'btn-primary active'    unless @cloud_provider}", data: {toggle: "collapse", target: ".cloud-settings-panel-body"}
+          = f.radio_button :cloud_provider, "disable", checked: @cloud_provider.blank?
           | Disable
 
-    .cloud-settings-panel-body.panel-collapse.collapse class="#{'in' if @cloud_enabled}"
+    .cloud-settings-panel-body.panel-collapse.collapse class="#{'in' if @cloud_provider.present?} #{'hidden' if cloud_provider_value != 'openstack'}"
       .panel-body
-        .form-group.mirror-url-group
-          = f.label :url, "Choose the driver"
-          = f.select :cloud_provider, cloud_providers_options_for_select, { include_blank: true }, class: "form-control cloud-provider-select"
-
         = render partial: 'setup/cloud/openstack_configuration', locals: { f: f }

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -613,7 +613,6 @@ RSpec.describe SetupController, type: :controller do
     context "when cloud settings is enabled" do
       let(:cloud_settings) do
         settings_params.dup.tap do |s|
-          s["cloud_enabled"] = "enable"
           s["cloud_provider"] = "openstack"
           s["cloud_openstack_domain"] = "local.lan"
         end
@@ -637,8 +636,7 @@ RSpec.describe SetupController, type: :controller do
     context "when cloud settings is disabled" do
       let(:cloud_settings) do
         settings_params.dup.tap do |s|
-          s["cloud_enabled"] = "disable"
-          s["cloud_provider"] = "openstack"
+          s["cloud_provider"] = "disable"
           s["cloud_openstack_domain"] = "local.lan"
         end
       end

--- a/spec/features/bootstrap_settings_feature_spec.rb
+++ b/spec/features/bootstrap_settings_feature_spec.rb
@@ -54,21 +54,37 @@ describe "Bootstrap settings feature" do
       expect(page).to have_content("Cloud provider integration")
     end
 
-    it "toggles settings when enabling/disabling it" do
-      find(".enable-cloud").click
+    it "shows custom settings for openstack" do
+      find(".enable-cpi").click
       expect(page).to have_css(".cloud-settings-panel-body.in")
-      expect(page).to have_content("Choose the driver")
-
-      find(".disable-cloud").click
-      expect(page).not_to have_content("Choose the driver")
+      expect(page).to have_content("Keystone API URL")
     end
 
-    it "shows custom settings for openstack" do
-      find(".enable-cloud").click
-      expect(page).to have_css(".cloud-settings-panel-body.in")
+    it "attaches openstack value when no cloud framework is set" do
+      expect(page).to have_css("input[value=openstack]")
+    end
 
-      select "OpenStack", from: "settings_cloud_provider"
-      expect(page).to have_content("Keystone API URL")
+    context "when cloud framework is set" do
+      it "attaches ec2 value when AWS" do
+        Pillar.create(pillar: "cloud:framework", value: "ec2")
+
+        visit setup_path
+        expect(page).to have_css("input[value=ec2]")
+      end
+
+      it "shows GCE option when gce" do
+        Pillar.create(pillar: "cloud:framework", value: "gce")
+
+        visit setup_path
+        expect(page).to have_css("input[value=gce]")
+      end
+
+      it "shows Azure option when azure" do
+        Pillar.create(pillar: "cloud:framework", value: "azure")
+
+        visit setup_path
+        expect(page).to have_css("input[value=azure]")
+      end
     end
   end
 end

--- a/spec/helpers/setup_helper_spec.rb
+++ b/spec/helpers/setup_helper_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe SetupHelper, type: :helper do
+  describe "#cloud_provider_value" do
+    it "returns openstack by default" do
+      expect(cloud_provider_value).to eq("openstack")
+    end
+
+    it "returns ec2 options when cloud:framework is aws" do
+      Pillar.create(pillar: "cloud:framework", value: "ec2")
+      expect(cloud_provider_value).to eq("ec2")
+    end
+
+    it "returns gce options when cloud:framework is gce" do
+      Pillar.create(pillar: "cloud:framework", value: "gce")
+      expect(cloud_provider_value).to eq("gce")
+    end
+
+    it "returns azure options when cloud:framework is azure" do
+      Pillar.create(pillar: "cloud:framework", value: "azure")
+      expect(cloud_provider_value).to eq("azure")
+    end
+  end
+end


### PR DESCRIPTION
If a cloud framework is previously set, CPI value, if enabled, would be
based on what was set.
    
For example, if cloud:framework pillar value is "ec2", we would
set "ec2" as the CPI value if enabled. The same be applied for GCE and
Azure.
    
Otherwise, "openstack" would be the default value for CPI if enabled.

Signed-off-by: Vítor Avelino <vavelino@suse.com>