### PR TITLE
Updated tool tips and removed default data

### DIFF
--- a/app/views/settings/dex_connector_ldaps/_form.html.slim
+++ b/app/views/settings/dex_connector_ldaps/_form.html.slim
@@ -3,6 +3,8 @@
     = f.label :name
     = f.text_field :name, class: "form-control", value: @certificate_holder.name
     = error_messages_for(@certificate_holder, :name)
+    small.form-text.text-muted
+      | Name shown to user when selecting a connector
 
   hr
   h4 Server
@@ -11,11 +13,19 @@
     = f.label :host
     = f.text_field :host, class: "form-control", value: @certificate_holder.host
     = error_messages_for(@certificate_holder, :host)
+    small.form-text.text-muted
+      | Host name of LDAP server reachable from the cluster
 
   .form-group class="#{error_class_for(@certificate_holder, :port)}"
     = f.label :port
     = f.text_field :port, class: "form-control", value: @certificate_holder.port
     = error_messages_for(@certificate_holder, :port)
+    small.form-text.text-muted
+      | The port on which to connect to the host (e.g. StartTLS On:
+      code 389
+      | , StartTLS Off:
+      code 636
+      | )
 
   .form-group class="#{error_class_for(@certificate_holder, :start_tls)}"
     = f.label :start_tls, "StartTLS"
@@ -28,10 +38,13 @@
         = f.radio_button :start_tls, "false", checked: !@certificate_holder.start_tls
         | Off
     = error_messages_for(@certificate_holder, :start_tls)
+    br
+    small.form-text.text-muted 
+      | When enabled use StartTLS otherwise TLS will be used
 
   .form-group.form-group-certificate class="#{error_class_for(@cert, :certificate) if @cert.present?}"
     = f.label :certificate
-    p Upload the certificate for the LDAP server here
+    p Upload the certificate of the root CA that issued the LDAP server certificate
     = f.file_field :certificate, class: "form-control", required: @cert.present?
     - if @cert.present?
       = error_messages_for(@cert, :certificate)
@@ -51,12 +64,17 @@
         = f.radio_button :bind_anon, "false", checked: !@certificate_holder.bind_anon
         | False
     = error_messages_for(@certificate_holder, :bind_anon)
+    br
+    small.form-text.text-muted 
+      | Use anonymous authentication to do initial user search
 
   .ldap-dn-authentication.collapse class="#{'in' if !@certificate_holder.bind_anon}" id="anonymous_bind_toggle" aria-expanded="true"
     .form-group class="#{error_class_for(@certificate_holder, :bind_dn)}" autocomplete="nope"
       = f.label :bind_dn, "DN"
       = f.text_field :bind_dn, class: "form-control", value: @certificate_holder.bind_dn, required: !@certificate_holder.bind_anon, disable: @certificate_holder.bind_anon
-      = error_messages_for(@certificate_holder, :bind_dn)
+      = error_messages_for(@certificate_holder, :bind_dn)    
+      small.form-text.text-muted
+        | Bind DN of user that can do user searches
 
 
     .form-group class="#{error_class_for(@certificate_holder, :bind_pw)}" autocomplete="nope"
@@ -65,23 +83,39 @@
       = f.text_field :bind_pw, class: "form_control settings-hidden", value:"none" 
       = f.password_field :bind_pw, class: "form-control", value: @certificate_holder.bind_pw, required: !@certificate_holder.bind_anon, disable: @certificate_holder.bind_anon, autocomplete: "new-password"
       = error_messages_for(@certificate_holder, :bind_pw)
+      small.form-text.text-muted
+        | Password of the user
 
   hr
   h4 User Search
   .form-group class="#{error_class_for(@certificate_holder, :username_prompt)}"
-    = f.label :username_prompt, "Username Prompt"
+    = f.label :username_prompt, "Identifying User Attribute"
     = f.text_field :username_prompt, class: "form-control", value: @certificate_holder.username_prompt
     = error_messages_for(@certificate_holder, :username_prompt)
+    small.form-text.text-muted
+      | Label of LDAP attribute users will enter to identify themselves (e.g.
+      code username
+      | )
 
   .form-group class="#{error_class_for(@certificate_holder, :user_base_dn)}"
     = f.label :user_base_dn, "Base DN"
     = f.text_field :user_base_dn, class: "form-control", value: @certificate_holder.user_base_dn
     = error_messages_for(@certificate_holder, :user_base_dn)
