### PR TITLE
[bsc#1098085] keep information about adding nodes to the cluster

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -11,6 +11,7 @@ class SetupController < ApplicationController
 
   skip_before_action :redirect_to_setup
   before_action :redirect_to_dashboard
+  skip_before_action :redirect_to_dashboard, only: :worker_bootstrap
   before_action :check_empty_settings, only: :configure
   before_action :check_empty_roles, only: :set_roles
 

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -62,6 +62,10 @@ h1 Cluster Status
         i.fa.fa-refresh.fa-fw
         | Retry cluster update
 
+      = link_to setup_worker_bootstrap_path, id: "add-nodes", class: "btn btn-sm btn-success pull-right" do
+        i.fa.fa-plus.fa-fw
+        | Add node
+
     .panel-body
       .row.nodes-loading
         p.text-center

--- a/app/views/setup/worker_bootstrap.html.slim
+++ b/app/views/setup/worker_bootstrap.html.slim
@@ -1,10 +1,18 @@
 = content_for :body_class, "worker_bootstrap"
 
-h1 Bootstrap your #{product_name}
+- if setup_done?
+  h1 Adding new nodes to the cluster
+
+  p
+    |  You can add new nodes to the cluster by leveraging AutoYaST.
+- else
+  h1 Bootstrap your #{product_name}
+
+  p
+    | In order to complete the installation, it is necessary to bootstrap a few additional nodes, those will be the Kubernetes Master and Workers.
+    |  This process leverages AutoYaST and is (almost) fully automated.
 
 p
-  | In order to complete the installation, it is necessary to bootstrap a few additional nodes, those will be the Kubernetes Master and Workers.
-  |  This process leverages AutoYaST and is (almost) fully automated.
   |  In case you are not familiar with it, you can find more information about AutoYaST in the&nbsp;
   a href="https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html" official documentation.
   |  The automatic installation gets invoked by adding <strong>autoyast=#{autoyast_url host: @controller_node, protocol: :http}</strong> to the kernel parameter list.
@@ -21,6 +29,10 @@ p
   a href="https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#bootmedium.pxe" here
   | . Where <strong>#{autoyast_url host: @controller_node, protocol: :http}</strong> is the real, generated path to the AutoYaST profile served by the dashboard.
 
-.clearfix.text-right.steps-container
-  = link_to "Back", setup_path, class: "btn btn-danger"
-  = link_to "Next", setup_discovery_path, class: "btn btn-primary"
+- if setup_done?
+  .clearfix.text-right.steps-container
+    = link_to "Back to dashboard", root_path, class: "btn btn-success"
+- else
+  .clearfix.text-right.steps-container
+    = link_to "Back", setup_path, class: "btn btn-danger"
+    = link_to "Next", setup_discovery_path, class: "btn btn-primary"


### PR DESCRIPTION
after the bootstrap all the useful hints regarding autoyast were
not accessible anymore

bsc#1098085

Signed-off-by: Maximilian Meister <mmeister@suse.de>

![addnode-button](https://user-images.githubusercontent.com/5364817/43007217-0550d4c2-8c38-11e8-859b-a7b71fdb2ed0.png)
![addnode-bootstrap](https://user-images.githubusercontent.com/5364817/43007223-08679c0e-8c38-11e8-8dfe-e0ab47b971a6.png)
