### PR TITLE
Avoid the event processor from crashing if it cannot interpret the event arguments

### DIFF
--- a/app/models/salt_handler/orchestration.rb
+++ b/app/models/salt_handler/orchestration.rb
@@ -18,7 +18,12 @@ class SaltHandler::Orchestration
     fun_args = event_data["fun_args"]
 
     ORCHESTRATIONS.each do |o|
-      return o if [fun_args.first, fun_args.first["mods"]].include? o
+      # rubocop:disable Lint/HandleExceptions
+      begin
+        return o if [fun_args.first, fun_args.first["mods"]].include? o
+      rescue StandardError
+      end
+      # rubocop:enable Lint/HandleExceptions
     end
 
     nil


### PR DESCRIPTION
If we executed: `salt-run state.orchestrate 2` we get an error that crashes the event
processor:

`TypeError: no implicit conversion of String into Integer`

This happens because of `fun_args.first["mods"]` being `2["mods"]`, what makes it
crash with the previous exception. `2.respond_to?(:[])` is `true`, so I think the
best thing we can do here is to swallow the exception, and ignore the event if we
cannot even process its arguments.

Fixes: bsc#1088597