### PR TITLE
Redirect to registry page instead of mirror when editing a registry.

### DIFF
--- a/app/views/settings/registries/_form.html.slim
+++ b/app/views/settings/registries/_form.html.slim
@@ -16,4 +16,4 @@
 
   .form-actions.clearfix
     = f.submit "Save", class: "btn btn-primary action"
-    = link_to "Cancel", settings_registry_mirrors_path, class: "btn btn-default action"
+    = link_to "Cancel", settings_registries_path, class: "btn btn-default action"


### PR DESCRIPTION
Fixes incorrect redirect: when cancelling an edit to a `registry`, it redirected to the `registry_mirror` list.