### PR TITLE
Bootstrap settings: cri-o support

### DIFF
--- a/app/assets/javascripts/setup/setup.js
+++ b/app/assets/javascripts/setup/setup.js
@@ -21,5 +21,10 @@ $(function() {
     }
   });
 
+  $(document).on('click', '.runtime-btn-group .btn', function() {
+    $('.docker-desc, .crio-desc').collapse('hide');
+    $($(this).data('element')).collapse('show');
+  });
+
   new SUSERegistryMirrorPanel('.suse-mirror-panel-body');
 });

--- a/app/assets/stylesheets/components/panels.scss
+++ b/app/assets/stylesheets/components/panels.scss
@@ -7,7 +7,7 @@
 
   .fa,
   .glyphicon {
-    vertical-align: middle;
+    vertical-align: bottom;
   }
 }
 

--- a/app/assets/stylesheets/pages/setup.scss
+++ b/app/assets/stylesheets/pages/setup.scss
@@ -5,3 +5,7 @@
 .invalid-insecure {
   color: $state-danger-text;
 }
+
+.runtime-btn-group {
+  margin-bottom: 10px;
+}

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -48,6 +48,9 @@ class SetupController < ApplicationController
     @cloud_openstack_floating = Pillar.value(pillar: :cloud_openstack_floating)
     @cloud_openstack_lb_mon_retries = Pillar.value(pillar: :cloud_openstack_lb_mon_retries) || "3"
     @cloud_openstack_bs_version = Pillar.value(pillar: :cloud_openstack_bs_version) || "v2"
+
+    # container runtime setting
+    @cri = Pillar.value(pillar: :container_runtime) || "docker"
   end
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
 

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -50,7 +50,8 @@ class Pillar < ApplicationRecord
         dex_client_secrets_velum:      "dex:client_secrets:velum",
         cloud_framework:               "cloud:framework",
         cloud_provider:                "cloud:provider",
-        kubernetes_feature_gates:      "kubernetes:feature_gates"
+        kubernetes_feature_gates:      "kubernetes:feature_gates",
+        container_runtime:             "cri:name"
       }
     end
 

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -51,7 +51,7 @@ class Pillar < ApplicationRecord
         cloud_framework:               "cloud:framework",
         cloud_provider:                "cloud:provider",
         kubernetes_feature_gates:      "kubernetes:feature_gates",
-        container_runtime:             "cri:name"
+        container_runtime:             "cri:chosen"
       }
     end
 

--- a/app/views/setup/settings/_container_runtime.html.slim
+++ b/app/views/setup/settings/_container_runtime.html.slim
@@ -1,0 +1,36 @@
+.panel.panel-default
+  .panel-heading
+    h3.panel-title
+      | Container runtime
+      | &nbsp;
+      i class='glyphicon glyphicon-info-sign' title="Software that Kubernetes uses to manage the containers."
+  .panel-body
+    p The choice of container runtime is completely transparent to end-users of the
+      cluster. Neither Kubernetes manifests nor container images need to be changed.
+
+    .form-group
+      = f.label :cri, "Choose the runtime"
+      br
+        .btn-group.btn-group-toggle.runtime-btn-group data-toggle="buttons"
+          = label_tag :container_runtime, nil, class: "docker btn btn-default #{'btn-primary active' if @cri == "docker"}", data: { element: '.docker-desc' }
+            = f.radio_button :container_runtime, "docker", checked: @cri == "docker"
+            | Docker open source engine
+          = label_tag :container_runtime, nil, class: "crio btn btn-default #{'btn-primary active' if @cri == "crio"}", data: { element: '.crio-desc' }
+            = f.radio_button :container_runtime, "crio", checked: @cri == "crio"
+            | cri-o
+
+      .docker-desc.collapse class="#{'in' if @cri == "docker"}"
+        | <em>Docker open source engine</em> (<strong>default</strong>) is a production-ready runtime, fully supported by SUSE.
+
+      .crio-desc.collapse class="#{'in' if @cri == "crio"}"
+        p <em>cri-o</em> is a lightweight container runtime designed and optimised for
+          Kubernetes. Based on Open Container Initiative standards, it can pull from any
+          compliant registry and can run any OCI-compliant container.
+
+        .alert.alert-warning role="alert"
+          span NOTE: cri-o is a <em>technology feature preview</em>. SUSE welcomes your
+               feedback on cri-o. As a preview, cri-o is <strong>not supported</strong>.
+               Previews may be functionally incomplete, unstable or in other ways not suitable
+               for production use. They are mainly included to give customers a chance to test
+               new technologies within an enterprise environment.
+

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -136,6 +136,7 @@ h1 Initial CaaS Platform Configuration
 
   = render partial: 'setup/settings/mirror', locals: { form: f }
   = render partial: 'setup/cloud/settings', locals: { f: f }
+  = render partial: 'setup/settings/container_runtime', locals: { f: f }
 
   .clearfix.steps-container
     = submit_tag "Next", class: "btn btn-primary pull-right"


### PR DESCRIPTION
Allow the user to choose between different container runtimes.

This enables users to create clusters backed by cri-o instead of docker.

feature#crio

@ajaeger and @eotchi: can you provide advice on this PR, especially when it comes to the following points:

  * wording: how I described what a container runtime is, what are the differences between cri-o and docker
  * placement of the settings inside of the page: right now I placed that right at the bottom of the page
  * should we make more prominent the fact cri-o is tech preview (eg: show a warning box when chosen)

## Screenshot

By default `docker` is being used:

![screenshot-2018-3-27 velum](https://user-images.githubusercontent.com/22728/37975847-7ad4fe42-31e0-11e8-9f74-9fc96e638c52.png)

Nothing fancy to be shown, this is what happens when `cri-o` is chosen:

![screenshot-2018-3-27 velum 1](https://user-images.githubusercontent.com/22728/37975849-7af45350-31e0-11e8-962c-6d0aec941069.png)

## QA

This is probably going to break openQA, ping @kravciak 