### PR TITLE
Fix pillar issue in public cloud

### DIFF
--- a/app/models/cloud_cluster.rb
+++ b/app/models/cloud_cluster.rb
@@ -68,6 +68,10 @@ class CloudCluster
     persist_to_pillar!(:cloud_worker_security_group, @security_group_id)
     Velum::Salt.call_runner(action: "saltutil.sync_pillar")
     Velum::Salt.call(targets: "admin", action: "saltutil.refresh_pillar")
+    # During tests, the salt-cloud call that immediately follows the pillar
+    # refresh was found to sometimes operate on the old pillar data and
+    # thus fail. The sleep(1) works around this issue. Ideally this should
+    # be resolved in salt and the work-around removed.
     sleep(1)
   end
 

--- a/app/models/cloud_cluster.rb
+++ b/app/models/cloud_cluster.rb
@@ -66,7 +66,8 @@ class CloudCluster
     persist_to_pillar!(:cloud_worker_net, @network_id)
     persist_to_pillar!(:cloud_worker_subnet, @subnet_id)
     persist_to_pillar!(:cloud_worker_security_group, @security_group_id)
-    Velum::Salt.call(action: "saltutil.refresh_pillar")
+    Velum::Salt.call_runner(action: "saltutil.sync_pillar")
+    Velum::Salt.call(targets: "admin", action: "saltutil.refresh_pillar")
   end
 
   def build!

--- a/app/models/cloud_cluster.rb
+++ b/app/models/cloud_cluster.rb
@@ -68,6 +68,7 @@ class CloudCluster
     persist_to_pillar!(:cloud_worker_security_group, @security_group_id)
     Velum::Salt.call_runner(action: "saltutil.sync_pillar")
     Velum::Salt.call(targets: "admin", action: "saltutil.refresh_pillar")
+    sleep(1)
   end
 
   def build!

--- a/lib/velum/salt.rb
+++ b/lib/velum/salt.rb
@@ -20,6 +20,15 @@ module Velum
       [res, JSON.parse(res.body)]
     end
 
+    # This method provides an interface to call salt-runners on the master
+    def self.call_runner(action:, arg: nil)
+      hsh = { client: "runner", fun: action }
+      hsh[:arg] = arg if arg
+
+      res = perform_request(endpoint: "/run", method: "post", data: hsh)
+      [res, JSON.parse(res.body)]
+    end
+
     # Trigger salt-cloud to construct a cluster
     def self.build_cloud_cluster(count)
       instance_names = (1..count).collect { "caasp-node-" + SecureRandom.hex(4) }

--- a/spec/vcr_cassettes/salt/cloud_profile.yml
+++ b/spec/vcr_cassettes/salt/cloud_profile.yml
@@ -2,10 +2,55 @@
 http_interactions:
 - request:
     method: post
+    uri: https://127.0.0.1:8000/run
+    body:
+      encoding: UTF-8
+      string: '{"client":"runner","fun":"saltutil.sync_pillar","username":"saltapi","password":"76KIQepxVKbDOtXdOwCM//kXGVZPl/Xyv02JMR2ScclNQ68wrxgtZrhA8mwt3AAu/gYEdrKU7YK9","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '16'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Tue, 28 Aug 2018 13:44:06 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"return": [[]]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:06 GMT
+- request:
+    method: post
     uri: https://127.0.0.1:8000/login
     body:
       encoding: UTF-8
-      string: '{"username":"saltapi","password":"l+ZtDm9lG1DPdt/QyFfABgWtCN/IKwnmGTK8nCt++PiOVG9Y2NccIrozchvz7RtxREIZe5CshcO0","eauth":"pam"}'
+      string: '{"username":"saltapi","password":"76KIQepxVKbDOtXdOwCM//kXGVZPl/Xyv02JMR2ScclNQ68wrxgtZrhA8mwt3AAu/gYEdrKU7YK9","eauth":"pam"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -23,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Content-Length:
-      - '217'
+      - '172'
       Access-Control-Expose-Headers:
       - GET, POST
       Vary:
@@ -35,29 +80,28 @@ http_interactions:
       Access-Control-Allow-Credentials:
       - 'true'
       Date:
-      - Mon, 05 Feb 2018 20:57:34 GMT
+      - Tue, 28 Aug 2018 13:44:06 GMT
       Access-Control-Allow-Origin:
       - "*"
       X-Auth-Token:
