### PR TITLE
[3.0] ui: renamed new nodes -> unassigned nodes

### DIFF
--- a/app/assets/stylesheets/pages/nodes_list.scss
+++ b/app/assets/stylesheets/pages/nodes_list.scss
@@ -70,7 +70,7 @@
   }
 
   .left-column dd {
-    margin-left: 107px;
+    margin-left: 122px;
   }
 
   .right-column dd {

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -23,9 +23,7 @@ h1 Cluster Status
             dd.assigned-count
             dt Master nodes
             dd.master-count
-            dt
-              | New nodes
-              i.fa.fw.fa-info-circle title="Available but have not been added to the cluster yet"
+            dt Unassigned nodes
             dd.unassigned-count data-url=assign_nodes_url
         .col-md-6.right-column
           dl.side-by-side


### PR DESCRIPTION
On the cluster status summary we decided to rename "new" by "unassigned"
to avoid mixing terms that may confuse the user.

bsc#1100113

Signed-off-by: Vítor Avelino <vavelino@suse.com>
(cherry picked from commit b18c46e19129e8c43d5e3abc87e355beae32d562)

Backport of #604 