### PR TITLE
Kubelet compute resources

### DIFF
--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -12,6 +12,9 @@ $velum-navbar-toggle-color: white;
   margin-right: -$grid-gutter-width/2;
   padding-left: $grid-gutter-width/2;
   padding-right: $grid-gutter-width/2;
+  position: fixed;
+  width: inherit;
+  z-index: 99;
 
   .navbar-toggle {
     border-color: $velum-navbar-toggle-color;

--- a/app/assets/stylesheets/velum_general.scss
+++ b/app/assets/stylesheets/velum_general.scss
@@ -79,4 +79,8 @@ a.disabled {
   }
 }
 
+.content-wrapper {
+  margin-top: 60px;
+}
+
 @import 'pages/**/*';

--- a/app/controllers/settings/kubelet_compute_resources_reservations_controller.rb
+++ b/app/controllers/settings/kubelet_compute_resources_reservations_controller.rb
@@ -1,0 +1,78 @@
+# Settings::KubeletComputeResourcesReservations is responsibe to manage all the requests
+# related to the kubelet compute resources reservations feature.
+class Settings::KubeletComputeResourcesReservationsController < SettingsController
+  def index
+    @kube_reservations = KubeletComputeResourcesReservation.find_or_initialize_by(
+      component: "kube"
+    )
+    @system_reservations = KubeletComputeResourcesReservation.find_or_initialize_by(
+      component: "system"
+    )
+    @eviction_hard = Pillar.find_or_initialize_by(pillar: "kubelet:eviction-hard")
+  end
+
+  def create
+    @kube_reservations = KubeletComputeResourcesReservation.find_or_initialize_by(
+      component: "kube"
+    )
+    @system_reservations = KubeletComputeResourcesReservation.find_or_initialize_by(
+      component: "system"
+    )
+
+    @kube_reservations.update_attributes(kube_reservation_params)
+    @system_reservations.update_attributes(system_reservation_params)
+    @eviction_hard = Pillar.find_or_initialize_by(pillar: "kubelet:eviction-hard")
+
+    ActiveRecord::Base.transaction do
+      @kube_reservations.save!
+      @system_reservations.save!
+
+      if eviction_hard_param.blank?
+        @eviction_hard.destroy
+        @eviction_hard = Pillar.find_or_initialize_by(pillar: "kubelet:eviction-hard")
+      else
+        @eviction_hard.value = eviction_hard_param
+        @eviction_hard.save!
+      end
+    end
+
+    redirect_to settings_kubelet_compute_resources_reservations_path,
+      notice: "kubelet resource reservations successfully saved."
+  rescue ActiveRecord::RecordInvalid
+    render action: :index, status: :unprocessable_entity
+  end
+
+  private
+
+  def kube_reservation_params
+    ret = {}
+    params.require(
+      :kubelet_compute_resources_reservations
+    ).permit(
+      :kube_cpu,
+      :kube_memory,
+      :kube_ephemeral_storage
+    ).each do |k, v|
+      ret[k.gsub("kube_", "")] = v
+    end
+    ret
+  end
+
+  def system_reservation_params
+    ret = {}
+    params.require(
+      :kubelet_compute_resources_reservations
+    ).permit(
+      :system_cpu,
+      :system_memory,
+      :system_ephemeral_storage
+    ).each do |k, v|
+      ret[k.gsub("system_", "")] = v
+    end
+    ret
+  end
+
+  def eviction_hard_param
+    params["kubelet_compute_resources_reservations"]["eviction_hard"]
+  end
+end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -12,6 +12,10 @@ module SettingsHelper
     request.fullpath.starts_with?(settings_registry_mirrors_path)
   end
 
+  def settings_kubelet_compute_resources_reservations_path?
+    request.fullpath.starts_with?(settings_kubelet_compute_resources_reservations_path)
+  end
+
   def registries_options_for_select
     registries = Registry.suse + Registry.displayable
     registries_for_options = registries.collect { |r| [r.name, r.id] }

