### PR TITLE
save online status through reconciler (bsc#1098436)

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -346,7 +346,7 @@ MinionPoller = {
   },
 
   renderDashboard: function(minion) {
-    var statusHtml;
+    var appliedHtml;
     var checked;
     var masterHtml;
     var actionsHtml;
@@ -354,26 +354,26 @@ MinionPoller = {
 
     switch(minion.highstate) {
       case "not_applied":
-        statusHtml = '<i class="fa fa-circle-o text-success fa-2x" aria-hidden="true"></i>';
+        appliedHtml = '<i class="fa fa-circle-o text-success fa-2x" aria-hidden="true"></i>';
         break;
       case "pending_removal":
       case "pending":
-        statusHtml = '\
+        appliedHtml = '\
           <span class="fa-stack" aria-hidden="true">\
             <i class="fa fa-circle fa-stack-2x text-muted" aria-hidden="true"></i>\
             <i class="fa fa-refresh fa-stack-1x fa-spin fa-inverse" aria-hidden="true"></i>\
           </span>';
         break;
       case "failed":
-        statusHtml = '<i class="fa fa-times-circle text-danger fa-2x" aria-hidden="true"></i>';
+        appliedHtml = '<i class="fa fa-times-circle text-danger fa-2x" aria-hidden="true"></i>';
         MinionPoller.alertFailedBootstrap();
         break;
       case "removal_failed":
         removalFailedClass = 'removal-failed';
-        statusHtml = '<i class="fa fa-minus-circle text-danger fa-2x" aria-hidden="true"></i> Removal Failed';
+        appliedHtml = '<i class="fa fa-minus-circle text-danger fa-2x" aria-hidden="true"></i> Removal Failed';
         break;
       case "applied":
-        statusHtml = '<i class="fa fa-check-circle-o text-success fa-2x" aria-hidden="true"></i>';
+        appliedHtml = '<i class="fa fa-check-circle-o text-success fa-2x" aria-hidden="true"></i>';
         break;
     }
 
@@ -390,17 +390,17 @@ MinionPoller = {
     if (minion.tx_update_reboot_needed) {
       switch (minion.highstate) {
         case "applied":
-          statusHtml = '<i class="fa fa-arrow-circle-up text-info fa-2x" aria-hidden="true"></i> Update Available';
+          appliedHtml = '<i class="fa fa-arrow-circle-up text-info fa-2x" aria-hidden="true"></i> Update Available';
           break;
         case "failed":
-          statusHtml = '<i class="fa fa-arrow-circle-up text-warning fa-2x" aria-hidden="true"></i> Update Failed - Retryable';
+          appliedHtml = '<i class="fa fa-arrow-circle-up text-warning fa-2x" aria-hidden="true"></i> Update Failed - Retryable';
           break;
         case "pending":
-          statusHtml += ' Update in progress'
+          appliedHtml += ' Update in progress'
           break;
         }
     } else if (minion.tx_update_failed) {
-      statusHtml = '<i class="fa fa-arrow-circle-up text-danger fa-2x" aria-hidden="true"></i> Update Failed';
+      appliedHtml = '<i class="fa fa-arrow-circle-up text-danger fa-2x" aria-hidden="true"></i> Update Failed';
     }
 
     if (State.pendingRemovalMinionId || State.hasPendingStateNode) {
@@ -420,7 +420,8 @@ MinionPoller = {
 
     return '\
       <tr> \
-        <td class="status">' + statusHtml +  '</td>\
+        <td class="status">' + onlineHtml(minion) +  '</td>\
+        <td class="status">' + appliedHtml +  '</td>\
         <td><strong>' + minion.minion_id +  '</strong></td>\
         <td class="minion-hostname">' + minion.fqdn +  '</td>\
         <td>' + masterHtml + minion.role + '</td>\
@@ -466,8 +467,8 @@ MinionPoller = {
     ';
 
     return '\
-      <tr class="minion_' + minion.id + '"> \
-        <td>' + minion.minion_id + '</td>\
+      <tr class="minion_' + minion.id + '">' +
+        '<td>' + minion.minion_id + '</td>\
         <td class="minion-hostname">' + minion.fqdn + '</td>' +
         roleHtml +
       '</tr>';
@@ -1061,4 +1062,12 @@ function requestNodeForceRemoval(minionId) {
   }).done(disableOrchTriggers)
     .fail(enableOrchTriggers)
     .fail(notifyRemovalError);
+}
+
+function onlineHtml(minion) {
+  if(minion.online) {
+    return '<i class="fa fa-circle text-success fa-2x" aria-hidden="true" title="Online"></i>';
+  } else {
+    return '<i class="fa fa-circle text-danger fa-2x" aria-hidden="true" title="Offline (last updated at: ' + minion.updated_at + ' admin server time)"></i>';
+  }
 }

--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -19,9 +19,14 @@ class Minion < ApplicationRecord
     Minion.all.find_each do |minion|
       begin
         minion_grains = minion.salt.info
+        online = minion_grains.present?
+        # update minion early as minion_grains can't be accessed
+        minion.update_columns online: false && next unless online
+
         tx_update_reboot_needed = minion_grains["tx_update_reboot_needed"] || false
         tx_update_failed = minion_grains["tx_update_failed"] || false
-        minion.update_columns tx_update_reboot_needed: tx_update_reboot_needed,
+        minion.update_columns online:                  online,
+                              tx_update_reboot_needed: tx_update_reboot_needed,
                               tx_update_failed:        tx_update_failed
       rescue StandardError
       end

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -74,7 +74,9 @@ h1 Cluster Status
           thead
             tr
               th
-                | Status
+                | Online
+              th
+                | Applied
               th
                 | ID
               th

--- a/bin/init
+++ b/bin/init
@@ -39,6 +39,7 @@ setup_database() {
             echo "Error at setup time"
             exit 1
         fi
+        bundle exec rake db:migrate
         ;;
       "DB_READY")
         echo "Database ready"

--- a/db/migrate/20181708070233_add_online_status_to_minions.rb
+++ b/db/migrate/20181708070233_add_online_status_to_minions.rb
@@ -1,0 +1,5 @@
+class AddOnlineStatusToMinions < ActiveRecord::Migration
+  def change
+    add_column :minions, :online, :boolean, default: true, after: :tx_update_failed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181708070232) do
+ActiveRecord::Schema.define(version: 20181708070233) do
 
   create_table "certificate_services", force: :cascade do |t|
     t.integer  "certificate_id", limit: 4
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20181708070232) do
     t.integer  "highstate",               limit: 4,   default: 0
     t.boolean  "tx_update_reboot_needed",             default: false
     t.boolean  "tx_update_failed",                    default: false
+    t.boolean  "online",                              default: true
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/packaging/suse/patches/0_set_default_salt_events_alter_time_column_value.rpm.patch
+++ b/packaging/suse/patches/0_set_default_salt_events_alter_time_column_value.rpm.patch
@@ -1,8 +1,8 @@
 diff --git a/db/schema.rb b/db/schema.rb
-index 1275187..9eb6291 100644
+index 1ea41ec..4d401d5 100644
 --- a/db/schema.rb
 +++ b/db/schema.rb
-@@ -106,7 +106,7 @@ ActiveRecord::Schema.define(version: 20181708070232) do
+@@ -107,7 +107,7 @@ ActiveRecord::Schema.define(version: 20181708070233) do
    create_table "salt_events", force: :cascade do |t|
      t.string   "tag",          limit: 255,      null: false
      t.text     "data",         limit: 16777215, null: false
@@ -11,7 +11,7 @@ index 1275187..9eb6291 100644
      t.string   "master_id",    limit: 255,      null: false
      t.datetime "taken_at"
      t.datetime "processed_at"
-@@ -135,7 +135,7 @@ ActiveRecord::Schema.define(version: 20181708070232) do
+@@ -136,7 +136,7 @@ ActiveRecord::Schema.define(version: 20181708070233) do
      t.string   "id",         limit: 255,      null: false
      t.string   "success",    limit: 10,       null: false
      t.text     "full_ret",   limit: 16777215, null: false

--- a/spec/features/monitoring_feature_spec.rb
+++ b/spec/features/monitoring_feature_spec.rb
@@ -30,4 +30,10 @@ describe "Monitoring feature" do
     expect(page).not_to have_content("minion1.k8s.local")
   end
   # rubocop:enable RSpec/ExampleLength
+
+  it "shows the node as offline", js: true do
+    Minion.last.update!(online: false)
+
+    expect(page).to have_css(".fa-circle.text-danger")
+  end
 end


### PR DESCRIPTION
when a minion is down, it should be shown as down in the UI

Signed-off-by: Maximilian Meister <mmeister@suse.de>

![miniondownred](https://user-images.githubusercontent.com/5364817/41969706-9b65f8bc-7a08-11e8-9b93-ef27d2006962.png)
