### PR TITLE
[test] reduce workers/threads

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,6 +1,6 @@
-WORKERS = ENV.fetch("VELUM_WORKERS", 8).freeze
-MIN_THREADS = ENV.fetch("VELUM_MIN_THREADS", 8).freeze
-MAX_THREADS = ENV.fetch("VELUM_MAX_THREADS", 32).freeze
+WORKERS = ENV.fetch("VELUM_WORKERS", 2).freeze
+MIN_THREADS = ENV.fetch("VELUM_MIN_THREADS", 5).freeze
+MAX_THREADS = ENV.fetch("VELUM_MAX_THREADS", 5).freeze
 SOCKET_NAME = ENV.fetch("VELUM_SOCKET_NAME", "dashboard.sock").freeze
 
 # Puma can serve each request in a thread from an internal thread pool.


### PR DESCRIPTION
in smaller scale environments, choosing such a high number of default
workers and threads might lead to resource overconsumption, as regarding
puma (rule of thumb) nr of cpu core == nr of workers

under normal circumstances it's enough to handle the workloads of
the rails app with 2 workers and the default set of threads (5)

this needs to be tested with a big amount of nodes to be sure it can
handle the workload

ideally we would have a way to dynamically set this configuration before
starting the rails app

Signed-off-by: Maximilian Meister <mmeister@suse.de>