### PR TITLE
ui: show kubectl config download link on auth page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,15 @@ module ApplicationHelper
     Pillar.exists? pillar: Pillar.all_pillars[:apiserver]
   end
 
+  def can_download_kubeconfig?
+    masters_applied_count = Minion.where(role:      Minion.roles[:master],
+                                         highstate: Minion.highstates[:applied]).count
+    masters_count = Minion.where(role: Minion.roles[:master]).count
+    masters_applied = masters_count == masters_applied_count
+
+    setup_done? && masters_applied
+  end
+
   def active_class?(path_or_bool)
     case path_or_bool
     when String

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -52,9 +52,9 @@ h1 Cluster Status
     .panel-heading
       h3.panel-title Nodes
 
-      = link_to kubectl_config_path, id: "download-kubeconfig", class: "btn btn-sm btn-default pull-right", disabled: true do
+      = link_to kubeconfig_path, id: "download-kubeconfig", class: "btn btn-sm btn-default pull-right", disabled: true do
         i.fa.fa-download.fa-fw
-        | kubectl config
+        | kubeconfig
 
       = link_to orchestrations_bootstrap_path, method: :post, id: "retry-cluster-bootstrap", class: "hidden btn btn-sm btn-primary pull-right" do
         i.fa.fa-refresh.fa-fw

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -12,6 +12,11 @@
         | Don't have an account?
         a.btn.btn-default[href="/users/sign_up"]
           | Create an account
+    - if can_download_kubeconfig?
+      p
+        | Do you need the kubeconfig file?
+        = link_to kubeconfig_path, id: "download-kubeconfig", class: "btn btn-default" do
+          | Download kubeconfig
   .col-sm-4.col-sm-offset-1
     h2.Raleway-font
       | Log In

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,8 @@ Rails.application.routes.draw do
   end
 
   get "/autoyast", to: "dashboard#autoyast"
-  get "/kubectl-config", to: "oidc#index"
+  get "/kubectl-config", to: redirect("/kubeconfig") # deprecated
+  get "/kubeconfig", to: "oidc#index"
   get "/_health", to: "health#index"
   post "/update", to: "salt#update"
   post "/accept-minion", to: "salt#accept_minion"


### PR DESCRIPTION
Some people that are not the admin user need the kubectl config file.
This link is only accessible in the dashboard page.

This patch shows s a link on for anonymous users on the authentication
page.

bsc#1093528

Signed-off-by: Vítor Avelino <vavelino@suse.com>
(cherry picked from commit 53124228fc1ad3ab570aa4be353a1fc1f6b1cd8d)