### PR TITLE
ux: toggle domain/project id/name inputs

### DIFF
--- a/app/assets/javascripts/setup/openstack.js
+++ b/app/assets/javascripts/setup/openstack.js
@@ -1,0 +1,36 @@
+(function (window) {
+  var dom = {
+    NAME_INPUTS: '#settings_cloud_openstack_domain, #settings_cloud_openstack_project',
+    ID_INPUTS: '#settings_cloud_openstack_domain_id, #settings_cloud_openstack_project_id',
+  };
+
+  function OpenStackSettings(el) {
+    this.$el = $(el);
+
+    this.$idInputs = this.$el.find(dom.ID_INPUTS);
+    this.$nameInputs = this.$el.find(dom.NAME_INPUTS);
+
+    this.events();
+  }
+
+  OpenStackSettings.prototype.events = function () {
+    this.$el.on('input', dom.ID_INPUTS, this.onIdInputs.bind(this));
+    this.$el.on('input', dom.NAME_INPUTS, this.onNameInputs.bind(this));
+  }
+
+  OpenStackSettings.prototype.onIdInputs = function (e) {
+    this.$nameInputs.prop('disabled', !this.isEmpty(this.$idInputs));
+  }
+
+  OpenStackSettings.prototype.onNameInputs = function (e) {
+    this.$idInputs.prop('disabled', !this.isEmpty(this.$nameInputs));
+  }
+
+  OpenStackSettings.prototype.isEmpty = function (els) {
+    var value = $.map(els, function (el) { return el.value }).join('');
+
+    return value.length === 0;
+  }
+
+  window.OpenStackSettings = OpenStackSettings;
+}(window));

--- a/app/assets/javascripts/setup/setup.js
+++ b/app/assets/javascripts/setup/setup.js
@@ -27,4 +27,5 @@ $(function() {
   });
 
   new SUSERegistryMirrorPanel('.suse-mirror-panel-body');
+  new OpenStackSettings('.openstack-settings');
 });


### PR DESCRIPTION
Whenever the user wants to configure openstack domain/project id/name,
they cannot fill both cases. To prevent that we are disabling the
respective opposite fields when one of the fields is filled.

bsc#1091809 ui improvement

Signed-off-by: Vítor Avelino <vavelino@suse.com>

![peek 2018-05-24 15-35](https://user-images.githubusercontent.com/188554/40505218-e9516f2a-5f69-11e8-8c4a-0d50ae4fce57.gif)