### PR TITLE
Add dex connector ldap table, models, and pillar output

### DIFF
--- a/app/controllers/internal_api/v1/pillars_controller.rb
+++ b/app/controllers/internal_api/v1/pillars_controller.rb
@@ -1,3 +1,5 @@
+require "velum/dex/ldap"
+
 # Serve the pillar information
 # rubocop:disable Metrics/ClassLength
 class InternalApi::V1::PillarsController < InternalApiController
@@ -12,6 +14,8 @@ class InternalApi::V1::PillarsController < InternalApiController
       kubelet_contents
     ).merge(
       system_certificate_contents
+    ).deep_merge(
+      dex_connectors_as_pillar
     )
   end
 
@@ -165,6 +169,12 @@ class InternalApi::V1::PillarsController < InternalApiController
         "eviction-hard"     => eviction_hard.value || ""
       }
     }
+  end
+
+  def dex_connectors_as_pillar
+    connectors = []
+    connectors.concat(Velum::Dex.ldap_connectors_as_pillar)
+    { dex: { connectors: connectors } }
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/dex_connector_ldap.rb
+++ b/app/models/dex_connector_ldap.rb
@@ -1,0 +1,6 @@
+# Model that represents a dex authentication connector for LDAP
+class DexConnectorLdap < ActiveRecord::Base
+  has_one :certificate_service, as: :service, dependent: :destroy
+  has_one :certificate, through: :certificate_service
+  self.table_name = "dex_connectors_ldap"
+end

--- a/db/migrate/20180530105000_create_dex_connectors_ldap.rb
+++ b/db/migrate/20180530105000_create_dex_connectors_ldap.rb
@@ -1,0 +1,26 @@
+class CreateDexConnectorsLdap < ActiveRecord::Migration
+  def change
+    create_table :dex_connectors_ldap do |t|
+      t.timestamps
+      t.string    :name,               limit: 255
+      t.string    :host,               limit: 255
+      t.integer   :port,               limit: 2,   default: 636
+      t.boolean   :start_tls,                      default: false, null: false
+      t.boolean   :bind_anon,                      default: false, null: false # bind_dn and bind_pw ignored if true
+      t.string    :bind_dn,            limit: 255, default: "uid=someuid,cn=users,dc=somedomain,dc=com"
+      t.string    :bind_pw,            limit: 255
+      t.string    :username_prompt,    limit: 255, default: "Username"
+      t.string    :user_base_dn,       limit: 255, default: "cn=users,dc=somedomain,dc=com"
+      t.string    :user_filter,        limit: 255, default: "(objectClass=person)"
+      t.string    :user_attr_username, limit: 255, default: "uid"
+      t.string    :user_attr_id,       limit: 255, default: "uid"
+      t.string    :user_attr_email,    limit: 255, default: "mail", null: false
+      t.string    :user_attr_name,     limit: 255, default: "name"
+      t.string    :group_base_dn,      limit: 255, default: "cn=groups,dc=somedomain,dc=com"
+      t.string    :group_filter,       limit: 255, default: "(objectClass=group)"
+      t.string    :group_attr_user,    limit: 255, default: "uid"
+      t.string    :group_attr_group,   limit: 255, default: "member"
+      t.string    :group_attr_name,    limit: 255, default: "name"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181708070232) do
+ActiveRecord::Schema.define(version: 20181708070234) do
 
   create_table "certificate_services", force: :cascade do |t|
     t.integer  "certificate_id", limit: 4
