### PR TITLE
[3.0] when rebooting admin, set tx_update_reboot_needed to false

### DIFF
--- a/app/controllers/updates_controller.rb
+++ b/app/controllers/updates_controller.rb
@@ -7,7 +7,7 @@ class UpdatesController < ApplicationController
   # Reboot the admin node.
   def create
     # rubocop:disable SkipsModelValidations
-    Minion.admin.update_all highstate: Minion.highstates[:applied]
+    Minion.admin.update_all highstate: Minion.highstates[:applied], tx_update_reboot_needed: false
     # rubocop:enable SkipsModelValidations
     ::Velum::Salt.call(
       action:  "cmd.run",


### PR DESCRIPTION
otherwise we have a window after the restart, where the reboot
admin button is still shown, as the event proccessor still needs
time to update the grains

bsc#1099015

Signed-off-by: Maximilian Meister <mmeister@suse.de>
(cherry picked from commit 34c7b11c6cfacd955701c7fefae17d7b22d6b7eb)

Backport of https://github.com/kubic-project/velum/pull/608