### PR TITLE
ui: show proper update failed message and reboot button

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -288,23 +288,25 @@ MinionPoller = {
   handleAdminUpdate: function(admin) {
     var $notification = $('.admin-outdated-notification');
 
-    if (State.hasPendingStateNode ||
-        State.pendingRemovalMinionId) {
+    if (State.hasPendingStateNode || State.pendingRemovalMinionId) {
       State.updateAdminNode = false;
       return;
     }
 
+    var updateFlag = admin.tx_update_reboot_needed || admin.tx_update_failed;
+
+    State.updateAdminNode = updateFlag;
+    $notification.toggleClass('hidden', !updateFlag);
+
+    $notification.removeClass('admin-outdated-notification--reboot');
+    $notification.removeClass('admin-outdated-notification--failed');
+
     if (admin.tx_update_reboot_needed) {
-      State.updateAdminNode = true;
-      $notification.removeClass('hidden');
-      $notification.removeClass('admin-outdated-notification--failed');
-    } else if (admin.tx_update_failed) {
-      State.updateAdminNode = true;
-      $notification.removeClass('hidden');
+      $notification.addClass('admin-outdated-notification--reboot');
+    }
+
+    if (admin.tx_update_failed) {
       $notification.addClass('admin-outdated-notification--failed');
-    } else {
-      State.updateAdminNode = false;
-      $notification.addClass('hidden');
     }
   },
 

--- a/app/assets/stylesheets/pages/nodes_list.scss
+++ b/app/assets/stylesheets/pages/nodes_list.scss
@@ -98,6 +98,7 @@
 
     .btn-link {
       font-weight: bold;
+      visibility: hidden;
     }
   }
 
@@ -107,9 +108,18 @@
     vertical-align: middle;
   }
 
+  &--reboot {
+    .actions .btn-link {
+      visibility: visible;
+    }
+  }
+
   &--failed {
     background-color: #f2dede;
-    color: #a94442;
+
+    &, .btn-link {
+      color: #a94442;
+    }
 
     .message {
       display: none;

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -42,7 +42,7 @@ h1 Cluster Status
         strong Admin node is running outdated software
       .failed-message
         i.fa.fw.fa-exclamation-circle
-        strong Admin node is running outdated software (failed to update)
+        strong An error occurred during the admin node update process
       .actions
         a.btn.btn-link.update-admin-btn data-toggle="modal" data-target=".update-admin-modal"
           | Update admin node

--- a/spec/features/admin_node_update_feature_spec.rb
+++ b/spec/features/admin_node_update_feature_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Manage nodes updates feature" do
+describe "Manage nodes updates feature", js: true do
   let!(:user) { create(:user) }
 
   before do
@@ -10,7 +10,7 @@ describe "Manage nodes updates feature" do
     setup_stubbed_pending_minions!
   end
 
-  it "Admin node has no update available", js: true do
+  it "Admin node has no update available" do
     visit authenticated_root_path
 
     expect(page).not_to have_content("Update admin node")
@@ -25,14 +25,11 @@ describe "Manage nodes updates feature" do
       visit authenticated_root_path
     end
 
-    it "Admin node has an update available", js: true do
+    it "Admin node has an update available" do
       expect(page).to have_content("Admin node is running outdated software")
     end
 
-    it "User clicks on admin 'Update admin node'", js: true do
-      expect(page).not_to have_content("Reboot to update")
-
-      # clicks on "Update admin node"
+    it "User clicks on admin 'Update admin node'" do
       find(".update-admin-btn").click
 
       expect(page).to have_content("The admin node needs to reboot "\
@@ -41,10 +38,9 @@ describe "Manage nodes updates feature" do
     end
 
     # rubocop:disable RSpec/ExampleLength
-    it "User clicks on 'Reboot to update'", js: true do
+    it "User clicks on 'Reboot to update'" do
       allow(::Velum::Salt).to receive(:call).and_return(true)
 
-      # clicks on "Update admin node"
       find(".update-admin-btn").click
 
       # wait modal to appear
@@ -60,13 +56,25 @@ describe "Manage nodes updates feature" do
     # rubocop:enable RSpec/ExampleLength
   end
 
-  it "Admin node has an update available (failed to update)", js: true do
+  it "shows admin update failed message" do
     # rubocop:disable Rails/SkipsModelValidations
     Minion.where(minion_id: "admin").update_all(tx_update_reboot_needed: false,
                                                 tx_update_failed:        true)
     # rubocop:enable Rails/SkipsModelValidations
     visit authenticated_root_path
 
-    expect(page).to have_content("Admin node is running outdated software (failed to update)")
+    expect(page).to have_content("An error occurred during the admin node update process")
+    expect(page).not_to have_content("UPDATE ADMIN NODE")
+  end
+
+  it "shows admin update failed message and update button" do
+    # rubocop:disable Rails/SkipsModelValidations
+    Minion.where(minion_id: "admin").update_all(tx_update_reboot_needed: true,
+                                                tx_update_failed:        true)
+    # rubocop:enable Rails/SkipsModelValidations
+    visit authenticated_root_path
+
+    expect(page).to have_content("An error occurred during the admin node update process")
+    expect(page).to have_content("UPDATE ADMIN NODE")
   end
 end


### PR DESCRIPTION
Changed update failed error message stating a generic state instead of
saying that the update failed itself.

Update admin node link only showing if `tx_update_reboot_needed` flag is
truthy. Otherwise keeps it hidden.

bsc#1082786

Signed-off-by: Vítor Avelino <vavelino@suse.com>

![10 17 1 0_ 2](https://user-images.githubusercontent.com/188554/40716432-62419d82-63df-11e8-8688-58bde7cbf731.png)
![10 17 1 0_ 1](https://user-images.githubusercontent.com/188554/40716433-62745664-63df-11e8-8517-56e63107eae9.png)
![10 17 1 0_](https://user-images.githubusercontent.com/188554/40716434-6299fdd8-63df-11e8-95fc-cbfc2f188de1.png)
