### PR TITLE
[3.0] show apply button after each setting creation

### DIFF
--- a/app/views/settings/registries/show.html.slim
+++ b/app/views/settings/registries/show.html.slim
@@ -1,3 +1,5 @@
+= render 'settings/apply'
+
 header.settings-content-header.clearfix
   .title.pull-left
     h2 #{@certificate_holder.name} registry details

--- a/app/views/settings/registry_mirrors/show.html.slim
+++ b/app/views/settings/registry_mirrors/show.html.slim
@@ -1,3 +1,5 @@
+= render 'settings/apply'
+
 header.settings-content-header.clearfix
   .title.pull-left
     h2 #{@certificate_holder.name} mirror details

--- a/app/views/settings/system_certificates/show.html.slim
+++ b/app/views/settings/system_certificates/show.html.slim
@@ -1,3 +1,5 @@
+= render 'settings/apply'
+
 header.settings-content-header.clearfix
   .title.pull-left
     h2 #{@certificate_holder.name} certificate details


### PR DESCRIPTION
it makes sense to offer the apply button directly after a user has
created a new setting

otherwise you have to navigate back to the setting index which is
not a good UX because it's hidden

in many cases a user just wants to create one setting and then
immediately apply

settings#apply-on-create

Signed-off-by: Maximilian Meister <mmeister@suse.de>
(cherry picked from commit f7d227d4879e83670205a5b1b5ace65ab70afd49)

backport of https://github.com/kubic-project/velum/pull/553