### PR TITLE
Properly create and update orchestrations that have been executed out of Velum

### DIFF
--- a/app/models/salt_handler/orchestration_trigger.rb
+++ b/app/models/salt_handler/orchestration_trigger.rb
@@ -19,10 +19,12 @@ class SaltHandler::OrchestrationTrigger < SaltHandler::Orchestration
                   when "orch.removal"
                     ::Orchestration.kinds[:removal]
       end
+      orch.params = (
+        event_data["fun_args"].find { |k| k.respond_to?(:key?) && k.key?("pillar") } || {}
+      )["pillar"]
     end
     orchestration.started_at = Time.zone.parse event_data["_stamp"]
     orchestration.save
-
     true
   end
 end


### PR DESCRIPTION
It's more correct for the removal orchestration to read the parameters that were
passed to the orchestration rather than to rely on the current status of the
minions on the database.