### PR TITLE
ui: allowed master node to be added to the cluster

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -1,6 +1,7 @@
 State = {
   nextClicked: false,
   bootstrapErrors: [],
+  assignableErrors: [],
 },
 
 MinionPoller = {
@@ -375,22 +376,7 @@ MinionPoller = {
   },
 
   renderUnassigned: function(minion) {
-    var minionHtml;
-    var minionChecked = '';
-
-    if (MinionPoller.selectedNodes.indexOf(minion.id) != -1) {
-      minionChecked += 'checked';
-    }
-
-    minionHtml = '<input name="roles[worker][]" id="roles_minion_' + minion.id +
-      '" value="' + minion.id + '" type="checkbox" title="Select node for bootstrapping" ' + minionChecked + '>';
-
-    return "\
-      <tr> \
-        <td>" + minionHtml +  "</td>\
-        <td>" + minion.minion_id +  "</td>\
-        <td class=\"minion-hostname\">" + minion.fqdn +  "</td>\
-      </tr>";
+    return MinionPoller.renderDiscovery(minion);
   }
 };
 
@@ -508,15 +494,38 @@ function healthCheckToReload() {
   });
 };
 
+// begin unassigned
+function isAssignable() {
+  var errors = [];
+
+  // We need an odd number of masters
+  if (selectedMastersLength() % 2 !== 0) {
+    errors.push('The number of masters to be added has to be an even number in order to maintain the odd constraint number in the cluster');
+  }
+
+  // We need unique hostnames
+  if (!hasUniqueHostnames()) {
+    errors.push("There's a node in the cluster or selected with conflicting hostnames");
+  }
+
+  State.assignableErrors = errors;
+
+  return errors.length === 0;
+}
+
+function showNodesSelectionErrors(errors, container) {
+  var html = errors.map(function (e) { return '<li>' + e + '</li>' }).join('');
+  $(container + ' .list').html(html);
+  $(container).fadeIn(100);
+}
+
 function handleUnassignedErrors() {
-  if (State.addNodesClicked && !hasUniqueHostnames()) {
-    State.addNodesEnabled = false;
-    $('.unique-hostnames-alert').fadeIn(100);
+  if (State.addNodesClicked && !isAssignable()) {
+    showNodesSelectionErrors(State.assignableErrors, '.unassigned-alert')
     $('.add-nodes-btn').prop('disabled', true);
   } else {
-    State.addNodesEnabled = true;
-    $('.unique-hostnames-alert').fadeOut(100);
-    $('.add-nodes-btn').prop('disabled', false);
+    $('.unassigned-alert').fadeOut(100);
+    $('.add-nodes-btn').prop('disabled', $('input:checked').length === 0);
   }
 }
 
@@ -526,24 +535,14 @@ $('body').on('click', '.add-nodes-btn', function(e) {
   e.preventDefault();
   handleUnassignedErrors();
 
-  if (State.addNodesEnabled) {
+  if (isAssignable()) {
+    MinionPoller.stop();
     $('form').submit();
+  } else {
+    window.scrollTo(0, 0);
   }
 });
-
-// enable/disable Add nodes button to assign nodes
-function toggleAddNodesButton() {
-  var selectedNodesLength = $("input[name='roles[worker][]']:checked").length;
-
-  $('.add-nodes-btn').prop('disabled', selectedNodesLength === 0);
-
-  if (selectedNodesLength > 0) {
-    handleUnassignedErrors();
-  }
-};
-
-// unassigned nodes page
-$('body').on('change', '.new-nodes-container input[name="roles[worker][]"]', toggleAddNodesButton);
+// end unassigned
 
 // return number of selected nodes
 function selectedWorkersLength() {
@@ -564,7 +563,7 @@ function hasUniqueHostnames() {
   var obj = {};
 
   for (; i < hostnames.length; i++) {
-    var hostname = hostnames[i];
+    var hostname = hostnames[i].toLowerCase();
 
     if (obj[hostname] === 0) {
       return false;
@@ -612,14 +611,8 @@ function isSupportedConfiguration() {
 
 // handle bootstrap button title
 function handleBootstrapErrors() {
-  var nextClicked = State.nextClicked;
-  var title;
-
-  if (nextClicked && !isBootstrappable()) {
-    var errors = State.bootstrapErrors;
-    var listHtml = errors.map(function(e) { return '<li>' + e + '</li>' }).join('');
-    $('.discovery-bootstrap-alert .list').html(listHtml);
-    $('.discovery-bootstrap-alert').fadeIn(100);
+  if (State.nextClicked && !isBootstrappable()) {
+    showNodesSelectionErrors(State.bootstrapErrors, '.discovery-bootstrap-alert')
     $('#set-roles').prop('disabled', true);
   } else {
     $('.discovery-bootstrap-alert').fadeOut(100);
@@ -680,7 +673,7 @@ $('body').on('click', '.deselect-nodes-btn', function() {
   $('.select-nodes-btn').show();
   $(unusedSelector).click();
   handleBootstrapErrors();
-  toggleAddNodesButton();
+  handleUnassignedErrors();
 });
 
 // select remaining nodes as workers
@@ -692,7 +685,7 @@ $('body').on('click', '.select-nodes-btn', function() {
   $(workersSelector).click();
 
   handleBootstrapErrors();
-  toggleAddNodesButton();
+  handleUnassignedErrors();
 });
 
 // when checking/unchecking a node
@@ -749,4 +742,5 @@ $('body').on('click', '.role-btn-group .btn', function(e) {
 
   toggleMinimumNodesAlert();
   handleBootstrapErrors();
+  handleUnassignedErrors();
 });

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -81,7 +81,7 @@ class DashboardController < ApplicationController
   private
 
   def update_nodes_params
-    params.require(:roles).permit(worker: [])
+    params.require(:roles).permit(worker: [], master: [])
   end
 
   def redirect_to_dashboard

--- a/app/views/dashboard/unassigned_nodes.html.slim
+++ b/app/views/dashboard/unassigned_nodes.html.slim
@@ -4,45 +4,53 @@
       | &times;
   i.fa.fa-4x.pull-left aria-hidden="true"
   span
-    | After choosing the nodes and clicking "Add nodes" all the selected nodes will be set to the worker role
+    | After selecting the respective nodes' by choosing their roles and clicking on "Add nodes", all of them will be assigned and added to the cluster.
 
-.alert.alert-danger.unique-hostnames-alert role="alert" hidden="true"
+.alert.alert-danger.unassigned-alert role="alert" hidden="true"
   i.fa.fa-4x.pull-left aria-hidden="true"
   span
-    strong Unable to add nodes:
-    |  All nodes must have unique hostnames
+    p Unable to add nodes:
+
+    ul.list
 
 h1 Unassigned Nodes
 
-.row
-  .col-xs-12.discovery-control
-    p#node-count #{@unassigned_minions.count} nodes found
+.panel.panel-default.unassigned-nodes-panel class=('hide' unless any_minion?)
+  .panel-heading
+    h3.panel-title#node-count #{@unassigned_minions.count} nodes found
 
-= form_tag(assign_nodes_url, method: "post")
-  <div class="nodes-container new-nodes-container" data-url="#{authenticated_root_path}" data-current-hostnames='#{@assigned_minions_hostnames}'>
-    table.table
-      thead
-        tr
-          th width=10
-            = check_box_tag "all", "all", false, { class: "check-all" }
-          th
-            | Id
-          th
-            | Hostname
-      tbody
-        - @unassigned_minions.each do |m|
-          tr
-            td
-              = check_box_tag "roles[worker][]", m.id
-            td
-              | #{m.minion_id}
-            td.minion-hostname
-              | #{m.fqdn}
-    .clearfix.text-right.steps-container
-      = link_to "Back", authenticated_root_path, class: "btn btn-default"
-      | &nbsp;
-      = submit_tag "Add nodes", class: "btn btn-primary add-nodes-btn", disabled: true
-  </div>
+    button.btn.btn-sm.btn-default.pull-right.select-nodes-btn title="Select remaining nodes as worker"
+      i.fa.fa-check.fa-fw
+      | Select remaining nodes
+
+    button.btn.btn-sm.btn-default.pull-right.hidden.deselect-nodes-btn title="Deselect all the nodes"
+      i.fa.fa-times.fa-fw
+      | Deselect all nodes
+  .panel-body
+    = form_tag(assign_nodes_url, method: "post")
+      div class="nodes-container new-nodes-container" data-url=authenticated_root_path data-current-hostnames='#{@assigned_minions_hostnames}'
+        table.table
+          thead
+            tr
+              th
+                | ID
+              th
+                | Hostname
+              th width="235"
+                | Role
+          tbody
+            tr
+              td colspan=4
+                p.text-center
+                  i class="fa fa-spinner fa-pulse fa-3x fa-fw"
+                  span class="sr-only" Loading...
+
+        hr
+
+        .clearfix.text-right.steps-container
+          = link_to "Back", authenticated_root_path, class: "btn btn-default"
+          | &nbsp;
+          = submit_tag "Add nodes", class: "btn btn-primary add-nodes-btn", disabled: true
 
 = content_for :page_javascript do
   javascript:


### PR DESCRIPTION
So far we only allowed workers to be added to the cluster through the
unassigned nodes page.

With this patch, we are now allowing the users to select the roles of the
nodes they want to add to the cluster. Very similar to what is available
from the discovery bootstrap page.

This feature keep forcing the user to respect the contrainst of having an
odd number of master nodes so we have a stable topology.

feature#add_master_node

Signed-off-by: Vítor Avelino <contact@vitoravelino.me>

### Screenshots

![screenshot-20180321150526-1203x624](https://user-images.githubusercontent.com/188554/37728746-d7c9f81c-2d19-11e8-8d79-84ac8e82f771.png)
![screenshot-20180321150512-1216x603](https://user-images.githubusercontent.com/188554/37728763-dd853884-2d19-11e8-98bf-0c46d4d123a4.png)
![screenshot-20180321150504-1206x710](https://user-images.githubusercontent.com/188554/37728772-e0d1bb0c-2d19-11e8-8485-c1bae3053986.png)
![screenshot-20180321150547-1201x718](https://user-images.githubusercontent.com/188554/37728784-e70dcd76-2d19-11e8-8bb2-ed1cae4985fd.png)
![screenshot-20180321150903-1203x712](https://user-images.githubusercontent.com/188554/37728787-e866635e-2d19-11e8-904f-c39e9b620831.png)