-      - 507fef45a35e7038c9a1cdb754acfc7539aac4a2
+      - 26035eeb65d805fb984dfedb6540b72f56bc7e2b
       Content-Type:
       - application/json
       Set-Cookie:
-      - session_id=507fef45a35e7038c9a1cdb754acfc7539aac4a2; expires=Tue, 06 Feb 2018
-        06:57:34 GMT; Path=/
+      - session_id=26035eeb65d805fb984dfedb6540b72f56bc7e2b; expires=Tue, 28 Aug 2018
+        23:44:06 GMT; Path=/
     body:
       encoding: UTF-8
-      string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
-        "start": 1517864254.835655, "token": "507fef45a35e7038c9a1cdb754acfc7539aac4a2",
-        "expire": 1517907454.835655, "user": "saltapi", "eauth": "pam"}]}'
-    http_version:
-  recorded_at: Mon, 05 Feb 2018 20:57:34 GMT
+      string: '{"return": [{"perms": {}, "start": 1535463846.993196, "token": "26035eeb65d805fb984dfedb6540b72f56bc7e2b",
+        "expire": 1535507046.993197, "user": "saltapi", "eauth": "pam"}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:07 GMT
 - request:
     method: post
     uri: https://127.0.0.1:8000/
     body:
       encoding: UTF-8
-      string: '{"client":"local_async","tgt":"admin","fun":"cloud.profile","arg":["cluster_node","caasp-node-d43efb76"]}'
+      string: '{"tgt":"admin","fun":"saltutil.refresh_pillar","expr_form":"glob","client":"local"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -70,7 +114,110 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Auth-Token:
-      - 507fef45a35e7038c9a1cdb754acfc7539aac4a2
+      - 26035eeb65d805fb984dfedb6540b72f56bc7e2b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '29'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Cache-Control:
+      - private
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Tue, 28 Aug 2018 13:44:07 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=26035eeb65d805fb984dfedb6540b72f56bc7e2b; expires=Tue, 28 Aug 2018
+        23:44:07 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"admin": true}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:07 GMT
+- request:
+    method: post
+    uri: https://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"76KIQepxVKbDOtXdOwCM//kXGVZPl/Xyv02JMR2ScclNQ68wrxgtZrhA8mwt3AAu/gYEdrKU7YK9","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '172'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Tue, 28 Aug 2018 13:44:08 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Auth-Token:
+      - a271cd8e6923cbf0e0be162fc26e958df079d896
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=a271cd8e6923cbf0e0be162fc26e958df079d896; expires=Tue, 28 Aug 2018
+        23:44:08 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"perms": {}, "start": 1535463848.285896, "token": "a271cd8e6923cbf0e0be162fc26e958df079d896",
+        "expire": 1535507048.285897, "user": "saltapi", "eauth": "pam"}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:08 GMT
+- request:
+    method: post
+    uri: https://127.0.0.1:8000/
+    body:
+      encoding: UTF-8
+      string: '{"client":"local_async","tgt":"admin","fun":"cloud.profile","arg":["cluster_node","caasp-node-f0a327bb"]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Auth-Token:
+      - a271cd8e6923cbf0e0be162fc26e958df079d896
   response:
     status:
       code: 200
@@ -91,25 +238,76 @@ http_interactions:
       Access-Control-Allow-Credentials:
       - 'true'
       Date:
-      - Mon, 05 Feb 2018 20:57:34 GMT
+      - Tue, 28 Aug 2018 13:44:08 GMT
       Access-Control-Allow-Origin:
       - "*"
       Content-Type:
       - application/json
       Set-Cookie:
-      - session_id=507fef45a35e7038c9a1cdb754acfc7539aac4a2; expires=Tue, 06 Feb 2018
-        06:57:34 GMT; Path=/
+      - session_id=a271cd8e6923cbf0e0be162fc26e958df079d896; expires=Tue, 28 Aug 2018
+        23:44:08 GMT; Path=/
     body:
       encoding: UTF-8
