### PR TITLE
Hide CPI panel when no cloud framework

### DIFF
--- a/app/helpers/setup_helper.rb
+++ b/app/helpers/setup_helper.rb
@@ -1,6 +1,10 @@
 # SetupHelper contains all the view helpers for the setup process.
 module SetupHelper
-  def cloud_provider_value
-    Pillar.value(pillar: :cloud_framework) || "openstack"
+  def cloud_framework_value
+    Pillar.value(pillar: :cloud_framework)
+  end
+
+  def cloud_provider_options?
+    ["openstack"].include?(cloud_framework_value)
   end
 end

--- a/app/views/setup/cloud/_settings.html.slim
+++ b/app/views/setup/cloud/_settings.html.slim
@@ -1,18 +1,19 @@
-.cloud-settings-wrapper
-  .cloud-settings-panel.panel.panel-default
-    .panel-heading.clearfix
-      h3.panel-title
-        | Cloud provider integration
-        | &nbsp;
-        i class='glyphicon glyphicon-info-sign' title="If running on a supported cloud provider, this enables Kubernetes' integration features, such as load-balancing and persistent storage."
-      .btn-group.btn-group-sm.btn-group-toggle.pull-right data-toggle="buttons"
-        = label_tag :cloud_provider, nil, class: "enable-cpi btn btn-default #{'btn-primary active' if @cloud_provider}", data: {toggle: "collapse", target: ".cloud-settings-panel-body"}
-          = f.radio_button :cloud_provider, cloud_provider_value, checked: @cloud_provider.present?
-          | Enable
-        = label_tag :cloud_provider, nil, class: "disable-cpi btn btn-default #{'btn-primary active'    unless @cloud_provider}", data: {toggle: "collapse", target: ".cloud-settings-panel-body"}
-          = f.radio_button :cloud_provider, "disable", checked: @cloud_provider.blank?
-          | Disable
+- if cloud_framework_value
+  .cloud-settings-wrapper
+    .cloud-settings-panel.panel.panel-default
+      .panel-heading.clearfix
+        h3.panel-title
+          | Cloud provider integration
+          | &nbsp;
+          i class='glyphicon glyphicon-info-sign' title="If running on a supported cloud provider, this enables Kubernetes' integration features, such as load-balancing and persistent storage."
+        .btn-group.btn-group-sm.btn-group-toggle.pull-right data-toggle="buttons"
+          = label_tag :cloud_provider, nil, class: "enable-cpi btn btn-default #{'btn-primary active' if @cloud_provider}", data: {toggle: "collapse", target: ".cloud-settings-panel-body"}
+            = f.radio_button :cloud_provider, cloud_framework_value, checked: @cloud_provider.present?
+            | Enable
+          = label_tag :cloud_provider, nil, class: "disable-cpi btn btn-default #{'btn-primary active'    unless @cloud_provider}", data: {toggle: "collapse", target: ".cloud-settings-panel-body"}
+            = f.radio_button :cloud_provider, "disable", checked: @cloud_provider.blank?
+            | Disable
 
-    .cloud-settings-panel-body.panel-collapse.collapse class="#{'in' if @cloud_provider.present?} #{'hidden' if cloud_provider_value != 'openstack'}"
-      .panel-body
-        = render partial: 'setup/cloud/openstack_configuration', locals: { f: f }
+      .cloud-settings-panel-body.panel-collapse.collapse class="#{'in' if @cloud_provider.present?} #{'hidden' unless cloud_provider_options?}"
+        .panel-body
+          = render partial: 'setup/cloud/openstack_configuration', locals: { f: f }

--- a/spec/features/bootstrap_settings_feature_spec.rb
+++ b/spec/features/bootstrap_settings_feature_spec.rb
@@ -50,40 +50,36 @@ describe "Bootstrap settings feature" do
   end
 
   context "CPI configuration", js: true do
-    it "shows panel settings" do
-      expect(page).to have_content("Cloud provider integration")
-    end
-
-    it "shows custom settings for openstack" do
-      find(".enable-cpi").click
-      expect(page).to have_css(".cloud-settings-panel-body.in")
-      expect(page).to have_content("Keystone API URL")
-    end
-
-    it "attaches openstack value when no cloud framework is set" do
-      expect(page).to have_css("input[value=openstack]")
+    context "when no cloud framework is set" do
+      it "hides panel settings" do
+        expect(page).not_to have_content("Cloud provider integration")
+      end
     end
 
     context "when cloud framework is set" do
-      it "attaches ec2 value when AWS" do
+      before do
+        Pillar.create(pillar: "cloud:framework", value: "openstack")
+        visit setup_path
+      end
+
+      it "shows panel settings" do
+        expect(page).to have_content("Cloud provider integration")
+      end
+
+      it "shows custom settings for openstack" do
+        find(".enable-cpi").click
+        expect(page).to have_css(".cloud-settings-panel-body.in")
+        expect(page).to have_content("Keystone API URL")
+      end
+
+      it "attaches cloud framework value" do
+        expect(page).to have_css("input[value=openstack]")
+
+        Pillar.find_by(pillar: "cloud:framework").destroy
         Pillar.create(pillar: "cloud:framework", value: "ec2")
 
         visit setup_path
         expect(page).to have_css("input[value=ec2]")
-      end
-
-      it "shows GCE option when gce" do
-        Pillar.create(pillar: "cloud:framework", value: "gce")
-
-        visit setup_path
-        expect(page).to have_css("input[value=gce]")
-      end
-
-      it "shows Azure option when azure" do
-        Pillar.create(pillar: "cloud:framework", value: "azure")
-
-        visit setup_path
-        expect(page).to have_css("input[value=azure]")
       end
     end
   end

--- a/spec/helpers/setup_helper_spec.rb
+++ b/spec/helpers/setup_helper_spec.rb
@@ -1,24 +1,26 @@
 require "rails_helper"
 
 RSpec.describe SetupHelper, type: :helper do
-  describe "#cloud_provider_value" do
-    it "returns openstack by default" do
-      expect(cloud_provider_value).to eq("openstack")
+  describe "#cloud_framework_value" do
+    it "returns whatever value cloud:framework is set" do
+      p = Pillar.create(pillar: "cloud:framework", value: "ec2")
+      expect(cloud_framework_value).to eq("ec2")
+
+      p.value = "gce"
+      p.save
+      expect(cloud_framework_value).to eq("gce")
+    end
+  end
+
+  describe "#cloud_provider_options?" do
+    it "returns true if has advanced settings available (e.g. openstack)" do
+      Pillar.create(pillar: "cloud:framework", value: "openstack")
+      expect(cloud_provider_options?).to eq(true)
     end
 
-    it "returns ec2 options when cloud:framework is aws" do
-      Pillar.create(pillar: "cloud:framework", value: "ec2")
-      expect(cloud_provider_value).to eq("ec2")
-    end
-
-    it "returns gce options when cloud:framework is gce" do
+    it "returns false if no advanced settings available (e.g. gce)" do
       Pillar.create(pillar: "cloud:framework", value: "gce")
-      expect(cloud_provider_value).to eq("gce")
-    end
-
-    it "returns azure options when cloud:framework is azure" do
-      Pillar.create(pillar: "cloud:framework", value: "azure")
-      expect(cloud_provider_value).to eq("azure")
+      expect(cloud_provider_options?).to eq(false)
     end
   end
 end


### PR DESCRIPTION
When no cloud:framework pillar is set, it means that CaaSP is not
running in a cloud environment. So it doesn't make sense to show that
option in that scenario.

feature#cpi

Signed-off-by: Vítor Avelino <contact@vitoravelino.me>