+    small.form-text.text-muted
+      | BaseDN where users are located (e.g.
+      code
+        | cn=users,dc=example,dc=com
+      | )
 
   .form-group class="#{error_class_for(@certificate_holder, :user_filter)}"
     = f.label :user_filter, "Filter"
     = f.text_field :user_filter, class: "form-control", value: @certificate_holder.user_filter
     = error_messages_for(@certificate_holder, :user_filter)
+    small.form-text.text-muted
+      | Filter to specify type of user objects (e.g.
+      code
+        | "(objectClass=person)"
+      | )
 
   br
   h4 User Attribute Map
@@ -90,21 +124,31 @@
     = f.label :user_attr_username, "Username"
     = f.text_field :user_attr_username, class: "form-control", value: @certificate_holder.user_attr_username
     = error_messages_for(@certificate_holder, :user_attr_username)
+    small.form-text.text-muted
+      | Attribute users will enter to identify themselves
 
   .form-group class="#{error_class_for(@certificate_holder, :user_attr_id)}"
     = f.label :user_attr_id, "ID"
     = f.text_field :user_attr_id, class: "form-control", value: @certificate_holder.user_attr_id
     = error_messages_for(@certificate_holder, :user_attr_id)
+    small.form-text.text-muted
+      | Attribute used to identify user within the system (e.g.
+      code uid
+      | )
 
   .form-group class="#{error_class_for(@certificate_holder, :user_attr_email)}"
     = f.label :user_attr_email, "Email"
     = f.text_field :user_attr_email, class: "form-control", value: @certificate_holder.user_attr_email
     = error_messages_for(@certificate_holder, :user_attr_email)
+    small.form-text.text-muted
+      | Attribute containing email of users
 
   .form-group class="#{error_class_for(@certificate_holder, :user_attr_name)}"
     = f.label :user_attr_name, "Name"
     = f.text_field :user_attr_name, class: "form-control", value: @certificate_holder.user_attr_name
     = error_messages_for(@certificate_holder, :user_attr_name)
+    small.form-text.text-muted
+      | Attribute used as username used within OIDC tokens
 
   hr
   h4 Group Search
@@ -113,11 +157,21 @@
     = f.label :group_base_dn, "Base DN"
     = f.text_field :group_base_dn, class: "form-control", value: @certificate_holder.group_base_dn
     = error_messages_for(@certificate_holder, :group_base_dn)
+    small.form-text.text-muted
+      | BaseDN where groups are located (e.g.
+      code
+        | cn=groups,dc=example,dc=com
+      | )
 
   .form-group class="#{error_class_for(@certificate_holder, :group_filter)}"
     = f.label :group_filter, "Filter"
     = f.text_field :group_filter, class: "form-control", value: @certificate_holder.group_filter
     = error_messages_for(@certificate_holder, :group_filter)
+    small.form-text.text-muted
+      | Filter to specify type of group objects. (e.g.
+      code
+        | "(objectClass=group)"
+      | )
 
   br
   h4 Group Attribute Map
@@ -125,17 +179,32 @@
   .form-group class="#{error_class_for(@certificate_holder, :group_attr_user)}"
     = f.label :group_attr_user, "User"
     = f.text_field :group_attr_user, class: "form-control", value: @certificate_holder.group_attr_user
-    = error_messages_for(@certificate_holder, :group_attr_user)
+    = error_messages_for(@certificate_holder, :group_attr_user)    
+    small.form-text.text-muted 
+      | Attribute to map as user (e.g.
+      code
+        | uid
+      | )
 
   .form-group class="#{error_class_for(@certificate_holder, :group_attr_group)}"
     = f.label :group_attr_group, "Group"
     = f.text_field :group_attr_group, class: "form-control", value: @certificate_holder.group_attr_group
     = error_messages_for(@certificate_holder, :group_attr_group)
+    small.form-text.text-muted
+      | Attribute identifying membership (e.g.
+      code 
+        | member
+      | )
 
   .form-group class="#{error_class_for(@certificate_holder, :group_attr_name)}"
     = f.label :group_attr_name, "Name"
     = f.text_field :group_attr_name, class: "form-control", value: @certificate_holder.group_attr_name
     = error_messages_for(@certificate_holder, :group_attr_name)
