### PR TITLE
Add and run a import_pillar_seeds rake task

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -61,6 +61,11 @@ setup_database() {
   set -e
 }
 
+setup_pillar_seeds() {
+  # Import pillar seeds
+  bundle exec rake velum:import_pillar_seeds
+}
+
 setup_cpi() {
   # Check if Cloud Provider config exists
   CPI_CONFIG="/etc/caasp/cpi/openstack.conf"
@@ -72,5 +77,6 @@ setup_cpi() {
 
 setup_root_ca
 setup_database
+setup_pillar_seeds
 setup_cpi
 bundle exec "puma -C config/puma.rb"


### PR DESCRIPTION
This is a generic rake task that will import seed pillar values from
all files in /etc/caasp/pillar-seeds/.

The format of files in this folder should match:

	# cat /etc/caasp/pillar-seeds/test.yaml
	- pillar: cloud:framework
	  value: openstack

feature#hide-openstack-cpi

Related to https://github.com/kubic-project/caasp-container-manifests/pull/170
Related to https://build.suse.de/request/show/161767