### PR TITLE
Redirect to registry page instead of mirror when editing a registry.

### DIFF
--- a/app/views/settings/registries/_form.html.slim
+++ b/app/views/settings/registries/_form.html.slim
@@ -16,4 +16,4 @@
 
   .form-actions.clearfix
     = f.submit "Save", class: "btn btn-primary action"
-    = link_to "Cancel", settings_registry_mirrors_path, class: "btn btn-default action"
+    = link_to "Cancel", settings_registries_path, class: "btn btn-default action"


### PR DESCRIPTION
Backport of https://github.com/kubic-project/velum/pull/534

(cherry picked from commit 9c31386051eadbd589b1eaa114da4889b6840ca8)