### PR TITLE
Updates to prevent auto complete from filling out LDAP fields

### DIFF
--- a/app/assets/stylesheets/pages/settings.scss
+++ b/app/assets/stylesheets/pages/settings.scss
@@ -13,6 +13,11 @@ $sidebar-item-highlight: #00c081;
   z-index: 10;
 }
 
+//used to make elements hidden
+.settings-hidden {
+  display: none
+}
+
 .settings-sidebar-section {
   .title {
     color: $sidebar-section-title;

--- a/app/views/settings/dex_connector_ldaps/_form.html.slim
+++ b/app/views/settings/dex_connector_ldaps/_form.html.slim
@@ -53,14 +53,17 @@
     = error_messages_for(@certificate_holder, :bind_anon)
 
   .ldap-dn-authentication.collapse class="#{'in' if !@certificate_holder.bind_anon}" id="anonymous_bind_toggle" aria-expanded="true"
-    .form-group class="#{error_class_for(@certificate_holder, :bind_dn)}"
+    .form-group class="#{error_class_for(@certificate_holder, :bind_dn)}" autocomplete="nope"
       = f.label :bind_dn, "DN"
       = f.text_field :bind_dn, class: "form-control", value: @certificate_holder.bind_dn, required: !@certificate_holder.bind_anon, disable: @certificate_holder.bind_anon
       = error_messages_for(@certificate_holder, :bind_dn)
 
-    .form-group class="#{error_class_for(@certificate_holder, :bind_pw)}"
+
+    .form-group class="#{error_class_for(@certificate_holder, :bind_pw)}" autocomplete="nope"
       = f.label :bind_pw, "Password"
-      = f.password_field :bind_pw, class: "form-control", value: @certificate_holder.bind_pw, required: !@certificate_holder.bind_anon, disable: @certificate_holder.bind_anon
+        / This is done to keep firefox from auto filling saved creditials.
+      = f.text_field :bind_pw, class: "form_control settings-hidden", value:"none" 
+      = f.password_field :bind_pw, class: "form-control", value: @certificate_holder.bind_pw, required: !@certificate_holder.bind_anon, disable: @certificate_holder.bind_anon, autocomplete: "new-password"
       = error_messages_for(@certificate_holder, :bind_pw)
 
   hr


### PR DESCRIPTION
A extra text field was added to break up the form flow to keep firefox from auto filling in the user name and password. this extra field was then hidden by css. if hidden in the HTML firefox would know and still auto fill.