-      string: '{"return": [{"jid": "20180501142133027777", "minions": ["admin"]}]}'
-    http_version:
-  recorded_at: Mon, 05 Feb 2018 20:57:34 GMT
+      string: '{"return": [{"jid": "20180828134408357764", "minions": ["admin"]}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:08 GMT
+- request:
+    method: post
+    uri: https://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"76KIQepxVKbDOtXdOwCM//kXGVZPl/Xyv02JMR2ScclNQ68wrxgtZrhA8mwt3AAu/gYEdrKU7YK9","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '172'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Tue, 28 Aug 2018 13:44:08 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Auth-Token:
+      - 8a8e64d6a002ceb0265833556628283556b3ff26
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=8a8e64d6a002ceb0265833556628283556b3ff26; expires=Tue, 28 Aug 2018
+        23:44:08 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"perms": {}, "start": 1535463848.435256, "token": "8a8e64d6a002ceb0265833556628283556b3ff26",
+        "expire": 1535507048.435257, "user": "saltapi", "eauth": "pam"}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:08 GMT
 - request:
     method: post
     uri: https://127.0.0.1:8000/
     body:
       encoding: UTF-8
-      string: '{"client":"local_async","tgt":"admin","fun":"cloud.profile","arg":["cluster_node","caasp-node-d43efb76"]}'
+      string: '{"client":"local_async","tgt":"admin","fun":"cloud.profile","arg":["cluster_node","caasp-node-63dbdf37"]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -122,7 +320,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Auth-Token:
-      - 507fef45a35e7038c9a1cdb754acfc7539aac4a2
+      - 8a8e64d6a002ceb0265833556628283556b3ff26
   response:
     status:
       code: 200
@@ -143,25 +341,76 @@ http_interactions:
       Access-Control-Allow-Credentials:
       - 'true'
       Date:
-      - Mon, 05 Feb 2018 20:57:34 GMT
+      - Tue, 28 Aug 2018 13:44:08 GMT
       Access-Control-Allow-Origin:
       - "*"
       Content-Type:
       - application/json
       Set-Cookie:
-      - session_id=507fef45a35e7038c9a1cdb754acfc7539aac4a2; expires=Tue, 06 Feb 2018
-        06:57:34 GMT; Path=/
+      - session_id=8a8e64d6a002ceb0265833556628283556b3ff26; expires=Tue, 28 Aug 2018
+        23:44:08 GMT; Path=/
     body:
       encoding: UTF-8
-      string: '{"return": [{"jid": "20180501142133027836", "minions": ["admin"]}]}'
-    http_version:
-  recorded_at: Mon, 05 Feb 2018 20:57:34 GMT
+      string: '{"return": [{"jid": "20180828134408511476", "minions": ["admin"]}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:08 GMT
+- request:
+    method: post
+    uri: https://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"76KIQepxVKbDOtXdOwCM//kXGVZPl/Xyv02JMR2ScclNQ68wrxgtZrhA8mwt3AAu/gYEdrKU7YK9","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '172'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Tue, 28 Aug 2018 13:44:08 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Auth-Token:
+      - 8d63ff17cfc4fd0ee27facc2abe9adcf638e80fe
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=8d63ff17cfc4fd0ee27facc2abe9adcf638e80fe; expires=Tue, 28 Aug 2018
+        23:44:08 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"perms": {}, "start": 1535463848.589046, "token": "8d63ff17cfc4fd0ee27facc2abe9adcf638e80fe",
+        "expire": 1535507048.589047, "user": "saltapi", "eauth": "pam"}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:08 GMT
 - request:
     method: post
     uri: https://127.0.0.1:8000/
     body:
       encoding: UTF-8
-      string: '{"client":"local_async","tgt":"admin","fun":"cloud.profile","arg":["cluster_node","caasp-node-d43efb76"]}'
+      string: '{"client":"local_async","tgt":"admin","fun":"cloud.profile","arg":["cluster_node","caasp-node-1d3bbab4"]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -174,7 +423,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Auth-Token:
-      - 507fef45a35e7038c9a1cdb754acfc7539aac4a2
+      - 8d63ff17cfc4fd0ee27facc2abe9adcf638e80fe
   response:
     status:
       code: 200
@@ -195,25 +444,76 @@ http_interactions:
       Access-Control-Allow-Credentials:
       - 'true'
       Date:
-      - Mon, 05 Feb 2018 20:57:34 GMT
+      - Tue, 28 Aug 2018 13:44:08 GMT
       Access-Control-Allow-Origin:
       - "*"
       Content-Type:
       - application/json
       Set-Cookie:
