### PR TITLE
Extend salt-api timeout as long as possible.

### DIFF
--- a/lib/velum/salt_api.rb
+++ b/lib/velum/salt_api.rb
@@ -82,7 +82,7 @@ module Velum
           ca_file:      "/etc/pki/ca.crt",
           ssl_version:  :TLSv1,
           open_timeout: 2,
-          read_timeout: 30
+          read_timeout: 45
         }
 
         Net::HTTP.start(uri.hostname, uri.port, opts) { |http| http.request(req) }


### PR DESCRIPTION
Allow enough time for the salt timeout, and a minion timeout before cutting off the API call.

Should resolve https://github.com/kubic-project/velum/issues/456 introduced in 6189bcad .