--- a/app/models/kubelet_compute_resources_reservation.rb
+++ b/app/models/kubelet_compute_resources_reservation.rb
@@ -1,0 +1,20 @@
+# KubeletComputeResourcesReservation represents the pillar values
+# used to configure kubelet resource reservations.
+class KubeletComputeResourcesReservation < ApplicationRecord
+  BYTES_REGEX = /\A(\d+(e\d+)?([EPTGMK]i?)?)?\z/
+
+  validates :component, inclusion: {
+    in: %w[kube system], message: "%<value>s is not a valid component"
+  }
+  validates :cpu, format: {
+    with: /\A(\d+(\.\d+|m))?\z/, message: "%<value>s format invalid"
+  }
+
+  validates :memory, format: {
+    with: BYTES_REGEX, message: "%<value>s format invalid"
+  }
+
+  validates :ephemeral_storage, format: {
+    with: BYTES_REGEX, message: "%<value>s format invalid"
+  }
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,7 +18,7 @@ html(lang='en')
   body class="#{yield :body_class}"
     .container
       = render :partial => "shared/header"
-      .row
+      .row.content-wrapper
         .col-xs-12.alerts-container
           = render :partial => "shared/notifications"
       .row

--- a/app/views/layouts/settings.html.slim
+++ b/app/views/layouts/settings.html.slim
@@ -20,7 +20,7 @@ html(lang='en')
     .container
       = render partial: "shared/header"
 
-      .row
+      .row.content-wrapper
         .settings-sidebar
           = render partial: "settings/sidebar"
         .col-xs-12.settings-content

--- a/app/views/settings/_sidebar.html.slim
+++ b/app/views/settings/_sidebar.html.slim
@@ -5,3 +5,7 @@ aside.settings-sidebar-section
       = link_to "Remote Registries", settings_registries_path
     li class="#{active_class?(settings_registry_mirrors_path?)}"
       = link_to "Mirrors", settings_registry_mirrors_path
+  h5.title Kubernetes
+  ul.list
+    li class="#{active_class?(settings_kubelet_compute_resources_reservations_path?)}"
+      = link_to "Compute Resources Reservations", settings_kubelet_compute_resources_reservations_path

--- a/app/views/settings/kubelet_compute_resources_reservations/_resources.html.slim
+++ b/app/views/settings/kubelet_compute_resources_reservations/_resources.html.slim
@@ -1,0 +1,34 @@
+.form-group
+  = f.label :cpu, "CPU"
+  = f.text_field "#{reservation.component}_cpu", value: reservation.cpu, class: 'form-control', 'aria-describedby' => "#{reservation.component}_cpu_help"
+  small.form-text.text-muted id="#{reservation.component}_cpu_help"
+    | The amount of CPU units to reserve, as a decimal number or in "millicores" (e.g. 
+    code 100m
+    |  , 
+    code 0.1
+    | ). Leave empty for no CPU reservation.
+
+.form-group
+  = f.label :memory, "Memory"
+  = f.text_field "#{reservation.component}_memory", value: reservation.memory, class: "form-control", 'aria-describedby' => "#{reservation.component}_memory_help"
+  small.form-text.text-muted id="#{reservation.component}_memory_help"
+    | The amount of memory to reserve, measured in bytes (e.g. 
+    code 1024
+    |  , 
+    code 1G
+    |  , 
+    code 1Gi
+    | ). Leave empty for no memory reservation.
+
+.form-group
+  = f.label :storage, "Ephemeral storage"
+  = f.text_field "#{reservation.component}_ephemeral_storage", value: reservation.ephemeral_storage, class: 'form-control', 'aria-describedby' => "#{reservation.component}_ephemeral_storage_help"
+  small.form-text.text-muted id="#{reservation.component}_ephemeral_storage_help"
+    | The amount of ephemeral storage to reserve, measured in bytes (e.g. 
+    code 1024
+    |  , 
+    code 1G
+    |  , 
+    code 1Gi
+    | ). Leave empty for no ephemeral storage reservation.
+

