### PR TITLE
Check for trailing dot in FQDNs for external master & velum fields.

### DIFF
--- a/app/assets/javascripts/polyfills.js
+++ b/app/assets/javascripts/polyfills.js
@@ -1,2 +1,3 @@
 //= require url-polyfill
 //= require array-polyfill
+//= require_tree ./polyfills

--- a/app/assets/javascripts/polyfills/string.js
+++ b/app/assets/javascripts/polyfills/string.js
@@ -1,0 +1,8 @@
+if (!String.prototype.endsWith) {
+	  String.prototype.endsWith = function(search, this_len) {
+		    if (this_len === undefined || this_len > this.length) {
+			      this_len = this.length;
+		    }
+		    return this.substring(this_len - search.length, this_len) === search;
+	  };
+}

--- a/app/assets/javascripts/setup/bootstrap.js
+++ b/app/assets/javascripts/setup/bootstrap.js
@@ -1,0 +1,76 @@
+(function (window) {
+    var dom = {
+        EXTERNAL_K8S_FQDN_GROUP: '.form-group-external-kubernetes',
+        EXTERNAL_K8S_FQDN_INPUT: '#settings_apiserver',
+        EXTERNAL_VELUM_FQDN_GROUP: '.form-group-external-velum',
+        EXTERNAL_VELUM_FQDN_INPUT: '#settings_dashboard_external_fqdn',
+        TRAILING_DOT_K8S_MSG: '.trailing-dot-k8s',
+        TRAILING_DOT_VELUM_MSG: '.trailing-dot-velum',
+        BOOTSTRAP_BTN: '#bootstrap'
+    };
+
+    function proxy(validations) {
+        return {
+            valid: true,
+            set: function(val) {
+                this.valid = val;
+                this.validations();
+            },
+            validations: validations
+        };
+    };
+
+    /** Using FQDNs with a trailing dot causes problems in:
+     * - velum: can not connect to the master server in app/controllers/oidc_controller.rb
+     * - dex: can not connect to the master server
+     * These functions will flag a value that ends in a trailing dot as an error.
+     */
+    function BootstrapSettings(el) {
+        this.$el = $(el);
+        k8sValidations = function() {
+            this.displayError(dom.EXTERNAL_K8S_FQDN_GROUP, dom.TRAILING_DOT_K8S_MSG, this.$k8s.valid);
+            this.validateSubmit();
+        };
+        velumValidations = function() {
+            this.displayError(dom.EXTERNAL_VELUM_FQDN_GROUP, dom.TRAILING_DOT_VELUM_MSG, this.$velum.valid);
+            this.validateSubmit();
+        };
+        // Instead of using a Proxy(), uses a simple setter that will trigger
+        // the validations callback function, as Proxy is not compatible with
+        // phantomJs (no support for JS6).
+        this.$k8s = proxy(k8sValidations.bind(this));
+        this.$velum = proxy(velumValidations.bind(this));
+
+        this.$k8sFqdnGroup = this.$el.find(dom.EXTERNAL_K8S_FQDN_GROUP);
+        this.$k8sFqdnInput = this.$el.find(dom.EXTERNAL_K8S_FQDN_INPUT);
+
+        this.$velumFqdnGroup = this.$el.find(dom.EXTERNAL_VELUM_FQDN_GROUP);
+        this.$velumFqdnInput = this.$el.find(dom.EXTERNAL_VELUM_FQDN_INPUT);
+
+        this.events();
+    };
+
+    BootstrapSettings.prototype.events = function() {
+        this.$el.on('input', dom.EXTERNAL_K8S_FQDN_INPUT, this.onK8sFqdnInput.bind(this));
+        this.$el.on('input', dom.EXTERNAL_VELUM_FQDN_INPUT, this.onVelumFqdnInput.bind(this));
+    };
+
+    BootstrapSettings.prototype.onK8sFqdnInput = function (e) {
+        this.$k8s.set(!this.$k8sFqdnInput.val().endsWith("."));
+    };
+
+    BootstrapSettings.prototype.onVelumFqdnInput = function (e) {
+        this.$velum.set(!this.$velumFqdnInput.val().endsWith("."));
+    };
+
+    BootstrapSettings.prototype.displayError = function(errorGroup, errorMsg, predicate) {
+        $(errorGroup).toggleClass("has-error", !predicate);
+        $(errorMsg).toggleClass("hidden", predicate);
+    };
+
+    BootstrapSettings.prototype.validateSubmit = function() {
+        $(dom.BOOTSTRAP_BTN).prop('disabled', !(this.$k8s.valid && this.$velum.valid));
+    };
+
+    window.BootstrapSettings = BootstrapSettings;
+}(window));