@@ -167,4 +167,29 @@ ActiveRecord::Schema.define(version: 20181708070232) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  create_table "dex_connectors_ldap", force: :cascade do |t|
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "name",               limit: 255
+    t.string   "host",               limit: 255
+    t.integer  "port",               limit: 2,   default: 636
+    t.boolean  "start_tls",                      default: false,                                       null: false
+    t.boolean  "bind_anon",                      default: false,                                       null: false
+    t.string   "bind_dn",            limit: 255, default: "uid=someuid,cn=users,dc=somedomain,dc=com"
+    t.string   "bind_pw",            limit: 255
+    t.string   "username_prompt",    limit: 255, default: "Username"
+    t.string   "user_base_dn",       limit: 255, default: "cn=users,dc=somedomain,dc=com"
+    t.string   "user_filter",        limit: 255, default: "(objectClass=person)"
+    t.string   "user_attr_username", limit: 255, default: "uid"
+    t.string   "user_attr_id",       limit: 255, default: "uid"
+    t.string   "user_attr_email",    limit: 255, default: "mail",                                      null: false
+    t.string   "user_attr_name",     limit: 255, default: "name"
+    t.string   "group_base_dn",      limit: 255, default: "cn=groups,dc=somedomain,dc=com"
+    t.string   "group_filter",       limit: 255, default: "(objectClass=group)"
+    t.string   "group_attr_user",    limit: 255, default: "uid"
+    t.string   "group_attr_group",   limit: 255, default: "member"
+    t.string   "group_attr_name",    limit: 255, default: "name"
+  end
+
+  add_index "dex_connectors_ldap", ["id"], name: "index_dex_connectors_ldap_on_id", unique: true, using: :btree
 end

--- a/lib/velum/dex/ldap.rb
+++ b/lib/velum/dex/ldap.rb
@@ -1,0 +1,68 @@
+require "base64"
+
+module Velum
+  # This class offers the integration between ruby and the Saltstack API.
+  module Dex
+    class << self
+      def ldap_connectors_as_pillar
+        ldap_connectors = DexConnectorLdap.all.map do |con|
+          {
+            type:            "ldap",
+            id:              con.id,
+            name:            con.name,
+
+            # Combine host and port since they ultimately
+            #   feed into a single line of config for dex
+            server:          "#{con.host}:#{con.port}",
+            start_tls:       con.start_tls,
+            root_ca_data:    Base64.encode64(con.certificate.try(:certificate) || ""),
+            bind:            generate_bind_block(con), # Place basic bind information together
+            user:            generate_user_block(con), # Place user stuff together
+            group:           generate_group_block(con), # Place group stuff together
+            username_prompt: con.username_prompt
+          }
+        end
+        ldap_connectors
+      end
+
+      private
+
+      def generate_user_block(con)
+        {
+          base_dn:  con.user_base_dn,
+          filter:   con.user_filter,
+          attr_map: {
+            username: con.user_attr_username,
+            id:       con.user_attr_id,
+            email:    con.user_attr_email,
+            name:     con.user_attr_name
+          }
+        }
+      end
+
+      def generate_bind_block(con)
+        bind = {}
+        if con.bind_anon
+          bind[:anonymous] = true
+        else
+          bind[:anonymous] = false
+          bind[:dn] = con.bind_dn
+          bind[:pw] = con.bind_pw
+        end
+        bind
+      end
+
+      def generate_group_block(con)
+        {
+          base_dn:  con.group_base_dn,
+          filter:   con.group_filter,
+          attr_map: {
+            user:  con.group_attr_user,
+            group: con.group_attr_group,
+            name:  con.group_attr_group
+          }
+        }
+      end
+    end
+  end
+end

--- a/packaging/suse/patches/0_set_default_salt_events_alter_time_column_value.rpm.patch
+++ b/packaging/suse/patches/0_set_default_salt_events_alter_time_column_value.rpm.patch
@@ -1,8 +1,8 @@
 diff --git a/db/schema.rb b/db/schema.rb
-index 1275187..9eb6291 100644
+index 1ea41ec..4d401d5 100644
 --- a/db/schema.rb
 +++ b/db/schema.rb
-@@ -106,7 +106,7 @@ ActiveRecord::Schema.define(version: 20181708070232) do
+@@ -107,7 +107,7 @@ ActiveRecord::Schema.define(version: 20181708070233) do
    create_table "salt_events", force: :cascade do |t|
      t.string   "tag",          limit: 255,      null: false
      t.text     "data",         limit: 16777215, null: false
