### PR TITLE
ui: do not count failed removal as minion for removal

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -467,8 +467,14 @@ MinionPoller = {
 };
 
 function isTheLast(minion, role) {
+  var remainingValid = State.minions.filter(function (m) {
+    return m.role === role &&
+           m.highstate !== 'removal_failed';
+  });
+
   return minion.role === role &&
-         State.minions.filter(function (m) { return m.role === role }).length === 1;
+         remainingValid.length === 1 &&
+         !(minion.highstate === 'removal_failed');
 }
 
 function hasPendingAcceptance(minionId) {

--- a/spec/features/node_force_removal_feature_spec.rb
+++ b/spec/features/node_force_removal_feature_spec.rb
@@ -29,13 +29,6 @@ describe "feature: node force removal", js: true do
     expect(page).to have_link("Force remove", count: 2)
   end
 
-  it "hides 'Force remove' link if only 1 master and 1 worker" do
-    Minion.destroy([minions[1].id, minions[2].id, minions[3].id])
-
-    visit authenticated_root_path
-    expect(page).not_to have_link("Force remove")
-  end
-
   context "with successful orchestration" do
     before do
       allow(Orchestration).to receive(:run).and_return(true)
@@ -83,7 +76,7 @@ describe "feature: node force removal", js: true do
       expect(page).to have_css(".force-remove-node-link.disabled",
         count: 2)
       expect(page).to have_css(".remove-node-link.disabled",
-        count: 2)
+        count: 1)
 
       # assign nodes
       expect(page).not_to have_link("(new)")

--- a/spec/features/node_removal_feature_spec.rb
+++ b/spec/features/node_removal_feature_spec.rb
@@ -27,6 +27,13 @@ describe "feature: node removal", js: true do
     expect(page).to have_link("Remove", count: Minion.cluster_role.count)
   end
 
+  it "hides 'Remove' link if 2 remaining and 1 is failed" do
+    [minions[1], minions[2], minions[3]].each { |m| m.update(highstate: :removal_failed) }
+
+    visit authenticated_root_path
+    expect(page).not_to have_link("Remove")
+  end
+
   it "hides 'Remove' link if only 1 master and 1 worker" do
     Minion.destroy([minions[1].id, minions[2].id, minions[3].id])
 


### PR DESCRIPTION
We should not consider a failed removal minion as a valid removal when
we decide to show/hide the removals link.

In this case, if we are in a scenario 1+2 and one of the workers is in
removal failed highstate, we should not show the 'Remove' link for the
other worker.

bsc#1095205

Signed-off-by: Vítor Avelino <vavelino@suse.com>

![10 17 1 0_ 1](https://user-images.githubusercontent.com/188554/40920732-ce383232-67e3-11e8-89b4-a4e0b32d1cb7.png)
![10 17 1 0_](https://user-images.githubusercontent.com/188554/40920733-ce634df0-67e3-11e8-9c60-3f7820e87413.png)
