### PR TITLE
Removing systemd dependency

### DIFF
--- a/packaging/suse/velum.spec.in
+++ b/packaging/suse/velum.spec.in
@@ -36,14 +36,9 @@ Group:          System/Management
 %define velumdir /srv/velum
 
 Requires:       ruby >= 2.1
-%if 0%{?suse_version} >= 1210
-BuildRequires: systemd-rpm-macros
-%endif
 BuildRequires:  fdupes
 BuildRequires:  gcc-c++
 BuildRequires:  ruby-macros >= 5
-%{?systemd_requires}
-Provides:       velum = %{version}
 Obsoletes:      velum < %{version}
 # javascript engine to build assets
 BuildRequires:  nodejs


### PR DESCRIPTION
I can't see why systemd is required in velum, as it is mostly used within a container and also no unit files are provided... Probably I am missing something, but to me this dependency looks like some kind of leftover.