-      - session_id=507fef45a35e7038c9a1cdb754acfc7539aac4a2; expires=Tue, 06 Feb 2018
-        06:57:34 GMT; Path=/
+      - session_id=8d63ff17cfc4fd0ee27facc2abe9adcf638e80fe; expires=Tue, 28 Aug 2018
+        23:44:08 GMT; Path=/
     body:
       encoding: UTF-8
-      string: '{"return": [{"jid": "20180501142133027856", "minions": ["admin"]}]}'
-    http_version:
-  recorded_at: Mon, 05 Feb 2018 20:57:34 GMT
+      string: '{"return": [{"jid": "20180828134408680735", "minions": ["admin"]}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:08 GMT
+- request:
+    method: post
+    uri: https://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"76KIQepxVKbDOtXdOwCM//kXGVZPl/Xyv02JMR2ScclNQ68wrxgtZrhA8mwt3AAu/gYEdrKU7YK9","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '171'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Tue, 28 Aug 2018 13:44:08 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Auth-Token:
+      - 5e0854582c63beadd3f50359e090cbed806b7265
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=5e0854582c63beadd3f50359e090cbed806b7265; expires=Tue, 28 Aug 2018
+        23:44:08 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"perms": {}, "start": 1535463848.73994, "token": "5e0854582c63beadd3f50359e090cbed806b7265",
+        "expire": 1535507048.739941, "user": "saltapi", "eauth": "pam"}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:08 GMT
 - request:
     method: post
     uri: https://127.0.0.1:8000/
     body:
       encoding: UTF-8
-      string: '{"client":"local_async","tgt":"admin","fun":"cloud.profile","arg":["cluster_node","caasp-node-d43efb76"]}'
+      string: '{"client":"local_async","tgt":"admin","fun":"cloud.profile","arg":["cluster_node","caasp-node-47d15b76"]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -226,7 +526,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Auth-Token:
-      - 507fef45a35e7038c9a1cdb754acfc7539aac4a2
+      - 5e0854582c63beadd3f50359e090cbed806b7265
   response:
     status:
       code: 200
@@ -247,25 +547,76 @@ http_interactions:
       Access-Control-Allow-Credentials:
       - 'true'
       Date:
-      - Mon, 05 Feb 2018 20:57:34 GMT
+      - Tue, 28 Aug 2018 13:44:08 GMT
       Access-Control-Allow-Origin:
       - "*"
       Content-Type:
       - application/json
       Set-Cookie:
-      - session_id=507fef45a35e7038c9a1cdb754acfc7539aac4a2; expires=Tue, 06 Feb 2018
-        06:57:34 GMT; Path=/
+      - session_id=5e0854582c63beadd3f50359e090cbed806b7265; expires=Tue, 28 Aug 2018
+        23:44:08 GMT; Path=/
     body:
       encoding: UTF-8
-      string: '{"return": [{"jid": "20180501142133027871", "minions": ["admin"]}]}'
-    http_version:
-  recorded_at: Mon, 05 Feb 2018 20:57:34 GMT
+      string: '{"return": [{"jid": "20180828134408827105", "minions": ["admin"]}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:08 GMT
+- request:
+    method: post
+    uri: https://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"76KIQepxVKbDOtXdOwCM//kXGVZPl/Xyv02JMR2ScclNQ68wrxgtZrhA8mwt3AAu/gYEdrKU7YK9","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '172'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Tue, 28 Aug 2018 13:44:08 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Auth-Token:
+      - 772ebee17cf4f5f2b641f25225e01b78061c5219
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=772ebee17cf4f5f2b641f25225e01b78061c5219; expires=Tue, 28 Aug 2018
+        23:44:08 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"perms": {}, "start": 1535463848.938453, "token": "772ebee17cf4f5f2b641f25225e01b78061c5219",
+        "expire": 1535507048.938454, "user": "saltapi", "eauth": "pam"}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:08 GMT
 - request:
     method: post
     uri: https://127.0.0.1:8000/
     body:
       encoding: UTF-8
-      string: '{"client":"local_async","tgt":"admin","fun":"cloud.profile","arg":["cluster_node","caasp-node-d43efb76"]}'
+      string: '{"client":"local_async","tgt":"admin","fun":"cloud.profile","arg":["cluster_node","caasp-node-8b019053"]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -278,7 +629,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Auth-Token:
-      - 507fef45a35e7038c9a1cdb754acfc7539aac4a2
+      - 772ebee17cf4f5f2b641f25225e01b78061c5219
   response:
     status:
       code: 200