+    small.form-text.text-muted
+      | Attribute to map as name (e.g.
+      code
+        | name
+      | )
 
   .form-actions.clearfix
     = f.submit "Save", class: "btn btn-primary action", id: "ldap_conn_save"

--- a/db/migrate/20181715075510_alter_dex_defaults.rb
+++ b/db/migrate/20181715075510_alter_dex_defaults.rb
@@ -1,0 +1,20 @@
+class AlterDexDefaults < ActiveRecord::Migration
+    def change
+        change_column_default("dex_connectors_ldap", "port", nil)
+        change_column_default("dex_connectors_ldap", "start_tls", nil)
+        change_column_default("dex_connectors_ldap", "bind_anon", nil)
+        change_column_default("dex_connectors_ldap", "bind_dn", nil)
+        change_column_default("dex_connectors_ldap", "username_prompt", nil)
+        change_column_default("dex_connectors_ldap", "user_base_dn", nil)
+        change_column_default("dex_connectors_ldap", "user_filter", nil)
+        change_column_default("dex_connectors_ldap", "user_attr_id", nil)
+        change_column_default("dex_connectors_ldap", "user_attr_username", nil)
+        change_column_default("dex_connectors_ldap", "user_attr_email", nil)
+        change_column_default("dex_connectors_ldap", "user_attr_name", nil)
+        change_column_default("dex_connectors_ldap", "group_base_dn", nil)
+        change_column_default("dex_connectors_ldap", "group_filter", nil)
+        change_column_default("dex_connectors_ldap", "group_attr_user", nil)
+        change_column_default("dex_connectors_ldap", "group_attr_group", nil)
+        change_column_default("dex_connectors_ldap", "group_attr_name", nil)        
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181708070234) do
+ActiveRecord::Schema.define(version: 20181715075510) do
 
   create_table "certificate_services", force: :cascade do |t|
     t.integer  "certificate_id", limit: 4
@@ -173,23 +173,23 @@ ActiveRecord::Schema.define(version: 20181708070234) do
     t.datetime "updated_at"
     t.string   "name",               limit: 255
     t.string   "host",               limit: 255
-    t.integer  "port",               limit: 2,   default: 636
-    t.boolean  "start_tls",                      default: false,                                       null: false
-    t.boolean  "bind_anon",                      default: false,                                       null: false
-    t.string   "bind_dn",            limit: 255, default: "uid=someuid,cn=users,dc=somedomain,dc=com"
+    t.integer  "port",               limit: 2 
+    t.boolean  "start_tls",                          null: false
+    t.boolean  "bind_anon",                          null: false
+    t.string   "bind_dn",            limit: 255
     t.string   "bind_pw",            limit: 255
-    t.string   "username_prompt",    limit: 255, default: "Username"
-    t.string   "user_base_dn",       limit: 255, default: "cn=users,dc=somedomain,dc=com"
-    t.string   "user_filter",        limit: 255, default: "(objectClass=person)"
-    t.string   "user_attr_username", limit: 255, default: "uid"
-    t.string   "user_attr_id",       limit: 255, default: "uid"
-    t.string   "user_attr_email",    limit: 255, default: "mail",                                      null: false
-    t.string   "user_attr_name",     limit: 255, default: "name"
-    t.string   "group_base_dn",      limit: 255, default: "cn=groups,dc=somedomain,dc=com"
-    t.string   "group_filter",       limit: 255, default: "(objectClass=group)"
-    t.string   "group_attr_user",    limit: 255, default: "uid"
-    t.string   "group_attr_group",   limit: 255, default: "member"
-    t.string   "group_attr_name",    limit: 255, default: "name"
+    t.string   "username_prompt",    limit: 255 
+    t.string   "user_base_dn",       limit: 255 
+    t.string   "user_filter",        limit: 255 
+    t.string   "user_attr_username", limit: 255 
+    t.string   "user_attr_id",       limit: 255 
+    t.string   "user_attr_email",    limit: 255,     null: false
+    t.string   "user_attr_name",     limit: 255
+    t.string   "group_base_dn",      limit: 255
+    t.string   "group_filter",       limit: 255
+    t.string   "group_attr_user",    limit: 255
+    t.string   "group_attr_group",   limit: 255
+    t.string   "group_attr_name",    limit: 255
   end
 
   add_index "dex_connectors_ldap", ["id"], name: "index_dex_connectors_ldap_on_id", unique: true, using: :btree