--- a/app/views/settings/kubelet_compute_resources_reservations/index.html.slim
+++ b/app/views/settings/kubelet_compute_resources_reservations/index.html.slim
@@ -1,0 +1,96 @@
+= render 'settings/apply'
+
+- unless @kube_reservations.errors.empty?
+  .alert.alert-danger role='alert'
+    p Error saving reservations for Kubernetes core services:
+    ul
+      - @kube_reservations.errors.messages.map{|k, errs| "#{k}: #{errs.join(',')}"}.each do |msg|
+        li= msg
+
+
+- unless @system_reservations.errors.empty?
+  .alert.alert-danger role='alert'
+    p Error saving reservations for Host system services:
+    ul
+      - @system_reservations.errors.messages.map{|k, errs| "#{k}: #{errs.join(',')}"}.each do |msg|
+        li= msg
+
+- unless @eviction_hard.errors.empty?
+  .alert.alert-danger role='alert'
+    p Error saving eviction hard policies:
+    ul
+      - @eviction_hard.errors.messages.map{|k, errs| "#{k}: #{errs.join(',')}"}.each do |msg|
+        li= msg
+
+.alert.alert-warning role='alert'
+  p Warning: Entering invalid values for any of the following settings will cause
+    the nodes to enter into a broken state.
+
+h2 Compute resources reservations
+
+p Every node of the Kubernetes cluster has a kubelet instance running. By default,
+  the kubelet process will try to use all available resources on each node. This
+  behaviour can lead to resource starvation for critical system services as well
+  as for Kubernetes' own components.
+
+p To prevent this, it is possible to instruct kubelet to reserve a certain
+  amount of resources for the host system and for Kubernetes core services on each node.
+  The Kubernetes scheduler takes these limits into account by when deciding
+  on which node to schedule a certain pod.
+
+= form_for :kubelet_compute_resources_reservations, url: settings_kubelet_compute_resources_reservations_path, method: :post do |f|
+  .panel.panel-default
+
+    .panel-heading
+      h3.panel-title Kubernetes core services
+    .panel-body
+      p This category include processes such as:
+      ul
+        li kubernetes API server
+        li kubernetes controller manager
+        li kubernetes scheduler
+        li kubelet
+        li kube-proxy
+        li Container runtime: Docker daemon, containerd, CRI-O or runc
+
+      = render 'resources', f: f, reservation: @kube_reservations
+
+  .panel.panel-default
+    .panel-heading
+      h3.panel-title Host system services
+    .panel-body
+      p This category include processes such as:
+      ul
+        li Regular system services (eg: sshd, cron, journald,...)
+        li As-yet non-containerized services (eg: etcd)
+
+      = render 'resources', f: f, reservation: @system_reservations
+
+  .panel.panel-default
+    .panel-heading
+      h3.panel-title Eviction threshold
+    .panel-body
+      p If nodes run out of memory, the Out-Of-Memory (OOM) killer will
+        relieve the memory pressure by forcibly killing those containers which are using the most resources
+        and with the lowest quality of service until the system can resume proper behaviour.
+      p Note that nodes undergoing the memory reclamation process can become temporarily
+        unreachable.
+      p To reduce or avoid the risk of this occurring, it is possible to instruct kubelet
+         to start evicting pods as soon as the utilization of some resources
+         (e.g. memory or disk) approaches a critical level.
+
+      .form-group
+        = f.label :eviction_hard, "Hard eviction"
+        = f.text_field :eviction_hard, value: @eviction_hard.value, class: "form-control", 'aria-describedby' => 'eviction_hard_help'
+        small.form-text.text-muted#eviction_hard_help
+          | Eviction policy rules to apply (eg: 
+          code memory.available<10%
+          |  , 
+          code memory.available<100M
+          |  , 
+          code memory.available<500Mi,nodefs.available<10%
+          | ). Leave empty for no hard eviction policy.
+
+
+  .clearfix.text-right.steps-container
+    = submit_tag "Save", id: "save", class: "btn btn-primary pull-right"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
     resources :registries
     post :apply
     resources :registry_mirrors, path: :mirrors
+    resources :kubelet_compute_resources_reservations
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/db/migrate/20180508070232_create_kubelet_compute_resources_reservations.rb
+++ b/db/migrate/20180508070232_create_kubelet_compute_resources_reservations.rb
@@ -1,0 +1,13 @@
+class CreateKubeletComputeResourcesReservations < ActiveRecord::Migration
+  def change
+    create_table :kubelet_compute_resources_reservations do |t|
+      t.string :component, null: false
+      t.string :cpu, default: ''
+      t.string :memory, default: ''
+      t.string :ephemeral_storage, default: ''
+      t.timestamps
+    end
+
+    add_index :kubelet_compute_resources_reservations, :component, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180427014552) do
+ActiveRecord::Schema.define(version: 20180508070232) do
 
   create_table "certificate_services", force: :cascade do |t|
     t.integer  "certificate_id", limit: 4
