### PR TITLE
Allow override of CNI related pillars

### DIFF
--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -28,6 +28,8 @@ class Pillar < ApplicationRecord
         cluster_cidr_len:              "cluster_cidr_len",
         flannel_backend:               "flannel:backend",
         flannel_port:                  "flannel:port",
+        cni_plugin:                    "cni:plugin",
+        cilium_image:                  "cilium:image",
         services_cidr:                 "services_cidr",
         api_cluster_ip:                "api:cluster_ip",
         dns_cluster_ip:                "dns:cluster_ip",


### PR DESCRIPTION
Make Velum aware of some pillars related with CNI/cilium. That makes
possible to switch to cilium.

No UI is needed for that right now.

feature#cilium-selected-preview-on-v3

(cherry picked from commit dc2884b260b2cbacfabc4d0ede5d2ae153f56f38)