### PR TITLE
ui: added placeholder for mirror registry blank option

### DIFF
--- a/app/views/settings/registry_mirrors/_form.html.slim
+++ b/app/views/settings/registry_mirrors/_form.html.slim
@@ -3,7 +3,7 @@
     = f.label :registry_id, "Mirror of"
     .row
       .col-xs-4
-        = f.select :registry_id, registries_options_for_select, { include_blank: true }, class: "form-control registry-select", required: true, disabled: !@certificate_holder.new_record?
+        = f.select :registry_id, registries_options_for_select, { prompt: "Select a registry" }, class: "form-control registry-select", required: true, disabled: !@certificate_holder.new_record?
       - if @certificate_holder.new_record?
         .col-xs-8
           = link_to "Create new registry", new_settings_registry_path, class: "btn btn-primary add-entry-btn hide"


### PR DESCRIPTION
The default blank option for the registry on the mirror creation form
was confusing. To keep the same experience with the "Create new
registry" button, the solution was to simply add "Select a registry"
text to work as a placeholder.

bsc#1095255

Signed-off-by: Vítor Avelino <vavelino@suse.com>

![screenshot from 2018-06-01 09-42-26](https://user-images.githubusercontent.com/188554/40843101-518c0574-6586-11e8-9ae0-4fca54925bcf.png)
