### PR TITLE
Mark admin as updated when we are going to reboot it

### DIFF
--- a/app/controllers/updates_controller.rb
+++ b/app/controllers/updates_controller.rb
@@ -6,6 +6,9 @@ class UpdatesController < ApplicationController
 
   # Reboot the admin node.
   def create
+    # rubocop:disable SkipsModelValidations
+    Minion.admin.update_all highstate: Minion.highstates[:applied]
+    # rubocop:enable SkipsModelValidations
     ::Velum::Salt.call(
       action:  "cmd.run",
       targets: "admin",


### PR DESCRIPTION
This ensures that when the admin is back, the status of the minion on
the database will match the grains from the very beginning, without
having to rely on the background task updating all minions (including
the admin) update status.

Fixes: bsc#1092910