### PR TITLE
PublicCloud#remove: Not yet implemented

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -403,10 +403,15 @@ MinionPoller = {
       appliedHtml = '<i class="fa fa-arrow-circle-up text-danger fa-2x" aria-hidden="true"></i> Update Failed';
     }
 
-    if (State.pendingRemovalMinionId || State.hasPendingStateNode) {
-      actionsHtml = '<a href="#" class="disabled remove-node-link">Remove</a><a href="#" class="disabled force-remove-node-link">Force remove</a>';
+    // Public Cloud frameworks do not currently support removing nodes
+    if (['azure', 'ec2', 'gce'].indexOf(minion.cloud_framework) > -1) {
+      actionsHtml = '';
     } else {
-      actionsHtml = '<a href="#" class="remove-node-link">Remove</a><a href="#" class="force-remove-node-link">Force remove</a>';
+      if (State.pendingRemovalMinionId || State.hasPendingStateNode) {
+        actionsHtml = '<a href="#" class="disabled remove-node-link">Remove</a><a href="#" class="disabled force-remove-node-link">Force remove</a>';
+      } else {
+        actionsHtml = '<a href="#" class="remove-node-link">Remove</a><a href="#" class="force-remove-node-link">Force remove</a>';
+      }
     }
 
     if (minion.minion_id === State.pendingRemovalMinionId) {

--- a/app/controllers/minions_controller.rb
+++ b/app/controllers/minions_controller.rb
@@ -1,5 +1,6 @@
 # Allows to manage Minions
 class MinionsController < ApplicationController
+  before_action :not_implemented_in_public_cloud
   before_action :fetch_minion
 
   def destroy
@@ -19,6 +20,12 @@ class MinionsController < ApplicationController
   end
 
   private
+
+  # Public Cloud frameworks do not currently support removing nodes
+  def not_implemented_in_public_cloud
+    return unless ["azure", "ec2", "gce"].include? Pillar.value(pillar: :cloud_framework)
+    render nothing: true, status: :not_implemented
+  end
 
   def fetch_minion
     @minion = Minion.find_by! minion_id: params[:id]

--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -13,6 +13,13 @@ class Minion < ApplicationRecord
   validates :minion_id, presence: true, uniqueness: true
   validates :fqdn, presence: true
 
+  # override the json formatter to include the cloud_framework method
+  def as_json(options = {})
+    options[:methods] ||= []
+    options[:methods] << :cloud_framework
+    super
+  end
+
   # Update all minions grains
   def self.update_grains
     # rubocop:disable Lint/HandleExceptions, SkipsModelValidations
@@ -126,5 +133,11 @@ class Minion < ApplicationRecord
   # Returns the proxy for the salt minion
   def salt
     @salt ||= Velum::SaltMinion.new minion: self
+  end
+
+  # The framework where this minion is running
+  # (currently all minions must be in the same framework)
+  def cloud_framework
+    Pillar.value(pillar: :cloud_framework)
   end
 end

--- a/spec/controllers/minions_controller_spec.rb
+++ b/spec/controllers/minions_controller_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe MinionsController, type: :controller do
+  before do
+    user = create(:user)
+    create(:master_minion)
+    create(:worker_minion)
+    setup_done
+    sign_in user
+  end
+
+  describe "destroy minion" do
+    let(:minion) { create(:worker_minion) }
+
+    it "is not implemented in public cloud" do
+      create(:ec2_pillar)
+
+      delete :destroy, id: minion
+      expect(response).to have_http_status(:not_implemented)
+    end
+  end
+end

--- a/spec/features/node_removal_feature_spec.rb
+++ b/spec/features/node_removal_feature_spec.rb
@@ -41,6 +41,14 @@ describe "feature: node removal", js: true do
     expect(page).not_to have_link("Remove")
   end
 
+  # Public Cloud frameworks do not currently support removing nodes
+  it "hides 'Remove' link if running in public cloud" do
+    create(:ec2_pillar)
+
+    visit authenticated_root_path
+    expect(page).not_to have_link("Remove")
+  end
+
   it "does not show warning modal when removing worker and # masters is even" do
     # removed one master to put cluster in unsupported configuration
     minions[0].destroy


### PR DESCRIPTION
Removing nodes is not implemented in public clouds (Azure, EC2, GCE) at this time, so the interfaces for doing so should be disabled until the feature is implemented.