@@ -35,6 +35,17 @@ ActiveRecord::Schema.define(version: 20180427014552) do
   end
 
   add_index "jids", ["jid"], name: "jid", unique: true, using: :btree
+
+  create_table "kubelet_compute_resources_reservations", force: :cascade do |t|
+    t.string   "component",         limit: 255,              null: false
+    t.string   "cpu",               limit: 255, default: ""
+    t.string   "memory",            limit: 255, default: ""
+    t.string   "ephemeral_storage", limit: 255, default: ""
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "kubelet_compute_resources_reservations", ["component"], name: "index_kubelet_compute_resources_reservations_on_component", unique: true, using: :btree
 
   create_table "minions", force: :cascade do |t|
     t.string   "minion_id",               limit: 255

--- a/packaging/suse/patches/0_set_default_salt_events_alter_time_column_value.rpm.patch
+++ b/packaging/suse/patches/0_set_default_salt_events_alter_time_column_value.rpm.patch
@@ -1,8 +1,8 @@
 diff --git a/db/schema.rb b/db/schema.rb
-index 6551801..9045f5f 100644
+index 1275187..9eb6291 100644
 --- a/db/schema.rb
 +++ b/db/schema.rb
-@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 20180427014552) do
+@@ -106,7 +106,7 @@ ActiveRecord::Schema.define(version: 20180508070232) do
    create_table "salt_events", force: :cascade do |t|
      t.string   "tag",          limit: 255,      null: false
      t.text     "data",         limit: 16777215, null: false
@@ -11,7 +11,7 @@ index 6551801..9045f5f 100644
      t.string   "master_id",    limit: 255,      null: false
      t.datetime "taken_at"
      t.datetime "processed_at"
-@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 20180427014552) do
+@@ -135,7 +135,7 @@ ActiveRecord::Schema.define(version: 20180508070232) do
      t.string   "id",         limit: 255,      null: false
      t.string   "success",    limit: 10,       null: false
      t.text     "full_ret",   limit: 16777215, null: false

--- a/spec/controllers/internal_api/v1/pillars_controller_spec.rb
+++ b/spec/controllers/internal_api/v1/pillars_controller_spec.rb
@@ -13,7 +13,11 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
       registries: [
         url:  Registry::SUSE_REGISTRY_URL,
         cert: nil
-      ]
+      ],
+      kubelet:    {
+        :"compute-resources" => {},
+        :"eviction-hard"     => ""
+      }
     }
   end
 
@@ -65,7 +69,11 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
               }
             ]
           }
-        ]
+        ],
+        kubelet:    {
+          :"compute-resources" => {},
+          :"eviction-hard"     => ""
+        }
       }
     end
 
@@ -90,6 +98,33 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
     end
   end
 
+  context "when contains kubelet resources" do
+
+    let!(:kube_reservation) { create(:kube_resouces_reservation) }
+
+    let(:expected_response) do
+      {
+        registries: [
+        ],
+        kubelet:    {
+          :"compute-resources" => {
+            kube: {
+              cpu: kube_reservation.cpu,
+              memory: kube_reservation.memory,
+              :"ephemeral-storage" => kube_reservation.ephemeral_storage
+            }
+          },
+          :"eviction-hard"     => ""
+        }
+      }
+    end
+
+    it "has remote registries and respective mirrors" do
+      get :show
+      expect(json).to match expected_response
+    end
+  end
+
   context "when in EC2 framework" do
     let(:custom_instance_type) { "custom-instance-type" }
     let(:subnet_id) { "subnet-9d4a7b6c" }
