### PR TITLE
Use `update_columns` to update minion attributes with the minion reconciler

### DIFF
--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -15,17 +15,18 @@ class Minion < ApplicationRecord
 
   # Update all minions grains
   def self.update_grains
-    # rubocop:disable Lint/HandleExceptions
+    # rubocop:disable Lint/HandleExceptions, SkipsModelValidations
     Minion.all.find_each do |minion|
       begin
         minion_grains = minion.salt.info
-        minion.tx_update_reboot_needed = minion_grains["tx_update_reboot_needed"] || false
-        minion.tx_update_failed = minion_grains["tx_update_failed"] || false
-        minion.save
+        tx_update_reboot_needed = minion_grains["tx_update_reboot_needed"] || false
+        tx_update_failed = minion_grains["tx_update_failed"] || false
+        minion.update_columns tx_update_reboot_needed: tx_update_reboot_needed,
+                              tx_update_failed:        tx_update_failed
       rescue StandardError
       end
     end
-    # rubocop:enable Lint/HandleExceptions
+    # rubocop:enable Lint/HandleExceptions, SkipsModelValidations
   end
 
   # Example:

--- a/spec/features/node_force_removal_feature_spec.rb
+++ b/spec/features/node_force_removal_feature_spec.rb
@@ -47,7 +47,7 @@ describe "feature: node force removal", js: true do
 
       expect(page).to have_css(worker_selector, text: "Force remove")
       find(worker_link).click
-      click_on "Proceed anyway"
+      click_on "Proceed with forcible removal"
       expect(page).to have_css(worker_selector, text: "Pending removal")
     end
 
@@ -64,9 +64,9 @@ describe "feature: node force removal", js: true do
       master_link = "#{master_selector} .force-remove-node-link"
 
       find(master_link).click
-      expect(page).to have_content("Proceed anyway")
+      expect(page).to have_content("Proceed with forcible removal")
 
-      click_on "Proceed anyway"
+      click_on "Proceed with forcible removal"
       expect(page).to have_css(master_selector, text: "Pending removal")
     end
 
@@ -75,7 +75,7 @@ describe "feature: node force removal", js: true do
       worker_link = "#{worker_selector} .force-remove-node-link"
 
       find(worker_link).click
-      click_on "Proceed anyway"
+      click_on "Proceed with forcible removal"
       minions[1].update!(highstate: "pending_removal")
       expect(page).to have_css(worker_selector, text: "Pending removal")
 
@@ -100,7 +100,7 @@ describe "feature: node force removal", js: true do
       worker_link = "#{worker_selector} .force-remove-node-link"
 
       find(worker_link).click
-      click_on "Proceed anyway"
+      click_on "Proceed with forcible removal"
       minions[1].update!(highstate: "pending_removal")
       expect(page).to have_css(worker_selector, text: "Pending removal")
 
@@ -128,7 +128,7 @@ describe "feature: node force removal", js: true do
       worker_link = "#{worker_selector} .force-remove-node-link"
 
       find(worker_link).click
-      click_on "Proceed anyway"
+      click_on "Proceed with forcible removal"
       minions[1].update!(highstate: "pending_removal")
       expect(page).to have_css(worker_selector, text: "Pending removal")
 
@@ -158,7 +158,7 @@ describe "feature: node force removal", js: true do
 
       expect(page).to have_css(worker_selector, text: "Force remove")
       find(worker_link).click
-      click_on "Proceed anyway"
+      click_on "Proceed with forcible removal"
       expect(page).to have_content("Orchestration currently ongoing. Please wait for it to finish.")
     end
   end
@@ -171,7 +171,7 @@ describe "feature: node force removal", js: true do
 
       expect(page).to have_css(worker_selector, text: "Force remove")
       find(worker_link).click
-      click_on "Proceed anyway"
+      click_on "Proceed with forcible removal"
       minions[1].update!(highstate: "removal_failed")
       expect(page).to have_content("Removal Failed")
     end
@@ -185,7 +185,7 @@ describe "feature: node force removal", js: true do
 
       expect(page).to have_css(worker_selector, text: "Force remove")
       find(worker_link).click
-      click_on "Proceed anyway"
+      click_on "Proceed with forcible removal"
       expect(page).to have_content("An attempt to remove node #{minions[3].minion_id} has failed")
     end
   end


### PR DESCRIPTION
This will avoid strange issues when Rails caches the attributes of the `minions`
table (we also avoid the need to `reload` explicitly for this corner cases).

Fixes: bsc#1091843