@@ -11,7 +11,7 @@ index 1275187..9eb6291 100644
      t.string   "master_id",    limit: 255,      null: false
      t.datetime "taken_at"
      t.datetime "processed_at"
-@@ -135,7 +135,7 @@ ActiveRecord::Schema.define(version: 20181708070232) do
+@@ -136,7 +136,7 @@ ActiveRecord::Schema.define(version: 20181708070233) do
      t.string   "id",         limit: 255,      null: false
      t.string   "success",    limit: 10,       null: false
      t.text     "full_ret",   limit: 16777215, null: false

--- a/spec/controllers/internal_api/v1/pillars_controller_spec.rb
+++ b/spec/controllers/internal_api/v1/pillars_controller_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
         url:  Registry::SUSE_REGISTRY_URL,
         cert: nil
       ],
+      dex:                 {
+        connectors: []
+      },
       kubelet:             {
         :"compute-resources" => {},
         :"eviction-hard"     => ""
@@ -72,6 +75,9 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
             ]
           }
         ],
+        dex:                 {
+          connectors: []
+        },
         kubelet:             {
           :"compute-resources" => {},
           :"eviction-hard"     => ""
@@ -108,6 +114,9 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
       {
         system_certificates: [],
         registries:          [],
+        dex:                 {
+          connectors: []
+        },
         kubelet:             {
           :"compute-resources" => {
             kube: {
@@ -136,6 +145,9 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
       {
         registries:          [],
         system_certificates: [],
+        dex:                 {
+          connectors: []
+        },
         kubelet:             {
           :"compute-resources" => {},
           :"eviction-hard"     => ""
@@ -201,6 +213,9 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
       {
         system_certificates: [],
         registries:          [],
+        dex:                 {
+          connectors: []
+        },
         kubelet:             {
           :"compute-resources" => {},
           :"eviction-hard"     => ""
@@ -291,6 +306,9 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
       {
         system_certificates: [],
         registries:          [],
+        dex:                 {
+          connectors: []
+        },
         kubelet:             {
           :"compute-resources" => {},
           :"eviction-hard"     => ""
@@ -340,6 +358,9 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
           name: "sca1",
           cert: "cert"
         ],
+        dex:                 {
+          connectors: []
+        },
         kubelet:             {
           :"compute-resources" => {},
           :"eviction-hard"     => ""
@@ -358,4 +379,98 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
       expect(json).to eq(expected_response)
     end
   end
+
+  def expected_dex_json(num, certificate)
+    {
+      id:              num,
+      name:            "LDAP Server #{num}",
+      root_ca_data:    Base64.encode64(certificate.certificate),
+      bind:            {
+        anonymous: false,
+        dn:        "cn=admin,dc=ldap_host_#{num},dc=com",
+        pw:        nil
+      },
+      username_prompt: "Username",
+      user:            {
+        base_dn:  "cn=users,dc=ldap_host_#{num},dc=com",
+        filter:   "(objectClass=person)",
+        attr_map: {
+          username: "uid",
+          id:       "uid",
+          email:    "mail",
+          name:     "name"
+        }
+      },
+      group:           {
+        base_dn:  "cn=groups,dc=ldap_host_#{num},dc=com",
+        filter:   "(objectClass=group)",
+        attr_map: {
+          user:  "uid",
+          group: "member",
+          name:  "name"
+        }
+      }
+    }
+  end
+
+  # rubocop:disable RSpec/ExampleLength
+  context "with dex LDAP connectors tls" do
+    it "has dex LDAP connectors" do
+      dex_connector_ldap = create(:dex_connector_ldap, :tls, :regular_admin)
+      CertificateService.create(service: dex_connector_ldap, certificate: certificate)
+
+      expected_json = {
+        registries:          [],
+        kubelet:             {
+          :"compute-resources" => {},
+          :"eviction-hard"     => ""
+        },
+        system_certificates: [],
+        dex:                 {
+          connectors: [
+            expected_dex_json(dex_connector_ldap.id, certificate).merge(
+              server:    "ldap_host_#{dex_connector_ldap.id}.com:636",
+              start_tls: false
+            )
+          ]
+        }
+      }
+      get :show do
+        expect(json).to eq(expected_json)
+        delete(dex_connector_ldap)
+      end
+    end
+  end
+
+  context "with dex LDAP connectors starttls" do
+    it "has dex LDAP connectors" do
+      dex_connector_ldap = create(:dex_connector_ldap, :starttls, :anon_admin)
+      CertificateService.create(service: dex_connector_ldap, certificate: certificate)
+
+      expected_json = {
+        registries:          [],
+        kubelet:             {
+          :"compute-resources" => {},
+          :"eviction-hard"     => ""
+        },
+        system_certificates: [],
+        dex:                 {
+          connectors: [
+            expected_dex_json(dex_connector_ldap.id, certificate).merge(
+              server:    "ldap_host_#{dex_connector_ldap.id}.com:389",
+              start_tls: true,
+              bind:      {
+                anonymous: true
+              }
+            )
+          ]
+        }
+      }
+      get :show do
+        expect(json).to eq(expected_json)
+        delete(dex_connector_ldap)
+      end
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength
 end

--- a/spec/factories/dex_connectors_ldap_factory.rb
+++ b/spec/factories/dex_connectors_ldap_factory.rb
@@ -1,0 +1,46 @@
+FactoryGirl.define do
+  factory :dex_connector_ldap, class: DexConnectorLdap do
+    sequence(:name) { |n| "LDAP Server #{n}" }
+    sequence(:host) { |n| "ldap_host_#{n}.com" }
+
+    # default to TLS
+    port 636
+    start_tls false
+
+    trait :tls do
+      port 636
+      start_tls false
+    end
+
+    trait :starttls do
+      port 389
+      start_tls true
+    end
+
+    # default to anon_admin
+    bind_anon true
+
+    trait :anon_admin do
+      bind_anon true
+    end
+
+    trait :regular_admin do
+      bind_anon false
+      bind_dn { "cn=admin,dc=#{host.chomp(".com")},dc=com" }
+      bind_pw nil
+    end
+
+    username_prompt "Username"
+    user_base_dn { "cn=users,dc=#{host.chomp(".com")},dc=com" }
+    user_filter "(objectClass=person)"
+    user_attr_username "uid"
+    user_attr_id "uid"
+    user_attr_email "mail"
+    user_attr_name "name"
+    group_base_dn { "cn=groups,dc=#{host.chomp(".com")},dc=com" }
+    group_filter "(objectClass=group)"
+    group_attr_user "uid"
+    group_attr_group "member"
+    group_attr_name "name"
+  end
+end

--- a/spec/models/dex_connector_ldap_spec.rb
+++ b/spec/models/dex_connector_ldap_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe DexConnectorLdap, type: :model do
+  describe "#configure_dex_ldap_connector" do
+    let(:dex_connector_ldap) { create(:dex_connector_ldap) }
+    let(:certificate)        { create(:certificate) }
+
+    before do
+      CertificateService.create(service: dex_connector_ldap, certificate: certificate)
+    end
+
+    after do
+      CertificateService.destroy_all
+    end
+
+    it "creates a valid looking certificate" do
+      expect(Certificate.find_by(certificate: certificate.certificate).certificate)
+        .to include("BEGIN CERTIFICATE")
+    end
+  end
+end


### PR DESCRIPTION
Added a new table "dex_connectors_ldap" and migration file to the db schema and migrate files.
Altered pillar controller to output this new data.
Added a basic/empty app model for the new table so that the data can be fetched through it.
Updated pillar rspec to test newly output connectors as well as to allow the empty connectors in the other pillar tests.