@@ -98,6 +133,10 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
     let(:expected_response) do
       {
         registries: [],
+        kubelet:    {
+          :"compute-resources" => {},
+          :"eviction-hard"     => ""
+        },
         cloud:      {
           framework: "ec2",
           profiles:  {
@@ -158,6 +197,10 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
     let(:expected_response) do
       {
         registries: [],
+        kubelet:    {
+          :"compute-resources" => {},
+          :"eviction-hard"     => ""
+        },
         cloud:      {
           framework: "azure",
           providers: {
@@ -243,6 +286,10 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
     let(:expected_response) do
       {
         registries: [],
+        kubelet:    {
+          :"compute-resources" => {},
+          :"eviction-hard"     => ""
+        },
         cloud:      {
           provider:  "openstack",
           openstack: {

--- a/spec/controllers/settings/kubelet_compute_resources_reservations_controller_spec.rb
+++ b/spec/controllers/settings/kubelet_compute_resources_reservations_controller_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+RSpec.describe Settings::KubeletComputeResourcesReservationsController, type: :controller do
+  let(:user) { create(:user) }
+
+  before do
+    setup_done
+    sign_in user
+  end
+
+  describe "GET #index" do
+    let!(:kube_expected) do
+      create(
+        :kube_resouces_reservation,
+        cpu:               "100m",
+        memory:            "1024",
+        ephemeral_storage: "1G"
+      )
+    end
+
+    let!(:system_expected) do
+      create(
+        :system_resouces_reservation,
+        cpu:               "200m",
+        memory:            "1024Gi",
+        ephemeral_storage: "2M"
+      )
+    end
+
+    let!(:eviction_expected) do
+      e = Pillar.new(
+        pillar: "kubelet:eviction-hard",
+        value:  "memory.available<10%"
+      )
+      e.save
+      e
+    end
+
+    before do
+      get :index
+    end
+
+    it "populates kube reservations" do
+      expect(assigns(:kube_reservations)).to eq(kube_expected)
+    end
+
+    it "populates system reservations" do
+      expect(assigns(:system_reservations)).to eq(system_expected)
+    end
+
+    it "populates eviction hard" do
+      expect(assigns(:eviction_hard)).to eq(eviction_expected)
+    end
+
+  end
+
+  describe "POST #create" do
+    context "when no pre-existing reservations are in place" do
+      let(:kube_cpu) { "100m" }
+      let(:kube_memory) { "100M" }
+      let(:kube_ephemeral_storage) { "1G" }
+
+      let(:system_cpu) { "200m" }
+      let(:system_memory) { "200M" }
+      let(:system_ephemeral_storage) { "2G" }
+
+      let(:eviction_policy) { "memory.available<10%" }
+
+      before do
+        post :create, kubelet_compute_resources_reservations: {
+          kube_cpu:                 kube_cpu,
+          kube_memory:              kube_memory,
+          kube_ephemeral_storage:   kube_ephemeral_storage,
+          system_cpu:               system_cpu,
+          system_memory:            system_memory,
+          system_ephemeral_storage: system_ephemeral_storage,
+          eviction_hard:            eviction_policy
+        }
+      end
+
+      # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      it "saves the kube reservations" do
+        kube_reservations = KubeletComputeResourcesReservation.find_by(
+          component: "kube"
+        )
+        expect(kube_reservations.cpu).to eq(kube_cpu)
+        expect(kube_reservations.memory).to eq(kube_memory)
+        expect(kube_reservations.ephemeral_storage).to eq(kube_ephemeral_storage)
+      end
+
+      it "saves the system reservations" do
+        system_reservations = KubeletComputeResourcesReservation.find_by(
+          component: "system"
+        )
+        expect(system_reservations.cpu).to eq(system_cpu)
+        expect(system_reservations.memory).to eq(system_memory)
+        expect(system_reservations.ephemeral_storage).to eq(system_ephemeral_storage)
+      end
+      # rubocop:enable RSpec/ExampleLength,RSpec/MultipleExpectations
+
+      it "saves the eviction policy" do
+        eviction_hard = Pillar.find_by(pillar: "kubelet:eviction-hard")
+        expect(eviction_hard.value).to eq(eviction_policy)
+      end
+    end
+
+    context "when an eviction policy is already defined" do
+      before do
+        Pillar.new(
+          pillar: "kubelet:eviction-hard",
+          value:  "memory.available<10%"
+        ).save
+      end
+
+      it "removes the eviction policy when an empty value is given" do
+        post :create, kubelet_compute_resources_reservations: {
+          eviction_hard: ""
+        }
+
+        expect(Pillar.find_by(pillar: "kubelet:eviction-hard")).to be_nil
+      end
+    end
+
+    it "send a 422 response when validation fails" do
+      post :create, kubelet_compute_resources_reservations: {
+        kube_cpu: "hello"
+      }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/factories/kubelet_compute_resources_reservation.rb
+++ b/spec/factories/kubelet_compute_resources_reservation.rb
@@ -1,0 +1,14 @@
+FactoryGirl.define do
+  factory :kube_resouces_reservation, class: KubeletComputeResourcesReservation do
+    sequence(:cpu) { |n| "#{n}m" }
+    sequence(:memory) { |n| "#{n}M" }
+    sequence(:ephemeral_storage) { |n| "#{n}Gi" }
+    component "kube"
+  end
+  factory :system_resouces_reservation, class: KubeletComputeResourcesReservation do
+    sequence(:cpu) { |n| "#{n}m" }
+    sequence(:memory) { |n| "#{n}M" }
+    sequence(:ephemeral_storage) { |n| "#{n}Gi" }
+    component "system"
+  end
+end

--- a/spec/models/kubelet_compute_resources_reservation_spec.rb
+++ b/spec/models/kubelet_compute_resources_reservation_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+describe KubeletComputeResourcesReservation, type: :model do
+
+  it { is_expected.not_to validate_presence_of(:cpu) }
+  it { is_expected.not_to validate_presence_of(:memory) }
+  it { is_expected.not_to validate_presence_of(:ephemeral_storage) }
+
+  describe "#cpu_validations" do
+    let(:reservation) { KubeletComputeResourcesReservation.new(component: "kube") }
+
+    it "allows numbers with digits" do
+      reservation.cpu = "0.1"
+      expect(reservation.valid?).to be true
+    end
+
+    it "does not allow numbers without digits" do
+      reservation.cpu = "1"
+      expect(reservation.valid?).to be false
+    end
+
+    it "allows millicpu format" do
+      reservation.cpu = "100m"
+      expect(reservation.valid?).to be true
+    end
+
+    it "does not allow to mix millicpu format and digits" do
+      reservation.cpu = "100.0m"
+      expect(reservation.valid?).to be false
+    end
+  end
+
+  describe "#bytes_validations" do
+    let(:reservation) { KubeletComputeResourcesReservation.new(component: "kube") }
+
+    it "allows numbers without suffix" do
+      reservation.memory = "1024"
+      reservation.ephemeral_storage = "1024"
+
+      expect(reservation.valid?).to be true
+    end
+
+    it "does not allow numbers with digits" do
+      reservation.memory = "1024.1"
+      reservation.ephemeral_storage = "1024.1"
+
+      expect(reservation.valid?).to be false
+    end
+
+    it "allows numbers with e-notation" do
+      reservation.memory = "129e6"
+      reservation.ephemeral_storage = "129e6"
+
+      expect(reservation.valid?).to be true
+    end
+
+    it "allows numbers with valid suffixes" do
+      %w[E P T G M K Ei Pi Ti Gi Mi Ki].each do |suffix|
+        reservation.memory = "1024#{suffix}"
+        reservation.ephemeral_storage = "1024#{suffix}"
+
+        expect(reservation.valid?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow users to provide values for the kubelet compute resources reservations and hard eviction policies.

This is, together with https://github.com/kubic-project/salt/pull/518, fixes [bsc#1086185](https://bugzilla.suse.com/show_bug.cgi?id=1086185).

The pull request is composed by two commits:

  * The first commit introduces all the pillars required by the feature and exposes them through the internal API of velum. This is mandatory to get the bug fix
  * The second commit is a quick attempt at introducing a new UI to handle these parameters. I have quite some questions about the UI. These are complex tasks, I tried to rephrase what the [kubernetes official documentation](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources) says. However I'm looking for feedback, especially from @ajaeger, @eotchi, @lproven and others.

Mandatory screenshot of the proposed UI:

![screenshot-2018-5-8 velum](https://user-images.githubusercontent.com/22728/39767535-4d1cf61c-52e7-11e8-8293-e7cb06463c17.png)
