### PR TITLE
[3.0] Fix bsc#1072242: Use keyboard layout from admin installation.

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,5 @@
 require "velum/suse_connect"
+require "velum/autoyast_values"
 
 # DashboardController shows the main page.
 class DashboardController < ApplicationController
@@ -18,9 +19,6 @@ class DashboardController < ApplicationController
 
   before_action :redirect_to_dashboard, only: :unassigned_nodes
 
-  DEFAULT_KEYBOARD_LAYOUT = "english-us".freeze
-  YAST_KEYBOARD_KEY = "YAST_KEYBOARD".freeze
-
   # Return the autoyast XML profile to bootstrap other worker nodes. They will read this response in
   # order to start an unattended installation of CaaSP.
   #
@@ -32,50 +30,12 @@ class DashboardController < ApplicationController
   # fields that customer uses) and also skips the redirection to the setup process (when a worker
   # asks for the autoyast profile we will either serve it, or return an error).
   def autoyast
-    @controller_node = Pillar.value pillar: :dashboard
+    pollute_variables!(Velum::AutoyastValues.new)
     if @controller_node.blank?
       head :service_unavailable
     else
-      begin
-        suse_connect_config = Rails.cache.fetch("SUSEConnect_config") do
-          Velum::SUSEConnect.config
-        end
-        @suse_smt_url = suse_connect_config.smt_url
-        @suse_regcode = suse_connect_config.regcode
-        @do_registration = true
-      rescue Velum::SUSEConnect::MissingRegCodeException,
-             Velum::SUSEConnect::MissingCredentialsException,
-             Velum::SUSEConnect::SCCConnectionException
-        @do_registration = false
-      end
-      ssh_key_file = "/var/lib/misc/ssh-public-key/id_rsa.pub"
-      # rubocop:disable Style/RescueModifier
-      @ssh_public_key = File.read(ssh_key_file) rescue nil
-      @keyboard_layout = read_keyboard_layout
-      # rubocop:enable Style/RescueModifier
-
-      # proxy related settings
-      @proxy_systemwide = Pillar.value(pillar: :proxy_systemwide) == "true"
-      @proxy_http       = Pillar.value(pillar: :http_proxy)
-      @proxy_https      = Pillar.value(pillar: :https_proxy)
-      @proxy_no_proxy   = Pillar.value(pillar: :no_proxy)
-
       render "autoyast.xml.erb", layout: false, content_type: "text/xml"
     end
-  end
-
-  # Read the keyboard layout set by Yast during installation.
-  #
-  # @return [String] the keyboard set from Yast, or 'english-us' as
-  # default
-  def read_keyboard_layout(keyboard_config_file: "/var/lib/misc/keyboard")
-    return DEFAULT_KEYBOARD_LAYOUT unless File.file?(keyboard_config_file)
-    yast_layout = File.readlines(keyboard_config_file).select do |line|
-      line =~ /^#{YAST_KEYBOARD_KEY}=/
-    end.first
-    return DEFAULT_KEYBOARD_LAYOUT unless yast_layout
-    layout, _char_map = yast_layout.split("=")[1].delete('"').split(",")
-    layout ? layout : DEFAULT_KEYBOARD_LAYOUT
   end
 
   # GET /assign_nodes
@@ -114,5 +74,20 @@ class DashboardController < ApplicationController
     flash[:alert] = "You are accessing velum from an unregistered host (#{request.host}). " \
                     "It is advised to access velum via one of the registered hosts " \
                     "#{accessible_hosts.join(" or ")}"
+  end
+
+  # This method will copy *all* instance variables of the given object to the
+  # current instance. No checks will be performed if a variable already exists -
+  # the current value will be overwritten in that case.
+  #
+  # This copying right now is used to prevent nesting values in the template:
+  # instead of writing `<%= other.var %>` it is possible to just write `<%= var
+  # %>` again.
+  #
+  # @param other [Object] Any object with instance variables.
+  def pollute_variables!(other)
+    other.instance_variables.each do |var|
+      instance_variable_set(var, other.instance_variable_get(var))
+    end
   end
 end

--- a/app/views/dashboard/autoyast.xml.erb
+++ b/app/views/dashboard/autoyast.xml.erb
@@ -115,7 +115,7 @@
     <import config:type="boolean">false</import>
   </ssh_import>
   <keyboard>
-    <keymap>english-us</keymap>
+    <keymap><%= @keyboard_layout %></keymap>
   </keyboard>
   <language>
     <language>en_US</language>

--- a/lib/velum/autoyast_values.rb
+++ b/lib/velum/autoyast_values.rb
@@ -1,0 +1,49 @@
+module Velum
+  # Load values that will be used to populate the autoyast profile
+  class AutoyastValues
+    DEFAULT_KEYBOARD_LAYOUT = "english-us".freeze
+    YAST_KEYBOARD_KEY = "YAST_KEYBOARD".freeze
+    SSH_KEY_FILE = "/var/lib/misc/ssh-public-key/id_rsa.pub".freeze
+
+    def initialize
+      @controller_node = Pillar.value pillar: :dashboard
+      return if @controller_node.blank?
+      begin
+        suse_connect_config = Rails.cache.fetch("SUSEConnect_config") do
+          Velum::SUSEConnect.config
+        end
+        @suse_smt_url = suse_connect_config.smt_url
+        @suse_regcode = suse_connect_config.regcode
+        @do_registration = true
+      rescue Velum::SUSEConnect::MissingRegCodeException,
+             Velum::SUSEConnect::MissingCredentialsException,
+             Velum::SUSEConnect::SCCConnectionException
+        @do_registration = false
+      end
+      # rubocop:disable Style/RescueModifier
+      @ssh_public_key = File.read(SSH_KEY_FILE) rescue nil
+      @keyboard_layout = read_keyboard_layout
+      # rubocop:enable Style/RescueModifier
+
+      # proxy related settings
+      @proxy_systemwide = Pillar.value(pillar: :proxy_systemwide) == "true"
+      @proxy_http       = Pillar.value(pillar: :http_proxy)
+      @proxy_https      = Pillar.value(pillar: :https_proxy)
+      @proxy_no_proxy   = Pillar.value(pillar: :no_proxy)
+    end
+
+    # Read the keyboard layout set by Yast during installation.
+    #
+    # @return [String] the keyboard set from Yast, or 'english-us' as
+    # default
+    def read_keyboard_layout(keyboard_config_file: "/var/lib/misc/keyboard")
+      return DEFAULT_KEYBOARD_LAYOUT unless File.file?(keyboard_config_file)
+      yast_layout = File.readlines(keyboard_config_file).select do |line|
+        line =~ /^#{YAST_KEYBOARD_KEY}=/
+      end.first
+      return DEFAULT_KEYBOARD_LAYOUT unless yast_layout
+      layout, _char_map = yast_layout.split("=")[1].delete('"').split(",")
+      layout ? layout : DEFAULT_KEYBOARD_LAYOUT
+    end
+  end
+end


### PR DESCRIPTION
The keyboard layout the user was using during the installation will be
used in the autoyast generated to bootstrap additional nodes.

Requires kubic-project/caasp-container-manifests#195

Backport of https://github.com/kubic-project/velum/pull/575