### PR TITLE
Fixed # of masters warning when adding a new master

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -116,6 +116,7 @@ MinionPoller = {
           minions = allMinions;
           break;
         case "Unassigned":
+          State.assignedMinions = minions;
           minions = unassignedMinions;
           break;
         default:
@@ -561,10 +562,12 @@ function healthCheckToReload() {
 // begin unassigned
 function isAssignable() {
   var errors = [];
+  var masters = State.assignedMinions.filter(function (m) { return m.role === 'master' });
 
   // We need an odd number of masters
-  if (selectedMastersLength() % 2 !== 0) {
-    errors.push('The number of masters to be added has to be an even number in order to maintain the odd constraint number in the cluster');
+  if (selectedMastersLength() > 0 &&
+      (masters.length + selectedMastersLength()) % 2 === 0) {
+    errors.push('The number of masters to be added needs to maintain the odd constraint number in the cluster');
   }
 
   // We need unique hostnames

--- a/spec/features/add_unassigned_nodes_feature_spec.rb
+++ b/spec/features/add_unassigned_nodes_feature_spec.rb
@@ -59,14 +59,29 @@ describe "Add unassigned nodes", js: true do
     expect(page).to have_button(value: "Add nodes", disabled: true)
   end
 
-  it "A user cannot add odd number of master nodes" do
+  it "cannot add a number (even) of master nodes that breaks the odd constraint" do
     minion = Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion2.k8s.local")
 
     # select only one master node
     find(".minion_#{minion.id} .master-btn").click
 
     click_button "Add nodes"
-    expect(page).to have_content("The number of masters to be added has to be an even number")
+    expect(page).to have_content("The number of masters to be added needs to maintain")
+    expect(page).to have_button(value: "Add nodes", disabled: true)
+  end
+
+  it "cannot add a number (odd) of master nodes that breaks the odd constraint" do
+    minion = Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion2.k8s.local")
+    minion2 = Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion3.k8s.local")
+    minion3 = Minion.create!(minion_id: SecureRandom.hex, fqdn: "minion4.k8s.local")
+
+    # select only one master node
+    find(".minion_#{minion.id} .master-btn").click
+    find(".minion_#{minion2.id} .master-btn").click
+    find(".minion_#{minion3.id} .master-btn").click
+
+    click_button "Add nodes"
+    expect(page).to have_content("The number of masters to be added needs to maintain")
     expect(page).to have_button(value: "Add nodes", disabled: true)
   end
 


### PR DESCRIPTION
This patch fixes the warning that was being shown when the user selected
a new master node to be added and it wasn't breaking the odd number
constraint. Before this, the current assigned masters were not being
considered to show/not show the warning.

Now the warning will only be shown if the number of masters to be added
breaks the constraint as it's expected to be.

bsc#1087267

Signed-off-by: Vítor Avelino <contact@vitoravelino.me>