### PR TITLE
prevent accessing discovery after bootstrap

### DIFF
--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -12,8 +12,7 @@ class SetupController < ApplicationController
   skip_before_action :redirect_to_setup
   before_action :redirect_to_dashboard
   skip_before_action :redirect_to_dashboard,
-                     only: [:worker_bootstrap, :build_cloud_cluster],
-                     if:   :setup_done?
+                     only: [:worker_bootstrap, :build_cloud_cluster]
   before_action :check_empty_settings, only: :configure
   before_action :check_empty_roles, only: :set_roles
 


### PR DESCRIPTION
PR #627 introduced a weird behaviour of skip_before_action
when 'only' and 'if' is used at the same time

see:
https://github.com/rails/rails/issues/9703

we can just omit the 'if setup_done?' check because that's
already implicitly happening through the application_controller

Signed-off-by: Maximilian Meister <mmeister@suse.de>