### PR TITLE
[3.0] Update the minion hostname in a regular basis, based on the grain information.

### DIFF
--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -25,7 +25,8 @@ class Minion < ApplicationRecord
 
         tx_update_reboot_needed = minion_grains["tx_update_reboot_needed"] || false
         tx_update_failed = minion_grains["tx_update_failed"] || false
-        minion.update_columns online:                  online,
+        minion.update_columns fqdn:                    minion_grains["fqdn"],
+                              online:                  online,
                               tx_update_reboot_needed: tx_update_reboot_needed,
                               tx_update_failed:        tx_update_failed
       rescue StandardError


### PR DESCRIPTION
Fixes: bsc#1103307
(cherry picked from commit a9e64beb5918c8432daeaee533731fc9789542de)

Backport of https://github.com/kubic-project/velum/pull/614