### PR TITLE
use online status during update for update status

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -396,7 +396,11 @@ MinionPoller = {
           appliedHtml = '<i class="fa fa-arrow-circle-up text-warning fa-2x" aria-hidden="true"></i> Update Failed - Retryable';
           break;
         case "pending":
-          appliedHtml += ' Update in progress'
+          if (!minion.online) {
+            appliedHtml += ' Rebooting'
+          } else {
+            appliedHtml += ' Update in progress'
+          }
           break;
         }
     } else if (minion.tx_update_failed) {


### PR DESCRIPTION
we can make use of the online status to have a more accurate status
during the update

if a node is offline during the update, it likely means that it's
rebooting

Signed-off-by: Maximilian Meister <mmeister@suse.de>

### Screenshot of current status

It could be misleading to see the node offline during the update. Without knowing why, it looks like sth went wrong

![update-reboot](https://user-images.githubusercontent.com/5364817/44771968-df8a4a80-ab6c-11e8-83d6-0ea600d3ad86.png)

### Screenshot with the PR applied

![update-rebooting](https://user-images.githubusercontent.com/5364817/44776905-7fe66c00-ab79-11e8-8bc3-04eea958c080.png)