@@ -299,69 +650,17 @@ http_interactions:
       Access-Control-Allow-Credentials:
       - 'true'
       Date:
-      - Mon, 05 Feb 2018 20:57:34 GMT
+      - Tue, 28 Aug 2018 13:44:08 GMT
       Access-Control-Allow-Origin:
       - "*"
       Content-Type:
       - application/json
       Set-Cookie:
-      - session_id=507fef45a35e7038c9a1cdb754acfc7539aac4a2; expires=Tue, 06 Feb 2018
-        06:57:34 GMT; Path=/
+      - session_id=772ebee17cf4f5f2b641f25225e01b78061c5219; expires=Tue, 28 Aug 2018
+        23:44:08 GMT; Path=/
     body:
       encoding: UTF-8
-      string: '{"return": [{"jid": "20180501142133027885", "minions": ["admin"]}]}'
-    http_version:
-  recorded_at: Mon, 05 Feb 2018 20:57:34 GMT
-- request:
-    method: post
-    uri: https://127.0.0.1:8000/
-    body:
-      encoding: UTF-8
-      string: '{"client":"local_async","tgt":"admin","fun":"cloud.profile","arg":["cluster_node","caasp-node-d43efb76"]}'
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - application/json; charset=utf-8
-      User-Agent:
-      - Ruby
-      Host:
-      - 127.0.0.1:8000
-      Content-Type:
-      - application/json; charset=utf-8
-      X-Auth-Token:
-      - 507fef45a35e7038c9a1cdb754acfc7539aac4a2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Length:
-      - '67'
-      Access-Control-Expose-Headers:
-      - GET, POST
-      Cache-Control:
-      - private
-      Vary:
-      - Accept-Encoding
-      Server:
-      - CherryPy/3.6.0
-      Allow:
-      - GET, HEAD, POST
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Date:
-      - Mon, 05 Feb 2018 20:57:34 GMT
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Type:
-      - application/json
-      Set-Cookie:
-      - session_id=507fef45a35e7038c9a1cdb754acfc7539aac4a2; expires=Tue, 06 Feb 2018
-        06:57:34 GMT; Path=/
-    body:
-      encoding: UTF-8
-      string: '{"return": [{"jid": "20180501142133027976", "minions": ["admin"]}]}'
-    http_version:
-  recorded_at: Mon, 05 Feb 2018 20:57:34 GMT
+      string: '{"return": [{"jid": "20180828134409031101", "minions": ["admin"]}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:44:09 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/salt/login_500.yml
+++ b/spec/vcr_cassettes/salt/login_500.yml
@@ -48,7 +48,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '["Nope!"]'
-    http_version:
+    http_version: 
   recorded_at: Mon, 05 Feb 2018 20:57:34 GMT
 - request:
     method: post
@@ -98,6 +98,51 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '["Nope!"]'
-    http_version:
+    http_version: 
   recorded_at: Mon, 05 Feb 2018 20:57:34 GMT
+- request:
+    method: post
+    uri: https://127.0.0.1:8000/run
+    body:
+      encoding: UTF-8
+      string: '{"client":"runner","fun":"saltutil.sync_pillar","username":null,"password":null,"eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Content-Length:
+      - 9
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Mon, 27 Aug 2018 15:45:10 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/html;charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '["Nope!"]'
+    http_version: 
+  recorded_at: Mon, 27 Aug 2018 15:45:11 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/salt/refresh_pillar.yml
+++ b/spec/vcr_cassettes/salt/refresh_pillar.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://127.0.0.1:8000/login
+    uri: https://127.0.0.1:8000/run
     body:
       encoding: UTF-8
-      string: '{"username":"saltapi","password":"x3NTblSaFzs2+SjtkW8zkUXL65L5AWbTPScpuzYkcDjmBMgvzixpuPTxDERT7Y1JEjqkMo7KG0+r","eauth":"pam"}'
+      string: '{"client":"runner","fun":"saltutil.sync_pillar","username":"saltapi","password":"76KIQepxVKbDOtXdOwCM//kXGVZPl/Xyv02JMR2ScclNQ68wrxgtZrhA8mwt3AAu/gYEdrKU7YK9","eauth":"pam"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Content-Length:
-      - '216'
+      - '16'
       Access-Control-Expose-Headers:
       - GET, POST
       Vary:
