### PR TITLE
Fixed # of masters warning when removing worker

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -873,6 +873,7 @@ function requestNodeRemoval(id) {
 
 function canRemoveWithoutWarning(id) {
   var errors = [];
+  var minion = State.minions.find(function (m) { return m.minion_id === id });
   var newCluster = State.minions.filter(function(m) { return m.minion_id !== id });
   var masters = newCluster.filter(function (m) { return m.role === 'master' });
   var workers = newCluster.filter(function (m) { return m.role === 'worker' });
@@ -888,7 +889,7 @@ function canRemoveWithoutWarning(id) {
   }
 
   // We need an odd number of masters
-  if (masters.length % 2 !== 1) {
+  if (minion.role === 'master' && masters.length % 2 !== 1) {
     errors.push('The number of masters has to be an odd number');
   }
 


### PR DESCRIPTION
This patch fixes the warning modal that was being shown when the cluster
was in an unsupported configuration (even # masters) and user was trying
to remove a normal worker node. This scenario should trigger that
warning modal.

bsc#1087123

Signed-off-by: Vítor Avelino <contact@vitoravelino.me>