### PR TITLE
js: removal of pending acceptance state

### DIFF
--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -108,6 +108,26 @@ describe "Bootstrap cluster feature" do
       expect(page).to have_content("Accept Node")
     end
 
+    it "removes node from pending acceptance state if accepted", js: true do
+      setup_stubbed_pending_minions!(stubbed: [minions[3].minion_id])
+      allow(::Velum::Salt).to receive(:accept_minion)
+
+      visit setup_discovery_path
+
+      expect(page).to have_content("Accept Node")
+      click_on("Accept Node")
+
+      expect(page).to have_content("Acceptance in progress")
+      is_pending = evaluate_script("hasPendingAcceptance('#{minions[3].minion_id}')")
+      expect(is_pending).to be true
+
+      setup_stubbed_pending_minions!
+
+      expect(page).not_to have_content("Acceptance in progress")
+      is_pending = evaluate_script("hasPendingAcceptance('#{minions[3].minion_id}')")
+      expect(is_pending).to be false
+    end
+
     it "A user selects a subset of nodes to be bootstrapped", js: true do
       # select master minion0.k8s.local
       find(".minion_#{minions[0].id} .master-btn").click


### PR DESCRIPTION
We are storing the minion id in session storage while it goes under
pending acceptance state. However we were not handling its removal if
the acceptance succeeded or if an error happened after the request.

This patch fixes those scenarios avoiding unwanted user experiences.

bsc#1093869

Signed-off-by: Vítor Avelino <vavelino@suse.com>
(cherry picked from commit a660c5b273befe3427f04036719c035fcf0635e1)