### PR TITLE
Added alert in overview page when unsupported config

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -186,6 +186,7 @@ MinionPoller = {
         MinionPoller.handleRetryableOrchestrations(data);
 
         handleBootstrapErrors();
+        handleUnsupportedClusterConfiguration();
 
         // show/hide "update all nodes" link
         var hasAdminNodeUpdate = data.admin.update_status === 1 || data.admin.update_status === 2;
@@ -925,4 +926,22 @@ function disableOrchTriggers() {
   $('#update-all-nodes').addClass('hidden');
   $('.pending-accept-link').addClass('hidden');
   $('.admin-outdated-notification').addClass('hidden');
+}
+
+function handleUnsupportedClusterConfiguration() {
+  var masters = State.minions.filter(function (m) { return m.role === 'master' });
+  var workers = State.minions.filter(function (m) { return m.role === 'worker' });
+  var $alert = $('.unsupported-alert');
+
+  // We need at least three nodes
+  if (masters.length + workers.length < 3) {
+    $alert.find('.reason').text('a minimum of three nodes');
+    $alert.fadeIn(100);
+  } else if (masters.length % 2 === 0) {
+    // We need an odd number of masters
+    $alert.find('.reason').text('an odd number of masters nodes');
+    $alert.fadeIn(100);
+  } else {
+    $alert.fadeOut(500);
+  }
 }

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -1,3 +1,10 @@
+.alert.alert-warning.unsupported-alert role="alert" hidden="true"
+  i.fa.fa-4x.pull-left aria-hidden="true"
+  span
+    | A supported deployment of SUSE CaaS Platform requires&nbsp;
+    span class="reason"
+    | .
+
 h1 Cluster Status
 
 .nodes-summary

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -131,6 +131,28 @@ describe "Dashboard" do
 
       expect(page).not_to have_content("(new)")
     end
+
+    context "when unsupported configuration" do
+      before do
+        Minion.destroy_all
+      end
+      it "shows alert if nodes is less than 3", js: true do
+        Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master" },
+                        { minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local", role: "worker" }]
+
+        visit authenticated_root_path
+        expect(page).to have_content("requires a minimum of three nodes")
+      end
+
+      it "shows alert if masters number is even", js: true do
+        Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "minion0.k8s.local", role: "master" },
+                        { minion_id: SecureRandom.hex, fqdn: "minion1.k8s.local", role: "master" },
+                        { minion_id: SecureRandom.hex, fqdn: "minion2.k8s.local", role: "worker" }]
+
+        visit authenticated_root_path
+        expect(page).to have_content("requires an odd number of masters")
+      end
+    end
   end
 end
 # rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
Whenever the cluster goes to an unsupported configuration state, an
alert is shown with the reason to keep the user aware of that.

enhancement#unsupported_config_msg

Signed-off-by: Vítor Avelino <contact@vitoravelino.me>

### Screenshots

![screenshot-20180326155441-753x246](https://user-images.githubusercontent.com/188554/37927511-b9dff50e-3110-11e8-99b1-7acc3edbc882.png)
![screenshot-20180326155504-645x233](https://user-images.githubusercontent.com/188554/37927512-b9fcbbf8-3110-11e8-9fe0-ae101c356f98.png)