### PR TITLE
Public Cloud fixes

### DIFF
--- a/app/assets/stylesheets/pages/instance_type.scss
+++ b/app/assets/stylesheets/pages/instance_type.scss
@@ -30,6 +30,8 @@
             background: $table-bg;
             color: $brand-success;
 
+            cursor: pointer;
+
             margin: 10px;
             padding: 10px;
 

--- a/app/controllers/internal_api/v1/pillars_controller.rb
+++ b/app/controllers/internal_api/v1/pillars_controller.rb
@@ -99,6 +99,7 @@ class InternalApi::V1::PillarsController < InternalApiController
         profiles:  {
           cluster_node: {
             size:                   Pillar.value(pillar: :cloud_worker_type),
+            storage_account:        Pillar.value(pillar: :cloud_storage_account),
             resource_group:         Pillar.value(pillar: :cloud_worker_resourcegroup),
             network_resource_group: Pillar.value(pillar: :cloud_worker_resourcegroup),
             network:                Pillar.value(pillar: :cloud_worker_net),

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -198,7 +198,8 @@ class SetupController < ApplicationController
     cloud_cluster = params.require(:cloud_cluster).permit(
       :subscription_id, :tenant_id, :client_id, :secret,
       :instance_type, :instance_type_custom, :instance_count,
-      :resource_group, :network_id, :subnet_id, :security_group_id
+      :resource_group, :storage_account,
+      :network_id, :subnet_id, :security_group_id
     )
     cloud_cluster["cloud_framework"] = Pillar.value(pillar: :cloud_framework)
     cloud_cluster

--- a/app/models/cloud_cluster.rb
+++ b/app/models/cloud_cluster.rb
@@ -7,7 +7,7 @@ class CloudCluster
     :instance_count, :instance_type, :instance_type_custom, :subnet_id,
     :security_group_id, # EC2 profile
     :subscription_id, :tenant_id, :client_id, :secret, # Azure provider
-    :resource_group, :network_id # Azure profile
+    :storage_account, :resource_group, :network_id # Azure profile
 
   def initialize(*args)
     super
@@ -44,6 +44,7 @@ class CloudCluster
     persist_to_pillar!(:azure_secret, @secret)
     # cloud.profile pillars
     persist_to_pillar!(:cloud_worker_type, @instance_type)
+    persist_to_pillar!(:cloud_storage_account, @storage_account)
     persist_to_pillar!(:cloud_worker_resourcegroup, @resource_group)
     persist_to_pillar!(:cloud_worker_net, @network_id)
     persist_to_pillar!(:cloud_worker_subnet, @subnet_id)

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -64,6 +64,8 @@ class Pillar < ApplicationRecord
           "cloud:providers:azure:client_id",
         azure_secret:
           "cloud:providers:azure:secret",
+        cloud_storage_account:
+          "cloud:profiles:cluster_node:storage_account",
         cloud_worker_type:
           "cloud:profiles:cluster_node:size",
         cloud_worker_subnet:

--- a/app/views/setup/worker_bootstrap_azure.html.slim
+++ b/app/views/setup/worker_bootstrap_azure.html.slim
@@ -31,7 +31,12 @@ h1
         .form-group
           label for="cloud_cluster_secret" Client Secret
           = form.password_field :secret, class: "form-control"
-
+    .panel-footer
+      h4 Tip
+      p
+        ' Questions about services principals? Check out the
+        = link_to("Azure documentation", "https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal")
+        ' .
 
   = render "instance_type_panel",
     form: form,

--- a/app/views/setup/worker_bootstrap_azure.html.slim
+++ b/app/views/setup/worker_bootstrap_azure.html.slim
@@ -49,6 +49,10 @@ h1
           = form.text_field :resource_group, class: "form-control"
       .col-md-3
         .form-group
+          label for="cloud_cluster_storage_account" Storage Account
+          = form.text_field :storage_account, class: "form-control"
+      .col-md-3
+        .form-group
           label for="cloud_cluster_network_id" Network
           = form.text_field :network_id, class: "form-control"
       .col-md-3

--- a/app/views/setup/worker_bootstrap_azure.html.slim
+++ b/app/views/setup/worker_bootstrap_azure.html.slim
@@ -15,19 +15,19 @@ h1
     .panel-heading
       h3.panel-title Service Principal Authentication
     .panel-body
-      .col-md-4
+      .col-lg-3.col-md-6
         .form-group
           label for="cloud_cluster_subscription_id" Subscription ID
           = form.text_field :subscription_id, class: "form-control"
-      .col-md-4
+      .col-lg-3.col-md-6
         .form-group
           label for="cloud_cluster_tenant_id" Tenant ID
           = form.text_field :tenant_id, class: "form-control"
-      .col-md-4
+      .col-lg-3.col-md-6
         .form-group
           label for="cloud_cluster_client_id" Application ID
           = form.text_field :client_id, class: "form-control"
-      .col-md-4
+      .col-lg-3.col-md-6
         .form-group
           label for="cloud_cluster_secret" Client Secret
           = form.password_field :secret, class: "form-control"
@@ -43,19 +43,19 @@ h1
     .panel-heading
       h3.panel-title Resource Scopes
     .panel-body
-      .col-md-3
+      .col-lg-3.col-md-6
         .form-group
           label for="cloud_cluster_resource_group" Resource Group
           = form.text_field :resource_group, class: "form-control"
-      .col-md-3
+      .col-lg-3.col-md-6
         .form-group
           label for="cloud_cluster_storage_account" Storage Account
           = form.text_field :storage_account, class: "form-control"
-      .col-md-3
+      .col-lg-3.col-md-6
         .form-group
           label for="cloud_cluster_network_id" Network
           = form.text_field :network_id, class: "form-control"
-      .col-md-3
+      .col-lg-3.col-md-6
         .form-group
           label for="cloud_cluster_subnet_id" Subnet
           = form.text_field :subnet_id, class: "form-control"

--- a/app/views/setup/worker_bootstrap_ec2.html.slim
+++ b/app/views/setup/worker_bootstrap_ec2.html.slim
@@ -21,11 +21,11 @@ h1
     .panel-heading
       h3.panel-title Networking
     .panel-body
-      .col-md-4
+      .col-lg-3.col-md-6
         .form-group
           label for="cloud_cluster_subnet_id" Subnet ID
           = form.text_field :subnet_id, class: "form-control"
-      .col-md-4
+      .col-lg-3.col-md-6
         .form-group
           label for="cloud_cluster_security_group_id" Security Group ID
           = form.text_field :security_group_id, class: "form-control"

--- a/spec/controllers/internal_api/v1/pillars_controller_spec.rb
+++ b/spec/controllers/internal_api/v1/pillars_controller_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
     let(:resource_group) { "azureresourcegroup" }
     let(:subnet_id) { "azuresubnetname" }
     let(:network_id) { "azurenetworkname" }
+    let(:storage_account) { "azurestorageaccount" }
 
     let(:expected_response) do
       {
@@ -170,6 +171,7 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
           profiles:  {
             cluster_node: {
               size:                   custom_instance_type,
+              storage_account:        storage_account,
               resource_group:         resource_group,
               network_resource_group: resource_group,
               network:                network_id,
@@ -223,6 +225,11 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
         :pillar,
         pillar: "cloud:profiles:cluster_node:resourcegroup",
         value:  resource_group
+      )
+      create(
+        :pillar,
+        pillar: "cloud:profiles:cluster_node:storage_account",
+        value:  storage_account
       )
     end
 

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -226,6 +226,7 @@ RSpec.describe SetupController, type: :controller do
     let(:client_id) { SecureRandom.uuid }
     let(:secret) { SecureRandom.hex(16) }
     let(:resource_group) { "azureresourcegroup" }
+    let(:storage_account) { "azurestorageaccount" }
     let(:subnet_id) { "azuresubnetname" }
     let(:network_id) { "azurenetworkname" }
     let(:cloud_cluster_params) do
@@ -238,7 +239,8 @@ RSpec.describe SetupController, type: :controller do
         instance_count:  instance_count,
         resource_group:  resource_group,
         network_id:      network_id,
-        subnet_id:       subnet_id
+        subnet_id:       subnet_id,
+        storage_account: storage_account
       }
     end
 
@@ -284,6 +286,10 @@ RSpec.describe SetupController, type: :controller do
 
       it "assigns the Azure resource group" do
         expect(assigns(:cloud_cluster).resource_group).to eq(resource_group)
+      end
+
+      it "assigns the Azure storage account" do
+        expect(assigns(:cloud_cluster).storage_account).to eq(storage_account)
       end
 
       it "assigns the Azure network id" do

--- a/spec/models/cloud_cluster_spec.rb
+++ b/spec/models/cloud_cluster_spec.rb
@@ -12,6 +12,7 @@ describe CloudCluster do
   let(:subnet_id) { "subnet-9d4a7b6c" }
   let(:security_group_id) { "sg-903004f8" }
   let(:instance_count) { 5 }
+  let(:storage_account) { "azurestorageaccount" }
 
   it "can implicitly represent a custom instance type" do
     cluster = described_class.new(instance_type_custom: custom_instance_type)
@@ -144,7 +145,8 @@ describe CloudCluster do
         instance_type:   custom_instance_type,
         resource_group:  resource_group,
         network_id:      network_id,
-        subnet_id:       subnet_id
+        subnet_id:       subnet_id,
+        storage_account: storage_account
       )
     end
 
@@ -174,6 +176,13 @@ describe CloudCluster do
         expect(cluster.save).to be(true)
       end
       expect(Pillar.value(pillar: :azure_secret)).to eq(secret)
+    end
+
+    it "stores storage account as :cloud_storage_account Pillar and refreshes" do
+      ensure_pillar_refresh do
+        expect(cluster.save).to be(true)
+      end
+      expect(Pillar.value(pillar: :cloud_storage_account)).to eq(storage_account)
     end
 
     it "stores instance type as :cloud_worker_type Pillar and refreshes" do


### PR DESCRIPTION
* An pillar for Azure storage account name was described as optional in the documentation, but in practice is required.
* Improve the layout of inputs in public cloud forms.
* Add an explanatory link on Azure service principal attributes.