### PR TITLE
ui: added openstack fields info and required validation

### DIFF
--- a/app/assets/javascripts/setup/openstack.js
+++ b/app/assets/javascripts/setup/openstack.js
@@ -1,20 +1,32 @@
 (function (window) {
   var dom = {
     PROJECT_NAME_INPUT: '#settings_cloud_openstack_project',
+    PROJECT_NAME_LABEL: 'label[for=settings_cloud_openstack_project]',
     PROJECT_ID_INPUT: '#settings_cloud_openstack_project_id',
+    PROJECT_ID_LABEL: 'label[for=settings_cloud_openstack_project_id]',
 
     DOMAIN_NAME_INPUT: '#settings_cloud_openstack_domain',
+    DOMAIN_NAME_LABEL: 'label[for=settings_cloud_openstack_domain]',
     DOMAIN_ID_INPUT: '#settings_cloud_openstack_domain_id',
+    DOMAIN_ID_LABEL: 'label[for=settings_cloud_openstack_domain_id]',
+
+    REQUIRED_INPUTS: 'input[required="required"]',
   };
 
   function OpenStackSettings(el) {
     this.$el = $(el);
 
     this.$projectIdInput = this.$el.find(dom.PROJECT_ID_INPUT);
+    this.$projectIdLabel = this.$el.find(dom.PROJECT_ID_LABEL);
     this.$projectNameInput = this.$el.find(dom.PROJECT_NAME_INPUT);
+    this.$projectNameLabel = this.$el.find(dom.PROJECT_NAME_LABEL);
 
     this.$domainIdInput = this.$el.find(dom.DOMAIN_ID_INPUT);
+    this.$domainIdLabel = this.$el.find(dom.DOMAIN_ID_LABEL);
     this.$domainNameInput = this.$el.find(dom.DOMAIN_NAME_INPUT);
+    this.$domainNameLabel = this.$el.find(dom.DOMAIN_NAME_LABEL);
+
+    this.$requiredInputs = this.$el.find(dom.REQUIRED_INPUTS);
 
     this.events();
   }
@@ -22,25 +34,51 @@
   OpenStackSettings.prototype.events = function () {
     this.$el.on('input', dom.PROJECT_ID_INPUT, this.onProjectIdInput.bind(this));
     this.$el.on('input', dom.PROJECT_NAME_INPUT, this.onProjectNameInput.bind(this));
-
     this.$el.on('input', dom.DOMAIN_ID_INPUT, this.onDomainIdInput.bind(this));
     this.$el.on('input', dom.DOMAIN_NAME_INPUT, this.onDomainNameInput.bind(this));
+
+    this.$el.on('settings.enabled', this.settingsEnabled.bind(this));
+    this.$el.on('settings.disabled', this.settingsDisabled.bind(this));
   }
 
   OpenStackSettings.prototype.onProjectIdInput = function (e) {
-    this.$projectNameInput.prop('disabled', !this.isEmpty(this.$projectIdInput));
+    const isIdEmpty = this.isEmpty(this.$projectIdInput);
+
+    this.$projectNameInput.prop('disabled', !isIdEmpty);
+    this.$projectNameLabel.attr('required', isIdEmpty);
   }
 
   OpenStackSettings.prototype.onProjectNameInput = function (e) {
-    this.$projectIdInput.prop('disabled', !this.isEmpty(this.$projectNameInput));
+    const isNameEmpty = this.isEmpty(this.$projectNameInput);
+
+    this.$projectIdInput.prop('disabled', !isNameEmpty);
+    this.$projectIdLabel.attr('required', isNameEmpty);
   }
 
   OpenStackSettings.prototype.onDomainIdInput = function (e) {
-    this.$domainNameInput.prop('disabled', !this.isEmpty(this.$domainIdInput));
+    const isIdEmpty = this.isEmpty(this.$domainIdInput);
+
+    this.$domainNameInput.prop('disabled', !isIdEmpty);
+    this.$domainNameLabel.attr('required', isIdEmpty);
   }
 
   OpenStackSettings.prototype.onDomainNameInput = function (e) {
-    this.$domainIdInput.prop('disabled', !this.isEmpty(this.$domainNameInput));
+    const isNameEmpty = this.isEmpty(this.$domainNameInput);
+
+    this.$domainIdInput.prop('disabled', !isNameEmpty);
+    this.$domainIdLabel.attr('required', isNameEmpty);
+  }
+
+  OpenStackSettings.prototype.settingsDisabled = function (e) {
+    this.$requiredInputs.prop('required', false);
+  }
+
+  OpenStackSettings.prototype.settingsEnabled = function (e) {
+    this.$requiredInputs.prop('required', true);
+    this.onDomainNameInput();
+    this.onDomainIdInput();
+    this.onProjectNameInput();
+    this.onProjectIdInput();
   }
 
   OpenStackSettings.prototype.isEmpty = function (els) {

--- a/app/assets/javascripts/setup/setup.js
+++ b/app/assets/javascripts/setup/setup.js
@@ -27,5 +27,16 @@ $(function() {
   });
 
   new SUSERegistryMirrorPanel('.suse-mirror-panel-body');
-  new OpenStackSettings('.openstack-settings');
+  var openstackSettings = new OpenStackSettings('.openstack-settings');
+
+  function toggleOpenStackSettings() {
+    if ($('input[name="settings[cloud_provider]"]').val() === 'openstack') {
+      openstackSettings.settingsEnabled();
+    } else {
+      openstackSettings.settingsDisabled();
+    }
+  }
+
+  $(document).on('change', 'input[name="settings[cloud_provider]"]', toggleOpenStackSettings);
+  toggleOpenStackSettings();
 });

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -1,0 +1,5 @@
+label[required=true]:after,
+label[required=required]:after {
+  content: " *";
+  color: red;
+}

--- a/app/views/setup/cloud/_openstack_configuration.html.slim
+++ b/app/views/setup/cloud/_openstack_configuration.html.slim
@@ -1,50 +1,75 @@
-.openstack-settings
-  h4 OpenStack Settings
+- required = @cloud_provider.present?
 
-  .form-group
-    = f.label :cloud_openstack_auth_url, "Keystone API URL"
-    = f.text_field :cloud_openstack_auth_url, value: @cloud_openstack_auth_url, class: "form-control"
-  .form-group
-    = f.label :cloud_openstack_domain, "Domain name"
-    = f.text_field :cloud_openstack_domain, value: @cloud_openstack_domain, class: "form-control"
-  .form-group
-    = f.label :cloud_openstack_domain_id, "Domain ID"
-    = f.text_field :cloud_openstack_domain_id, value: @cloud_openstack_domain_id, class: "form-control"
-  .form-group
-    = f.label :cloud_openstack_project, "Project name"
-    = f.text_field :cloud_openstack_project, value: @cloud_openstack_project, class: "form-control"
-  .form-group
-    = f.label :cloud_openstack_project_id, "Project ID"
-    = f.text_field :cloud_openstack_project_id, value: @cloud_openstack_project_id, class: "form-control"
-  .form-group
-    = f.label :cloud_openstack_region, "Region name"
-    = f.text_field :cloud_openstack_region, value: @cloud_openstack_region, class: "form-control"
-  .form-group
-    = f.label :cloud_openstack_username, "Username"
-    = f.text_field :cloud_openstack_username, value: @cloud_openstack_username, class: "form-control"
-  .form-group
-    = f.label :cloud_openstack_password, "Password"
-    = f.password_field :cloud_openstack_password, value: @cloud_openstack_password, class: "form-control"
-  .form-group
-    = f.label :cloud_openstack_subnet, "Subnet UUID for the #{product_name} private network"
-    = f.text_field :cloud_openstack_subnet, value: @cloud_openstack_subnet, class: "form-control"
-  .form-group
-    = f.label :cloud_openstack_floating, "Floating network UUID"
-    = f.text_field :cloud_openstack_floating, value: @cloud_openstack_floating, class: "form-control"
-  .form-group
-    = f.label :cloud_openstack_lb_mon_retries, "Load balancer monitor max retries"
-    = f.text_field :cloud_openstack_lb_mon_retries, value: @cloud_openstack_lb_mon_retries, class: "form-control"
-  .form-group
-    = f.label :cloud_openstack_bs_version, "Cinder Block Storage API version"
-    = f.text_field :cloud_openstack_bs_version, value: @cloud_openstack_bs_version, class: "form-control"
+- if cloud_framework_value === "openstack"
+  .openstack-settings
+    h4 OpenStack Settings
 
-  .form-group
-    = f.label :cloud_openstack_ignore_vol_az, "Ignore Cinder availability zone"
-    br
-      .btn-group.btn-group-toggle data-toggle="buttons"
-        = label_tag :cloud_openstack_ignore_vol_az, nil, class: "btn btn-default #{'btn-primary active' if @cloud_openstack_ignore_vol_az == "true"}"
-          = f.radio_button :cloud_openstack_ignore_vol_az, "true", checked: @cloud_openstack_ignore_vol_az == "true"
-          | True
-        = label_tag :cloud_openstack_ignore_vol_az, nil, class: "btn btn-default #{'btn-primary active' if @cloud_openstack_ignore_vol_az == "false"}"
-          = f.radio_button :cloud_openstack_ignore_vol_az, "false", checked: @cloud_openstack_ignore_vol_az == "false"
-          | False
+    .form-group
+      = f.label :cloud_openstack_auth_url, "Keystone API URL", required: true
+      = f.text_field :cloud_openstack_auth_url, value: @cloud_openstack_auth_url, class: "form-control", required: required
+      small.form-text.text-muted
+        | This is the URL of the keystone API used to authenticate the user. This value can be found
+        |  on the OpenStack control plane under <code>“Access and Security” > “API Access” > “Credentials”</code>.
+    .form-group
+      = f.label :cloud_openstack_domain, "Domain name", required: true
+      = f.text_field :cloud_openstack_domain, value: @cloud_openstack_domain, class: "form-control", required: required
+      small.form-text.text-muted
+        | Used to specify the name of the domain your user belongs to.
+    .form-group
+      = f.label :cloud_openstack_domain_id, "Domain ID", required: true
+      = f.text_field :cloud_openstack_domain_id, value: @cloud_openstack_domain_id, class: "form-control", required: required
+      small.form-text.text-muted
+        | Used to specify the ID of the domain your user belongs to.
+    .form-group
+      = f.label :cloud_openstack_project, "Project name", required: true
+      = f.text_field :cloud_openstack_project, value: @cloud_openstack_project, class: "form-control", required: required
+      small.form-text.text-muted
+        | Used to specify the name of the project where you want to create your resources.
+    .form-group
+      = f.label :cloud_openstack_project_id, "Project ID", required: true
+      = f.text_field :cloud_openstack_project_id, value: @cloud_openstack_project_id, class: "form-control", required: required
+      small.form-text.text-muted
+        | Used to specify the ID of the project where you want to create your resources.
+    .form-group
+      = f.label :cloud_openstack_region, "Region name", required: true
+      = f.text_field :cloud_openstack_region, value: @cloud_openstack_region, class: "form-control", required: required
+      small.form-text.text-muted
+        | Used to specify the identifier of the region to use when running on a multi-region OpenStack
+        |  cloud. A region is a general division of an OpenStack deployment.
+    .form-group
+      = f.label :cloud_openstack_username, "Username", required: true
+      = f.text_field :cloud_openstack_username, value: @cloud_openstack_username, class: "form-control", required: required
+      small.form-text.text-muted
+        | Refers to the username of a valid user set in keystone.
+    .form-group
+      = f.label :cloud_openstack_password, "Password", required: true
+      = f.password_field :cloud_openstack_password, value: @cloud_openstack_password, class: "form-control", required: required
+      small.form-text.text-muted
+        | Refers to the password of a valid user set in keystone.
+    .form-group
+      = f.label :cloud_openstack_subnet, "Subnet UUID for the #{product_name} private network", required: true
+      = f.text_field :cloud_openstack_subnet, value: @cloud_openstack_subnet, class: "form-control", required: required
+      small.form-text.text-muted
+        | Used to specify the identifier of the subnet you want to create your load balancer on.
+        |  This value can be found on the OpenStack control panels, <code>under “Network” > “Networks”</code> - click on the respective network to get its subnets.
+    .form-group
+      = f.label :cloud_openstack_floating, "Floating network UUID"
+      = f.text_field :cloud_openstack_floating, value: @cloud_openstack_floating, class: "form-control"
+      small.form-text.text-muted
+        | When specified will lead to the creation of a floating IP for the load balancer.
+    .form-group
+      = f.label :cloud_openstack_lb_mon_retries, "Load balancer monitor max retries"
+      = f.text_field :cloud_openstack_lb_mon_retries, value: @cloud_openstack_lb_mon_retries, class: "form-control"
+    .form-group
+      = f.label :cloud_openstack_bs_version, "Cinder Block Storage API version"
+      = f.text_field :cloud_openstack_bs_version, value: @cloud_openstack_bs_version, class: "form-control"
+    .form-group
+      = f.label :cloud_openstack_ignore_vol_az, "Ignore Cinder availability zone"
+      br
+        .btn-group.btn-group-toggle data-toggle="buttons"
+          = label_tag :cloud_openstack_ignore_vol_az, nil, class: "btn btn-default #{'btn-primary active' if @cloud_openstack_ignore_vol_az == "true"}"
+            = f.radio_button :cloud_openstack_ignore_vol_az, "true", checked: @cloud_openstack_ignore_vol_az == "true"
+            | True
+          = label_tag :cloud_openstack_ignore_vol_az, nil, class: "btn btn-default #{'btn-primary active' if @cloud_openstack_ignore_vol_az == "false"}"
+            = f.radio_button :cloud_openstack_ignore_vol_az, "false", checked: @cloud_openstack_ignore_vol_az == "false"
+            | False


### PR DESCRIPTION
The OpenStack API fields didn't have any additional information about
them and no indicator of which fields were required or not for a valid
configuration.

Fixes bsc#1097817

Signed-off-by: Vítor Avelino <vavelino@suse.com>

![screenshot from 2018-08-07 07-58-44](https://user-images.githubusercontent.com/188554/43772223-cb4b418e-9a17-11e8-97d7-ef4029ccd1a7.png)
![screenshot from 2018-08-07 07-55-50](https://user-images.githubusercontent.com/188554/43772229-cfaa90b8-9a17-11e8-8d70-1baca2e992d8.png)