--- a/spec/features/settings/dex_connector_ldap_feature_spec.rb
+++ b/spec/features/settings/dex_connector_ldap_feature_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 # rubocop:disable RSpec/ExampleLength
-describe "Feature: LDAP connector settings", js: true do
+# run in order to fix an issue with the `new_cert` test.
+describe "Feature: LDAP connector settings", js: true, order: :defined do
   let!(:user) { create(:user) }
   let!(:dex_connector_ldap) { create(:dex_connector_ldap) }
   let!(:dex_connector_ldap2) { create(:dex_connector_ldap) }
@@ -55,7 +56,7 @@ describe "Feature: LDAP connector settings", js: true do
     end
   end
 
-  describe "#new" do
+  describe "#new_cert" do
     before do
       visit new_settings_dex_connector_ldap_path
     end
@@ -63,29 +64,54 @@ describe "Feature: LDAP connector settings", js: true do
     it "allows a user to create an ldap connector (w/ certificate)" do
       fill_in id: "dex_connector_ldap_name", with: "openldap"
       fill_in "Host", with: "ldaptest.com"
+      fill_in "Port", with: "1234"
+      fill_in "Identifying User Attribute", with: "pass"
       attach_file "Certificate", admin_cert_file
       fill_in id: "dex_connector_ldap_bind_dn", with: "cn=admin,dc=ldaptest,dc=com"
-      fill_in "Password", with: "pass"
+      fill_in id: "dex_connector_ldap_bind_pw", with: "pass"
+      fill_in id: "dex_connector_ldap_user_attr_username", with: "username"
+      fill_in id: "dex_connector_ldap_user_attr_email", with: "email@email.com"
+      fill_in id: "dex_connector_ldap_user_attr_name", with: "name"
+      fill_in id: "dex_connector_ldap_group_attr_name", with: "name"
+      fill_in id: "dex_connector_ldap_group_base_dn", with: "bdn"
+      fill_in id: "dex_connector_ldap_user_base_dn", with: "bdn"
+      fill_in id: "dex_connector_ldap_user_filter", with: "filter"
+      fill_in id: "dex_connector_ldap_group_filter", with: "filter"
+      fill_in id: "dex_connector_ldap_name", with: "name"
+      fill_in id: "dex_connector_ldap_group_attr_user", with: "user"
+      fill_in id: "dex_connector_ldap_group_attr_group", with: "group"
+      fill_in id: "dex_connector_ldap_user_attr_id", with: "uid"
+
       page.execute_script("$('#ldap_conn_save').removeProp('disabled')")
       click_button("Save")
-
       last_ldap_connector = DexConnectorLdap.last
-      expect(page).to have_content(admin_cert_text)
+      expect(page.text).to have_text(admin_cert_text)
       expect(page).to have_content("DexConnectorLdap was successfully created.")
       expect(page).to have_current_path(settings_dex_connector_ldap_path(last_ldap_connector))
+    end
+
+  end
+
+  describe "#new" do
+    before do
+      visit new_settings_dex_connector_ldap_path
     end
 
     it "shows an error message if model validation fails" do
       fill_in "Port", with: "AAA"
       attach_file "Certificate", admin_cert_file
       fill_in "Password", with: "pass"
+      fill_in "Identifying User Attribute", with: "pass"
+      fill_in id: "dex_connector_ldap_bind_dn", with: "cn=admin,dc=ldaptest,dc=com"
+      fill_in id: "dex_connector_ldap_bind_pw", with: "pass"
+
       page.execute_script("$('#ldap_conn_save').removeProp('disabled')")
       click_button("Save")
-
       expect(page).to have_content("Name can't be blank")
       expect(page).to have_content("Host can't be blank")
       expect(page).to have_content("Port is not a number")
     end
+
   end
 
   describe "#edit" do


### PR DESCRIPTION
 - Added a database migration that removed default data from the database
 - Added smart documentation on each LDAP field in place of the default data.