@@ -35,29 +35,73 @@ http_interactions:
       Access-Control-Allow-Credentials:
       - 'true'
       Date:
-      - Sat, 27 Jan 2018 00:12:03 GMT
+      - Tue, 28 Aug 2018 13:43:52 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"return": [[]]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:43:53 GMT
+- request:
+    method: post
+    uri: https://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"76KIQepxVKbDOtXdOwCM//kXGVZPl/Xyv02JMR2ScclNQ68wrxgtZrhA8mwt3AAu/gYEdrKU7YK9","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '172'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Tue, 28 Aug 2018 13:43:53 GMT
       Access-Control-Allow-Origin:
       - "*"
       X-Auth-Token:
-      - cd96f194d3bb5a73ea6f5acd427abe4ff677cb27
+      - 5ead3499d82332daa6dc5eea17d9331737df5f5a
       Content-Type:
       - application/json
       Set-Cookie:
-      - session_id=cd96f194d3bb5a73ea6f5acd427abe4ff677cb27; expires=Sat, 27 Jan 2018
-        10:12:03 GMT; Path=/
+      - session_id=5ead3499d82332daa6dc5eea17d9331737df5f5a; expires=Tue, 28 Aug 2018
+        23:43:53 GMT; Path=/
     body:
       encoding: UTF-8
-      string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
-        "start": 1517011923.448009, "token": "cd96f194d3bb5a73ea6f5acd427abe4ff677cb27",
-        "expire": 1517055123.44801, "user": "saltapi", "eauth": "pam"}]}'
-    http_version:
-  recorded_at: Sat, 27 Jan 2018 00:12:03 GMT
+      string: '{"return": [{"perms": {}, "start": 1535463833.171102, "token": "5ead3499d82332daa6dc5eea17d9331737df5f5a",
+        "expire": 1535507033.171103, "user": "saltapi", "eauth": "pam"}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:43:53 GMT
 - request:
     method: post
     uri: https://127.0.0.1:8000/
     body:
       encoding: UTF-8
-      string: '{"tgt":"*","fun":"saltutil.refresh_pillar","expr_form":"glob","client":"local"}'
+      string: '{"tgt":"admin","fun":"saltutil.refresh_pillar","expr_form":"glob","client":"local"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -70,14 +114,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Auth-Token:
-      - cd96f194d3bb5a73ea6f5acd427abe4ff677cb27
+      - 5ead3499d82332daa6dc5eea17d9331737df5f5a
   response:
     status:
       code: 200
       message: OK
     headers:
       Content-Length:
-      - '41'
+      - '29'
       Access-Control-Expose-Headers:
       - GET, POST
       Cache-Control:
@@ -91,17 +135,17 @@ http_interactions:
       Access-Control-Allow-Credentials:
       - 'true'
       Date:
-      - Sat, 27 Jan 2018 00:12:03 GMT
+      - Tue, 28 Aug 2018 13:43:53 GMT
       Access-Control-Allow-Origin:
       - "*"
       Content-Type:
       - application/json
       Set-Cookie:
-      - session_id=cd96f194d3bb5a73ea6f5acd427abe4ff677cb27; expires=Sat, 27 Jan 2018
-        10:12:03 GMT; Path=/
+      - session_id=5ead3499d82332daa6dc5eea17d9331737df5f5a; expires=Tue, 28 Aug 2018
+        23:43:53 GMT; Path=/
     body:
       encoding: UTF-8
-      string: '{"return": [{"admin": true, "ca": true}]}'
-    http_version:
-  recorded_at: Sat, 27 Jan 2018 00:12:04 GMT
+      string: '{"return": [{"admin": true}]}'
+    http_version: 
+  recorded_at: Tue, 28 Aug 2018 13:43:53 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
I've added a call_runner function to salt interface and added a call to sync_pillar runner in cloud_cluster.rb. This is required to activate the external pillar, which is normally done at orchestration time, but for creating cluster nodes in the cloud, the pillar is needed before that. See also #399 for details.

I've also added a sleep(1) after the refresh_pillar, as we ran into the issue that the succeeding salt-cloud still works on the old pillar data, and this seems to work around it. I know that this is a bit ugly and perhaps can be fixed better in salt directly, but I haven't had any luck yet with narrowing the issue down.