### PR TITLE
[3.0] Serve the flannel backend on the Pillar API

### DIFF
--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -33,6 +33,7 @@ class Pillar < ApplicationRecord
         cluster_cidr_max:              "cluster_cidr_max",
         cluster_cidr_len:              "cluster_cidr_len",
         cni_plugin:                    "cni:plugin",
+        flannel_backend:               "flannel:backend",
         cilium_image:                  "cilium:image",
         services_cidr:                 "services_cidr",
         api_cluster_ip:                "api:cluster_ip",


### PR DESCRIPTION
If we don't serve the flannel backend on the Pillar API, the upgrade
will use the default in the `sls` files, that is: `vxlan`.

The intent was always to keep `udp` for upgraded systems until we
migrate them to the `vxlan` backend, so make the Pillar controller
serve the current `flannel:backend` pillar value that is present
on the database (it will be `vxlan` for new installations, and `udp`
for systems coming from the 2.0 release).

Fixes: bsc#1096710
(cherry picked from commit 4d19ba2b69cd72e3853986bc6a8ba6e48b1bbcda)