### PR TITLE
[followup #630] require uglifier

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,9 @@ Rails.application.configure do
   config.serve_static_files = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  if ENV["RPM_BUILD_ROOT"]
+    config.assets.js_compressor = Uglifier.new(harmony: true)
+  end
   # config.assets.css_compressor = :sass
 
   # include svg in the precompile


### PR DESCRIPTION
the constant `Uglifier` is not accessible when opening a
rails console or running a rake command

fix#uglifier

Signed-off-by: Maximilian Meister <mmeister@suse.de>

## Follow up of

https://github.com/kubic-project/velum/pull/630

@jordimassaguerpla a more elegant **nitpicky** solution would probably be to only configure `Uglifier` when we precompile the assets, as during runtime we don't really need it. But since we dont have the `PACKAGING` env anymore, we don't have an easy way to determine if we're about to precompile or not. it would look like this:

```ruby
...
  if ENV["PACKAGING"]
    config.assets.js_compressor = Uglifier.new(harmony: true)
  end
...
```

On the other hand it might not be an issue to load `Uglifier` during the rails console session, as during runtime it seems to be loaded and accessible already