### PR TITLE
[bsc#1099015] when rebooting admin, set tx_update_reboot_needed to false

### DIFF
--- a/app/controllers/updates_controller.rb
+++ b/app/controllers/updates_controller.rb
@@ -7,7 +7,7 @@ class UpdatesController < ApplicationController
   # Reboot the admin node.
   def create
     # rubocop:disable SkipsModelValidations
-    Minion.admin.update_all highstate: Minion.highstates[:applied]
+    Minion.admin.update_all highstate: Minion.highstates[:applied], tx_update_reboot_needed: false
     # rubocop:enable SkipsModelValidations
     ::Velum::Salt.call(
       action:  "cmd.run",


### PR DESCRIPTION
otherwise we have a window after the restart, where the reboot
admin button is still shown, as the event proccessor still needs
time to update the grains

bsc#1099015

Signed-off-by: Maximilian Meister <mmeister@suse.de>

@ereslibre i have first tried to add a `Minion.update_grains` statement to the end of `bin/init` or just before launching puma in `bin/run` but for some reason that didn't set the `tx_update_reboot_needed` flag to false after the reboot... then i came up with this solution