### PR TITLE
[2.1] Fixed misleading text about nodes selection

### DIFF
--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -36,7 +36,9 @@ h1 Select nodes and roles
       i.fa.fa-times.fa-fw
       | Deselect all nodes
   .panel-body
-    p After choosing the master and clicking "Next" all the other selected nodes will be set to the worker role.
+    p
+      | Please choose an odd number of <em>Master</em> nodes, then click "Select remaining nodes"
+      |  to assign the remaining nodes to the <em>Worker</em> role.
 
     = form_tag(setup_discovery_path, method: "post")
       .nodes-container data-url=setup_discovery_path


### PR DESCRIPTION
Small fix of a misleading text that referred to an old behavior of the
nodes discovery page.

bsc#1059787

Signed-off-by: Vítor Avelino <vavelino@suse.com>

(cherry picked from commit 9963ac7625c21fbe3bd609dbab791c9f8b9a9ab3)