### PR TITLE
[3.0] Make the `bin/init` process only do initialization operations

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -1,18 +1,8 @@
 #!/bin/bash
 
-# This script will setup the database and then start the rails application
+# This script will setup the database
 
 set -e
-
-: ${VELUM_PORT:=80}
-
-setup_root_ca() {
-  # Velum is going to need this CA to talk to the running CaaSP Cluster
-  [ -f "/etc/pki/trust/anchors/SUSE_CaaSP_CA.pem" ] && return
-
-  cp /etc/pki/ca.crt /etc/pki/trust/anchors/SUSE_CaaSP_CA.pem
-  update-ca-certificates
-}
 
 setup_database() {
   set +e
@@ -75,8 +65,6 @@ setup_cpi() {
   fi
 }
 
-setup_root_ca
 setup_database
 setup_pillar_seeds
 setup_cpi
-bundle exec "puma -C config/puma.rb"

--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+setup_root_ca() {
+  # Velum is going to need this CA to talk to the running CaaSP Cluster
+  [ -f "/etc/pki/trust/anchors/SUSE_CaaSP_CA.pem" ] && return
+
+  cp /etc/pki/ca.crt /etc/pki/trust/anchors/SUSE_CaaSP_CA.pem
+  update-ca-certificates
+}
+
+setup_root_ca
+bundle exec "puma -C config/puma.rb"


### PR DESCRIPTION
Do not make this script run the puma server. This way, this command
can be run as an init container, leaving the server execution to the
pod definition.

Fixes: bsc#1091843
(cherry picked from commit 1f3adaa64791b1caf11c95717517616a10fad811)