### PR TITLE
Prevent double-clicking setup#bootstrap submit in public cloud

### DIFF
--- a/app/assets/javascripts/cloud/bootstrap.js
+++ b/app/assets/javascripts/cloud/bootstrap.js
@@ -62,4 +62,9 @@ $(function() {
 
   // kick things off
   $('input[name="cloud_cluster[instance_type]"][checked="checked"]').click();
+
+  // only submit once
+  $('form#new_cloud_cluster').submit(function(){
+      $(this).find('input[type=submit]').prop('disabled', true);
+  });
 });


### PR DESCRIPTION
Since that actually triggered construction of nodes, we need just a little something to keep the impatient from clicking over & over.

![screenshot from 2018-05-03 11-51-45](https://user-images.githubusercontent.com/108494/39596944-c940e136-4ec8-11e8-8a5c-46012276dd22.png)
