### PR TITLE
[WIP] Add Openstack Keystone Trust ID option for Kubernetes CPI, bsc#1094196

### DIFF
--- a/app/controllers/internal_api/v1/pillars_controller.rb
+++ b/app/controllers/internal_api/v1/pillars_controller.rb
@@ -137,6 +137,7 @@ class InternalApi::V1::PillarsController < InternalApiController
           auth_url:       Pillar.value(pillar: :cloud_openstack_auth_url),
           username:       Pillar.value(pillar: :cloud_openstack_username),
           password:       Pillar.value(pillar: :cloud_openstack_password),
+          trust_id:       Pillar.value(pillar: :cloud_openstack_trust_id),
           domain:         Pillar.value(pillar: :cloud_openstack_domain),
           domain_id:      Pillar.value(pillar: :cloud_openstack_domain_id),
           project:        Pillar.value(pillar: :cloud_openstack_project),

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -46,6 +46,7 @@ class SetupController < ApplicationController
     @cloud_openstack_region = Pillar.value(pillar: :cloud_openstack_region)
     @cloud_openstack_username = Pillar.value(pillar: :cloud_openstack_username)
     @cloud_openstack_password = Pillar.value(pillar: :cloud_openstack_password)
+    @cloud_openstack_trust_id = Pillar.value(pillar: :cloud_openstack_trust_id)
     @cloud_openstack_subnet = Pillar.value(pillar: :cloud_openstack_subnet)
     @cloud_openstack_floating = Pillar.value(pillar: :cloud_openstack_floating)
     @cloud_openstack_lb_mon_retries = Pillar.value(pillar: :cloud_openstack_lb_mon_retries) || "3"

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -118,6 +118,8 @@ class Pillar < ApplicationRecord
           "cloud:openstack:username",
         cloud_openstack_password:
           "cloud:openstack:password",
+        cloud_openstack_trust_id:
+          "cloud:openstack:trust_id",
         cloud_openstack_subnet:
           "cloud:openstack:subnet",
         cloud_openstack_floating:

--- a/app/views/setup/cloud/_openstack_configuration.html.slim
+++ b/app/views/setup/cloud/_openstack_configuration.html.slim
@@ -26,6 +26,9 @@
     = f.label :cloud_openstack_password, "Password"
     = f.password_field :cloud_openstack_password, value: @cloud_openstack_password, class: "form-control"
   .form-group
+    = f.label :cloud_openstack_trust_id, "Trust ID"
+    = f.text_field :cloud_openstack_trust_id, value: @cloud_openstack_trust_id, class: "form-control"
+  .form-group
     = f.label :cloud_openstack_subnet, "Subnet UUID for the #{product_name} private network"
     = f.text_field :cloud_openstack_subnet, value: @cloud_openstack_subnet, class: "form-control"
   .form-group

--- a/lib/tasks/cpi.rake
+++ b/lib/tasks/cpi.rake
@@ -23,6 +23,7 @@ namespace :cpi do
       when "region" then              cfg["cloud:openstack:region"] = value
       when "username" then            cfg["cloud:openstack:username"] = value
       when "password" then            cfg["cloud:openstack:password"] = value
+      when "trust_id" then            cfg["cloud:openstack:trust_id"] = value
       when "subnet-id" then           cfg["cloud:openstack:subnet_id"] = value
       when "floating-network-id" then cfg["cloud:openstack:floating_id"] = value
       when "monitor-max-retries" then cfg["cloud:openstack:lb_mon_retries"] = value

--- a/spec/controllers/internal_api/v1/pillars_controller_spec.rb
+++ b/spec/controllers/internal_api/v1/pillars_controller_spec.rb
@@ -319,6 +319,7 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
             auth_url:       "http://keystone-test-host:5000/v3",
             username:       "testuser",
             password:       "pass",
+            trust_id:       "99905e50d80749b5a24292e830fff10c",
             domain:         "test",
             domain_id:      "9bc3e819a6ca648bb5e3c26c9e6c5e57",
             project:        "prj",


### PR DESCRIPTION
Add OpenStack Keystone Trust ID option for Kubernetes cloudprovider driver
to avoid storing user credentials.

More about OpenStack Keystone Trust you can find here
https://wiki.openstack.org/wiki/Keystone/Trusts

Option name added to CaaSP is "trust-id"