### PR TITLE
Added minimum of three nodes to warning

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -887,6 +887,11 @@ function canRemoveWithoutWarning(id) {
     errors.push("You need at least one worker");
   }
 
+  // We need at least three nodes
+  if (masters.length + workers.length < 3) {
+    errors.push("Minimum of three nodes");
+  }
+
   // We need an odd number of masters
   if (masters.length % 2 !== 1) {
     errors.push('The number of masters has to be an odd number');

--- a/app/views/dashboard/_warn_node_removal_modal.html.slim
+++ b/app/views/dashboard/_warn_node_removal_modal.html.slim
@@ -6,7 +6,7 @@
           span aria-hidden="true"
             | &times;
         h4#modal-label.modal-title
-          | Invalid cluster topology
+          | Unsupported cluster topology
       .modal-body
         p By removing the respective node you'll be breaking the following constraints that is needed to have a stable and supported topology:
         ul.node-removal-constraints-list

--- a/spec/features/node_removal_feature_spec.rb
+++ b/spec/features/node_removal_feature_spec.rb
@@ -55,7 +55,7 @@ describe "feature: node removal", js: true do
       master_selector = ".remove-node-link[data-id='#{minions[0].minion_id}']"
 
       find(master_selector).click
-      expect(page).to have_content("Invalid cluster topology")
+      expect(page).to have_content("Unsupported cluster topology")
     end
 
     it "proceeds with removal even after warning" do


### PR DESCRIPTION
This is a follow up from the previous node removal feature patch that
shows the requirement of minimum of three nodes when user removes a
node.

enhancement#follow_up_node_removal

Signed-off-by: Vítor Avelino <contact@vitoravelino.me>