### PR TITLE
ui: removed fixed width for main header logo

### DIFF
--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -33,7 +33,6 @@ $velum-navbar-toggle-color: white;
 
   .navbar-brand,
   img {
-    width: 235.5px;
     height: 60px;
     padding: 0;
   }


### PR DESCRIPTION
Logo can be both CaaSP or Kubic now and the fixed width was causing a
small misalignment with Kubic logo. Turns out that this fixed width is
not necessary at all.

fix#kubic-logo

Signed-off-by: Vítor Avelino <vavelino@suse.com>

![screenshot-20180628065256-289x144](https://user-images.githubusercontent.com/188554/42027613-8770454a-7aa0-11e8-909f-4f9e7a9c3eba.png)
![screenshot-20180628065323-297x320](https://user-images.githubusercontent.com/188554/42027614-8794dc0c-7aa0-11e8-942b-d97899cf4579.png)