### PR TITLE
node removal: improved way of showing removal links

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -303,6 +303,7 @@ MinionPoller = {
     var checked;
     var masterHtml;
     var actionsHtml;
+    var removalFailedClass = '';
 
     switch(minion.highstate) {
       case "not_applied":
@@ -321,6 +322,7 @@ MinionPoller = {
         MinionPoller.alertFailedBootstrap();
         break;
       case "removal_failed":
+        removalFailedClass = 'removal-failed';
         statusHtml = '<i class="fa fa-minus-circle text-danger fa-2x" aria-hidden="true"></i> Removal Failed';
         break;
       case "applied":
@@ -355,9 +357,9 @@ MinionPoller = {
     }
 
     if (State.pendingRemovalMinionId || State.hasPendingStateNode) {
-      actionsHtml = '<a href="#" class="disabled remove-node-link">Remove</a> | <a href="#" class="disabled force-remove-node-link">Force remove</a>';
+      actionsHtml = '<a href="#" class="disabled remove-node-link">Remove</a><a href="#" class="disabled force-remove-node-link">Force remove</a>';
     } else {
-      actionsHtml = '<a href="#" class="remove-node-link">Remove</a> | <a href="#" class="force-remove-node-link">Force remove</a>';
+      actionsHtml = '<a href="#" class="remove-node-link">Remove</a><a href="#" class="force-remove-node-link">Force remove</a>';
     }
 
     if (minion.minion_id === State.pendingRemovalMinionId) {
@@ -375,7 +377,7 @@ MinionPoller = {
         <td><strong>' + minion.minion_id +  '</strong></td>\
         <td class="minion-hostname">' + minion.fqdn +  '</td>\
         <td>' + masterHtml + minion.role + '</td>\
-        <td class="actions-column" data-id="' + minion.minion_id + '" data-hostname="' + minion.fqdn + '">' + actionsHtml + '</td>\
+        <td class="actions-column ' + removalFailedClass + '" data-id="' + minion.minion_id + '" data-hostname="' + minion.fqdn + '">' + actionsHtml + '</td>\
       </tr>';
   },
 
@@ -911,7 +913,7 @@ function notifyRemovalError(a, b, c) {
 };
 
 function enableOrchTriggers() {
-  $('.actions-column[data-id=' + State.pendingRemovalMinionId + ']').html('<a href="#" class="remove-node-link">Remove</a> | <a href="#" class="remove-node-link">Force remove</a>');
+  $('.actions-column[data-id=' + State.pendingRemovalMinionId + ']').html('<a href="#" class="remove-node-link">Remove</a><a href="#" class="remove-node-link">Force remove</a>');
   $('.remove-node-link').removeClass('disabled');
   $('.force-remove-node-link').removeClass('disabled');
   $('.assign-nodes-link').removeClass('disabled');

--- a/app/assets/stylesheets/pages/nodes_list.scss
+++ b/app/assets/stylesheets/pages/nodes_list.scss
@@ -155,3 +155,19 @@
 #retry-cluster-bootstrap, #retry-cluster-upgrade {
   margin-right: 10px;
 }
+
+.actions-column {
+  &.removal-failed {
+    .force-remove-node-link {
+      display: block;
+    }
+
+    .remove-node-link {
+      display: none;
+    }
+  }
+
+  .force-remove-node-link {
+    display: none;
+  }
+}

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -81,7 +81,7 @@ h1 Cluster Status
                 | Hostname
               th
                 | Role
-              th width="170"
+              th width="130"
                 | Actions
           tbody
 

--- a/spec/features/node_removal_feature_spec.rb
+++ b/spec/features/node_removal_feature_spec.rb
@@ -88,7 +88,7 @@ describe "feature: node removal", js: true do
       expect(page).to have_css(".remove-node-link.disabled", count: Minion.cluster_role.count - 1)
 
       # assign nodes
-      expect(page).to have_css(".assign-nodes-link.disabled")
+      expect(page).not_to have_link("(new)")
 
       # update all nodes
       expect(page).to have_css("#update-all-nodes.hidden", visible: false)
@@ -113,7 +113,7 @@ describe "feature: node removal", js: true do
       expect(page).not_to have_css(".remove-node-link.disabled")
 
       # assign nodes
-      expect(page).not_to have_css(".assign-nodes-link.disabled")
+      expect(page).to have_link("(new)")
 
       # update all nodes
       expect(page).not_to have_css("#update-all-nodes.hidden", visible: false)
@@ -172,6 +172,7 @@ describe "feature: node removal", js: true do
       find(worker_link).click
       minions[1].update!(highstate: "removal_failed")
       expect(page).to have_content("Removal Failed")
+      expect(page).to have_link("Force remove")
     end
 
     it "shows that attempt failed if en exception happens during request" do


### PR DESCRIPTION
'Remove' and 'Force remove' links were being shown at the same time so
far. But 'Force remove' only makes sense to be shown when a previous
removal has failed.

With this we are showing only one link at a time. When the highstate of
a minion is fine, we show 'Remove'. Whenever it comes 'removal_failed',
we show 'Force remove'.

enhancemente#node-removal

Signed-off-by: Vítor Avelino <vavelino@suse.com>

![screenshot-20180419144636-1161x377](https://user-images.githubusercontent.com/188554/39010300-955f74ac-43e4-11e8-807d-b1b917376811.png)
![screenshot-20180419144651-1152x380](https://user-images.githubusercontent.com/188554/39010301-957c8d1c-43e4-11e8-92c2-0921e0548439.png)
![screenshot-20180419144846-1156x331](https://user-images.githubusercontent.com/188554/39010302-9597477e-43e4-11e8-9711-331840da0e2d.png)
