### PR TITLE
ui: don't show failed alert for repeated orchestration

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -149,6 +149,7 @@ MinionPoller = {
         }
 
         State.minions = minions;
+        State.lastOrchestrationAt = data.last_orchestration_at;
 
         var pendingStateMinion = minions.find(function (minion) {
           return minion.highstate == "pending";
@@ -328,9 +329,20 @@ MinionPoller = {
   },
 
   alertFailedBootstrap: function() {
-    if (!$('.failed-bootstrap-alert').length) {
-      showAlert('At least one of the nodes is in a failed state. Please run "supportconfig" on the failed node(s) to gather the logs.', 'alert', 'failed-bootstrap-alert');
+    var cachedFailedLastOrchestration = window.localStorage.getItem('failedLastOrchestrationAt');
+
+    if ($('.failed-bootstrap-alert').length ||
+        cachedFailedLastOrchestration === State.lastOrchestrationAt) {
+      return;
     }
+
+    var $alert = showAlert('At least one of the nodes is in a failed state. Please run "supportconfig" on the failed node(s) to gather the logs.', 'alert', 'failed-bootstrap-alert');
+
+    window.localStorage.removeItem('failedLastOrchestrationAt');
+    $alert.on('closed.bs.alert', function () {
+      window.localStorage.setItem('failedLastOrchestrationAt', State.lastOrchestrationAt);
+      $alert.off('closed.bs.alert');
+    })
   },
 
   renderDashboard: function(minion) {

--- a/app/controllers/concerns/discovery.rb
+++ b/app/controllers/concerns/discovery.rb
@@ -18,7 +18,8 @@ module Discovery
           cloud_jobs_failed:                 SaltJob.failed.count,
           admin:                             Minion.find_by(minion_id: "admin"),
           retryable_bootstrap_orchestration: Orchestration.retryable?(kind: :bootstrap),
-          retryable_upgrade_orchestration:   Orchestration.retryable?(kind: :upgrade)
+          retryable_upgrade_orchestration:   Orchestration.retryable?(kind: :upgrade),
+          last_orchestration_at:             Orchestration.last.try(:created_at)
         }
         render json: hsh
       end


### PR DESCRIPTION
A failed alert is shown whenever one of the nodes fails to bootstrap.
This is an optimization to only show this alert once for a specific
orchestration run. If the user closes the alert, it won't come back
unless a new orchestration happens.

bsc#1097752

Signed-off-by: Vítor Avelino <vavelino@suse.com>