### PR TITLE
Revert "Allow users to choose flannel's backend"

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -51,10 +51,6 @@ class SetupController < ApplicationController
     @cloud_openstack_lb_mon_retries = Pillar.value(pillar: :cloud_openstack_lb_mon_retries) || "3"
     @cloud_openstack_bs_version = Pillar.value(pillar: :cloud_openstack_bs_version) || "v2"
 
-    # flannel settings
-    @flannel_backend = Pillar.value(pillar: :flannel_backend) || "vxlan"
-    @flannel_port = Pillar.value(pillar: :flannel_port) || "8472"
-
     # container runtime setting
     @cri = Pillar.value(pillar: :container_runtime) || "docker"
 

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -26,8 +26,6 @@ class Pillar < ApplicationRecord
         cluster_cidr_min:              "cluster_cidr_min",
         cluster_cidr_max:              "cluster_cidr_max",
         cluster_cidr_len:              "cluster_cidr_len",
-        flannel_backend:               "flannel:backend",
-        flannel_port:                  "flannel:port",
         cni_plugin:                    "cni:plugin",
         cilium_image:                  "cilium:image",
         services_cidr:                 "services_cidr",

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -70,24 +70,6 @@ h1 Initial CaaS Platform Configuration
 
         hr
 
-        .form-group
-          = f.label :flannel_backend, "Flannel backend"
-          = f.select :flannel_backend, options_for_select([["VXLAN", "vxlan"], ["UDP", "udp"]], @flannel_backend), {}, {class: "form-control", 'aria-describedby' => "flannel_backend_help"}
-          small.form-text.text-muted#flannel_backend_help
-            | The backend used by Flannel to encapsulate network traffic. VXLAN is the recommended choice.
-
-        .form-group
-          = f.label :flannel_port, "Flannel port"
-          = f.text_field :flannel_port, value: @flannel_port, class: "form-control", required: true, 'aria-describedby' => "flannel_port_help"
-          small.form-text.text-muted#flannel_port_help
-            | The port used by Flannel to encapsulate network traffic. 
-            code 8472
-            |  is the recommended port for the VXLAN backend. 
-            code 8285
-            |  is the recommended port for the UDP backend.
-
-        hr
-
         p The Service Network is used internally within Kubernetes for pod to service communications. Each Kubernetes service will be allocated an IP from this range, this IP will be independant of any single master or worker. This network range will not be accessible from outside the cluster, however, conflicts with preexisting address ranges used elsewhere should be avoided.
 
         .form-group


### PR DESCRIPTION
This reverts commit 99550aacb6b7c5bfa48545005039c743aa2ee853.

It turns out it's possible to use the VXLAN backend to create clusters
over segmented networks.

feature#revert-UDP-selection-UI