### PR TITLE
emphasize settings apply workflow

### DIFF
--- a/app/assets/stylesheets/velum_bootstrap-variables.sass
+++ b/app/assets/stylesheets/velum_bootstrap-variables.sass
@@ -21,7 +21,6 @@
 $brand-success:         #04a36f
 // $brand-info:            #5bc0de
 // $brand-warning:         #f0ad4e
-$brand-warning:         #d9534f
 // $brand-danger:          #d9534f
 
 
@@ -182,9 +181,7 @@ $btn-success-border:             #ccc
 
 // $btn-warning-color:              #fff
 // $btn-warning-bg:                 $brand-warning
-$btn-warning-bg:                 $brand-warning
 // $btn-warning-border:             darken($btn-warning-bg, 5%)
-$btn-warning-border:             #d43f3a
 
 // $btn-danger-color:               #fff
 // $btn-danger-bg:                  $brand-danger

--- a/app/views/settings/_apply.html.slim
+++ b/app/views/settings/_apply.html.slim
@@ -1,6 +1,6 @@
-.alert.alert-info.alert-with-btn-sm.clearfix role="alert"
+.alert.alert-warning.alert-with-btn-sm.clearfix role="alert"
   .left
     | Changes are not immediately reflected. You might want to apply it.
 
   .right
-    = button_to "Apply changes", settings_apply_path, class: "btn btn-info btn-sm pull-right"
+    = button_to "Apply changes", settings_apply_path, class: "btn btn-danger btn-sm pull-right"


### PR DESCRIPTION
the warning that any changes are not immediately applied should be
more visible

a blue flash message background with a blue button is not visible
enough

settings-ui#apply

Signed-off-by: Maximilian Meister <mmeister@suse.de>

### before

![apply-before](https://user-images.githubusercontent.com/5364817/40039698-ae52daa2-5817-11e8-902a-b273e975fe92.png)

### after

![apply-danger](https://user-images.githubusercontent.com/5364817/40061762-f41ec93c-5859-11e8-9572-44c1c9f8fbf4.png)

### alternatively

![apply-warning](https://user-images.githubusercontent.com/5364817/40061643-b495decc-5859-11e8-8d75-ca722ac0ac36.png)

![apply-red-blue](https://user-images.githubusercontent.com/5364817/40061911-4630c324-585a-11e8-82ee-b1a09d96250c.png)

![warning](https://user-images.githubusercontent.com/5364817/40062000-73f32dba-585a-11e8-9eac-49993106197b.png)
