### PR TITLE
[CPI] Add option to ignore OpenStack Cinder availability zone, bsc#1095572

### DIFF
--- a/app/controllers/internal_api/v1/pillars_controller.rb
+++ b/app/controllers/internal_api/v1/pillars_controller.rb
@@ -141,7 +141,8 @@ class InternalApi::V1::PillarsController < InternalApiController
           floating:       Pillar.value(pillar: :cloud_openstack_floating),
           subnet:         Pillar.value(pillar: :cloud_openstack_subnet),
           bs_version:     Pillar.value(pillar: :cloud_openstack_bs_version),
-          lb_mon_retries: Pillar.value(pillar: :cloud_openstack_lb_mon_retries)
+          lb_mon_retries: Pillar.value(pillar: :cloud_openstack_lb_mon_retries),
+          ignore_vol_az:  Pillar.value(pillar: :cloud_openstack_ignore_vol_az)
         }
       }
     }

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -50,6 +50,7 @@ class SetupController < ApplicationController
     @cloud_openstack_floating = Pillar.value(pillar: :cloud_openstack_floating)
     @cloud_openstack_lb_mon_retries = Pillar.value(pillar: :cloud_openstack_lb_mon_retries) || "3"
     @cloud_openstack_bs_version = Pillar.value(pillar: :cloud_openstack_bs_version) || "v2"
+    @cloud_openstack_ignore_vol_az = Pillar.value(pillar: :cloud_openstack_ignore_vol_az) || "false"
 
     # container runtime setting
     @cri = Pillar.value(pillar: :container_runtime) || "docker"

--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -125,7 +125,9 @@ class Pillar < ApplicationRecord
         cloud_openstack_lb_mon_retries:
           "cloud:openstack:lb_mon_retries",
         cloud_openstack_bs_version:
-          "cloud:openstack:bs_version"
+          "cloud:openstack:bs_version",
+        cloud_openstack_ignore_vol_az:
+          "cloud:openstack:ignore_vol_az"
       }
     end
     # rubocop:enable Layout/AlignHash

--- a/app/views/setup/cloud/_openstack_configuration.html.slim
+++ b/app/views/setup/cloud/_openstack_configuration.html.slim
@@ -37,3 +37,6 @@
   .form-group
     = f.label :cloud_openstack_bs_version, "Cinder Block Storage API version"
     = f.text_field :cloud_openstack_bs_version, value: @cloud_openstack_bs_version, class: "form-control"
+  .form-group
+    = f.label :cloud_openstack_ignore_vol_az, "Ignore Cinder availability zone"
+    = f.text_field :cloud_openstack_ignore_vol_az, value: @cloud_openstack_ignore_vol_az, class: "form-control"

--- a/lib/tasks/cpi.rake
+++ b/lib/tasks/cpi.rake
@@ -27,6 +27,7 @@ namespace :cpi do
       when "floating-network-id" then cfg["cloud:openstack:floating_id"] = value
       when "monitor-max-retries" then cfg["cloud:openstack:lb_mon_retries"] = value
       when "bs-version" then          cfg["cloud:openstack:bs_version"] = value
+      when "ignore-volume-az" then    cfg["cloud:openstack:ignore_vol_az"] = value
       when /^./ then                  puts "Unknown option: #{key}"
       end
     end

--- a/spec/controllers/internal_api/v1/pillars_controller_spec.rb
+++ b/spec/controllers/internal_api/v1/pillars_controller_spec.rb
@@ -309,7 +309,8 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
             floating:       "9bc3e819-a6ca-648b-b5e3-c26c9e6c5e57",
             subnet:         "4b64b38d-0b38-40d0-a69f-ade7299ef4ab",
             bs_version:     "v2",
-            lb_mon_retries: "3"
+            lb_mon_retries: "3",
+            ignore_vol_az:  "false"
           }
         }
       }


### PR DESCRIPTION

Ignore OpenStack Cinder avability zone when attaching volumes.
When Nova and Cinder have different availability zones,
this should be set to true. Default is false.