### PR TITLE
[2.1] Avoid the event processor from crashing if it cannot interpret the event arguments

### DIFF
--- a/app/models/salt_handler/minion_orchestration.rb
+++ b/app/models/salt_handler/minion_orchestration.rb
@@ -18,7 +18,12 @@ class SaltHandler::MinionOrchestration
     fun_args = parsed_event_data["fun_args"]
 
     orchestrations.each do |o|
-      return true if fun_args.first == o || fun_args.first["mods"] == o
+      # rubocop:disable Lint/HandleExceptions
+      begin
+        return true if fun_args.first == o || fun_args.first["mods"] == o
+      rescue StandardError
+      end
+      # rubocop:enable Lint/HandleExceptions
     end
 
     false


### PR DESCRIPTION
If we executed: `salt-run state.orchestrate 2` we get an error that crashes the event
processor:

`TypeError: no implicit conversion of String into Integer`

This happens because of `fun_args.first["mods"]` being `2["mods"]`, what makes it
crash with the previous exception. `2.respond_to?(:[])` is `true`, so I think the
best thing we can do here is to swallow the exception, and ignore the event if we
cannot even process its arguments.

Fixes: bsc#1088597

Backport of https://github.com/kubic-project/velum/pull/489