--- a/app/assets/javascripts/setup/setup.js
+++ b/app/assets/javascripts/setup/setup.js
@@ -39,7 +39,10 @@ $(function () {
     } else {
       openstackSettings.settingsDisabled();
     }
-  }
+  };
+
+  new BootstrapSettings(".bootstrap-settings");
+
 
   $(document).on('change', 'input[name="settings[cloud_provider]"]', toggleOpenStackSettings);
   toggleOpenStackSettings();

--- a/app/assets/javascripts/test.js
+++ b/app/assets/javascripts/test.js
@@ -1,12 +1,3 @@
 // Include here scripts that are only required for test env (e.g.: polyfills)
 
 $.fx.off = true;
-
-if (!String.prototype.endsWith) {
-	  String.prototype.endsWith = function(search, this_len) {
-		    if (this_len === undefined || this_len > this.length) {
-			      this_len = this.length;
-		    }
-		    return this.substring(this_len - search.length, this_len) === search;
-	  };
-}

--- a/app/assets/javascripts/test.js
+++ b/app/assets/javascripts/test.js
@@ -1,3 +1,12 @@
 // Include here scripts that are only required for test env (e.g.: polyfills)
 
 $.fx.off = true;
+
+if (!String.prototype.endsWith) {
+	  String.prototype.endsWith = function(search, this_len) {
+		    if (this_len === undefined || this_len > this.length) {
+			      this_len = this.length;
+		    }
+		    return this.substring(this_len - search.length, this_len) === search;
+	  };
+}

--- a/app/views/setup/bootstrap.html.slim
+++ b/app/views/setup/bootstrap.html.slim
@@ -1,20 +1,22 @@
 h1 Confirm bootstrap
 
 = form_for :settings, url: setup_bootstrap_path, method: :post do |f|
-  .panel.panel-default
+  .panel.panel-default.bootstrap-settings
     .panel-heading
       h3.panel-title Cluster specific settings
     .panel-body
-      .form-group
+      .form-group.form-group-external-kubernetes
         = f.label :apiserver, "External Kubernetes API FQDN"
+        .trailing-dot-k8s.text-danger.hidden FQDNs with trailing dots cause problems in TLS, please do not use a trailing dot.
         .input-group
           = f.text_field :apiserver, value: @apiserver, class: "form-control", required: true
           span class="input-group-addon"
             a data-toggle="tooltip" data-placement="left" title="Fully qualified domain name used to reach the cluster from the outside. In a simple, single master deployment this will be the FQDN of the node you are about to select as master. For advanced options refer to the documentation."
               i class='glyphicon glyphicon-info-sign'
 
-      .form-group
+      .form-group.form-group-external-velum
         = f.label :dashboard_external_fqdn, "External Dashboard FQDN"
+        .trailing-dot-velum.text-danger.hidden FQDNs with trailing dots cause problems in TLS, please do not use a trailing dot.
         .input-group
           = f.text_field :dashboard_external_fqdn, value: @dashboard_external_fqdn, class: "form-control", required: true
           span class="input-group-addon"

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -226,6 +226,31 @@ describe "Bootstrap cluster feature" do
       expect(page).to have_content(minions[4].fqdn)
     end
 
+    it "A user cannot bootstrap the cluster with external FQDN ending in a dot", js: true do
+      # wait for all minions to be there
+      expect(page).to have_content(minions[0].fqdn)
+      expect(page).to have_content(minions[1].fqdn)
+      expect(page).to have_content(minions[2].fqdn)
+      expect(page).to have_content(minions[3].fqdn)
+      # select master minion0.k8s.local
+      find(".minion_#{minions[0].id} .master-btn").click
+      # select all nodes
+      find(".select-nodes-btn").click
+
+      click_on_when_enabled "#set-roles"
+
+      # means it went to the confirmation page
+      expect(page).to have_content("Confirm bootstrap")
+      fill_in("External Kubernetes API FQDN", with: "some.url.")
+      fill_in("External Dashboard FQDN", with: "some.url.")
+      velum_error_msg = find(".trailing-dot-velum")
+      k8s_error_msg = find(".trailing-dot-k8s")
+      submit_btn = find("#bootstrap")
+      expect(velum_error_msg).not_to have_selector(:css, "hidden")
+      expect(k8s_error_msg).not_to have_selector(:css, "hidden")
+      expect(submit_btn["disabled"]).to eq(true)
+    end
+
     it "A user cannot bootstrap nodes with conflicting hostnames", js: true do
       duplicated = Minion.create! [{ minion_id: SecureRandom.hex, fqdn: "minion99.k8s.local" },
                                    { minion_id: SecureRandom.hex, fqdn: "minion99.k8s.local" }]


### PR DESCRIPTION
Trailing dots causes errors in velum and dex and should not be used.

Should prevent errors described in bsc#1097175.

@vitoravelino I feel the javascript is really ugly and would be very grateful for some nice pointers!