### PR TITLE
Fix conflicts with cert upload and ldap connection test

### DIFF
--- a/app/assets/javascripts/settings/ldap-conn-test.js
+++ b/app/assets/javascripts/settings/ldap-conn-test.js
@@ -18,6 +18,45 @@ $(function () {
     $('#ldap_conn_message').html(msg)
   }
 
+  function getCert () {
+    var cert = $('#dex_connector_ldap_certificate').val()
+    var stripped = cert.replace("-----BEGIN CERTIFICATE-----\n",'');
+    stripped = stripped.replace("\n-----END CERTIFICATE-----",'');
+    if( stripped != cert ) $('#dex_connector_ldap_certificate').val( stripped )
+    return stripped;
+  }
+
+  function connectionTest (event) {
+    var cert = getCert();
+    var host = $('#dex_connector_ldap_host').val()
+    var port = $('#dex_connector_ldap_port').val()
+    var startTLS = $('#dex_connector_ldap_start_tls_true').parent().hasClass('active')
+    // Flip logic of #anonymous_bind_toggle since expanded div means anonymous binding is 'false'
+    var anonBind = ($('#anonymous_bind_toggle').attr('aria-expanded') === 'false')
+    var dn = $('#dex_connector_ldap_bind_dn').val()
+    var pass = $("#dex_connector_ldap_bind_pw[required='required']").val();
+    var baseDN = $('#dex_connector_ldap_user_base_dn').val()
+    var filter = $('#dex_connector_ldap_user_filter').val()
+
+    var paramArray = anonBind ? [host, port, cert, baseDN, filter] :
+        [host, port, cert, dn, pass, baseDN, filter]
+    
+    if (noneEmpty(paramArray)) { // Check if form inputs are filled in
+      $.post('/settings/ldap_test', {
+        host: host, port: port, start_tls: startTLS, cert: cert,
+        anon_bind: anonBind, dn: dn, pass: pass, base_dn: baseDN, filter: filter
+      }).done(function (data) {
+        if (data.result.test_pass) renderValidity('Sucessfully validated connection to LDAP server', true)
+        else renderValidity('Validation failure. ' + data.result.message, false)
+      }).fail(function (status) {
+        var valMessage = 'Failed to connect to Velum server with following error code/message: ' + status.status + '; ' + status.statusText
+        renderValidity(valMessage, false)
+      })
+    } else {
+      renderValidity('Missing form data', false)
+    }
+  }
+  
   $(function () {
     // Elements specific to LDAP Connector page; check for existence before changing
     if ($('#ldap_conn_save').length > 0 && $('#ldap_conn_message').length > 0) {
@@ -27,56 +66,6 @@ $(function () {
     };
 
     // Run LDAP Connection Test with button click
-    $('#ldap_conn_test').click(function (event) {
-      // Get values from form
-      var host = $('#dex_connector_ldap_host').val()
-      var port = $('#dex_connector_ldap_port').val()
-      var startTLS = $('#dex_connector_ldap_start_tls_true').parent().hasClass('active')
-      var cert = $('#dex_connector_ldap_certificate').val()
-      // Flip logic of #anonymous_bind_toggle since expanded div means anonymous binding is 'false'
-      var anonBind = ($('#anonymous_bind_toggle').attr('aria-expanded') === 'false')
-      var dn = $('#dex_connector_ldap_bind_dn').val()
-      var pass = $('#dex_connector_ldap_bind_pw').val()
-      var baseDN = $('#dex_connector_ldap_user_base_dn').val()
-      var filter = $('#dex_connector_ldap_user_filter').val()
-
-      var baseURL = '/settings/ldap_test'
-      var valMessage = ''
-      var paramArray = []
-
-      if (anonBind) {
-        paramArray = [host, port, cert, baseDN, filter]
-      } else {
-        paramArray = [host, port, cert, dn, pass, baseDN, filter]
-      }
-
-      var allParamsEntered = noneEmpty(paramArray)
-
-      // Check if form inputs are filled in
-      if (allParamsEntered) {
-        $.post(baseURL, {
-          host: host,
-          port: port,
-          start_tls: startTLS,
-          cert: cert,
-          anon_bind: anonBind,
-          dn: dn,
-          pass: pass,
-          base_dn: baseDN,
-          filter: filter
-        }).done(function (data) {
-          if (data.result.test_pass) {
-            renderValidity('Sucessfully validated connection to LDAP server', true)
-          } else {
-            renderValidity('Validation failure. ' + data.result.message, false)
-          }
-        }).fail(function (status) {
-          valMessage = 'Failed to connect to Velum server with following error code/message: ' + status.status + '; ' + status.statusText
-          renderValidity(valMessage, false)
-        })
-      } else {
-        renderValidity('Missing form data', false)
-      }
-    })
+    $('#ldap_conn_test').click( connectionTest )
   })
 })

--- a/app/controllers/settings/dex_connector_ldaps_controller.rb
+++ b/app/controllers/settings/dex_connector_ldaps_controller.rb
@@ -1,6 +1,36 @@
 # Settings::DexConnectorLdapsController is responsible to manage requests
 # related to LDAP connectors.
 class Settings::DexConnectorLdapsController < Settings::BaseCertificateController
+  def new
+    @certificate_holder = certificate_holder_type.new
+  end
+
+  def create
+    @certificate_holder = certificate_holder_type.new(
+      certificate_holder_params
+    )
+
+    ActiveRecord::Base.transaction do
+      @certificate_holder.save!
+    end
+
+    redirect_to [:settings, @certificate_holder],
+                notice: "#{@certificate_holder.class} was successfully created."
+  rescue ActiveRecord::RecordInvalid
+    render action: :new, status: :unprocessable_entity
+  end
+
+  def update
+    ActiveRecord::Base.transaction do
+      @certificate_holder.update_attributes!(certificate_holder_update_params)
+    end
+
+    redirect_to [:settings, @certificate_holder],
+                notice: "#{@certificate_holder.class} was successfully updated."
+  rescue ActiveRecord::RecordInvalid
+    render action: :edit, status: :unprocessable_entity
+  end
+
   def index
     @ldap_connectors = DexConnectorLdap.all
   end
@@ -22,7 +52,7 @@ class Settings::DexConnectorLdapsController < Settings::BaseCertificateControlle
   end
 
   def certificate_holder_update_params
-    ldap_connector_params.except(:certificate, :current_cert)
+    ldap_connector_params
   end
 
   private
@@ -34,6 +64,6 @@ class Settings::DexConnectorLdapsController < Settings::BaseCertificateControlle
                                                :user_base_dn, :user_filter, :user_attr_username,
                                                :user_attr_id, :user_attr_email, :user_attr_name,
                                                :group_base_dn, :group_filter, :group_attr_user,
-                                               :group_attr_group, :group_attr_name)
+                                               :group_attr_group, :group_attr_name, :certificate)
   end
 end

--- a/app/models/dex_connector_ldap.rb
+++ b/app/models/dex_connector_ldap.rb
@@ -1,7 +1,5 @@
 # Model that represents a dex authentication connector for LDAP
 class DexConnectorLdap < ActiveRecord::Base
-  has_one :certificate_service, as: :service, dependent: :destroy
-  has_one :certificate, through: :certificate_service
   self.table_name = "dex_connectors_ldap"
 
   validates :name, presence: true
@@ -21,4 +19,5 @@ class DexConnectorLdap < ActiveRecord::Base
   validates :group_attr_user, presence: true
   validates :group_attr_group, presence: true
   validates :group_attr_name, presence: true
+  validates :certificate, presence: true
 end

--- a/app/views/settings/dex_connector_ldaps/_form.html.slim
+++ b/app/views/settings/dex_connector_ldaps/_form.html.slim
@@ -42,13 +42,11 @@
     small.form-text.text-muted 
       | When enabled use StartTLS otherwise TLS will be used
 
-  .form-group.form-group-certificate class="#{error_class_for(@cert, :certificate) if @cert.present?}"
+  .form-group.form-group-certificate class="#{error_class_for(@certificate_holder, :certificate)}"
     = f.label :certificate
-    p Upload the certificate of the root CA that issued the LDAP server certificate
-    = f.file_field :certificate, class: "form-control", required: @cert.present?
-    - if @cert.present?
-      = error_messages_for(@cert, :certificate)
-      = f.text_area :current_cert, class: "form-control", value: @cert.certificate, rows: 7, readonly: "readonly"
+    p Paste the certificate for the LDAP server here.
+    = f.text_area :certificate, value: @certificate_holder.certificate, class: "form-control", rows: 5, required: true
+    = error_messages_for(@certificate_holder, :certificate)
 
   br
   h4 Authentication

--- a/app/views/settings/dex_connector_ldaps/show.html.slim
+++ b/app/views/settings/dex_connector_ldaps/show.html.slim
@@ -33,7 +33,7 @@ section.settings-details
     .field
       .details-label Certificate
       .details-value
-        = @certificate_holder.certificate.certificate
+        = @certificate_holder.certificate
 
   h4 Authentication
   .field

--- a/db/migrate/20182030152200_add_dex_connector_cert.rb
+++ b/db/migrate/20182030152200_add_dex_connector_cert.rb
@@ -1,0 +1,5 @@
+class AddDexConnectorCert < ActiveRecord::Migration
+  def change
+    add_column :dex_connectors_ldap, :certificate, :text, after: :group_attr_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181715075510) do
+ActiveRecord::Schema.define(version: 20182030152200) do
 
   create_table "certificate_services", force: :cascade do |t|
     t.integer  "certificate_id", limit: 4
@@ -190,6 +190,7 @@ ActiveRecord::Schema.define(version: 20181715075510) do
     t.string   "group_attr_user",    limit: 255
     t.string   "group_attr_group",   limit: 255
     t.string   "group_attr_name",    limit: 255
+    t.text     "certificate"
   end
 
   add_index "dex_connectors_ldap", ["id"], name: "index_dex_connectors_ldap_on_id", unique: true, using: :btree

--- a/packaging/suse/patches/0_set_default_salt_events_alter_time_column_value.rpm.patch
+++ b/packaging/suse/patches/0_set_default_salt_events_alter_time_column_value.rpm.patch
@@ -1,22 +1,23 @@
 diff --git a/db/schema.rb b/db/schema.rb
-index d37f481..ec3219f 100644
+index e7dbe75..d1df08e 100644
 --- a/db/schema.rb
 +++ b/db/schema.rb
-@@ -107,7 +107,7 @@ ActiveRecord::Schema.define(version: 20181708070234) do
+@@ -107,7 +107,7 @@ ActiveRecord::Schema.define(version: 20182030152200) do
    create_table "salt_events", force: :cascade do |t|
      t.string   "tag",          limit: 255,      null: false
      t.text     "data",         limit: 16777215, null: false
 -    t.datetime "alter_time",                    null: false
-+    t.column   "alter_time",   "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"
++    t.datetime "alter_time",   "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"
      t.string   "master_id",    limit: 255,      null: false
      t.datetime "taken_at"
      t.datetime "processed_at"
-@@ -136,7 +136,7 @@ ActiveRecord::Schema.define(version: 20181708070234) do
+@@ -136,7 +136,7 @@ ActiveRecord::Schema.define(version: 20182030152200) do
      t.string   "id",         limit: 255,      null: false
      t.string   "success",    limit: 10,       null: false
      t.text     "full_ret",   limit: 16777215, null: false
 -    t.datetime "alter_time",                  null: false
-+    t.column   "alter_time", "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"
++    t.datetime "alter_time",   "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"
    end
- 
+
    add_index "salt_returns", ["fun"], name: "fun", using: :btree
+

--- a/spec/controllers/settings/dex_connector_ldaps_controller_spec.rb
+++ b/spec/controllers/settings/dex_connector_ldaps_controller_spec.rb
@@ -4,9 +4,6 @@ RSpec.describe Settings::DexConnectorLdapsController, type: :controller do
   let(:user) { create(:user) }
   let(:certificate) { create(:certificate) }
   let(:certificate_text) { certificate.certificate.strip }
-  let(:certificate_file) do
-    fixture_file_upload(to_fixture_file(certificate.certificate), "application/x-x509-user-cert")
-  end
 
   before do
     setup_done
@@ -33,43 +30,14 @@ RSpec.describe Settings::DexConnectorLdapsController, type: :controller do
     it "assigns a new ldap dex connector to @certificate_holder" do
       expect(assigns(:certificate_holder)).to be_a_new(DexConnectorLdap)
     end
-
-    it "assigns a new certificate to @cert" do
-      expect(assigns(:cert)).to be_a_new(Certificate)
-    end
   end
 
   describe "GET #edit" do
     let!(:dex_connector_ldap) { create(:dex_connector_ldap) }
-    let!(:dex_connector_ldap_with_cert) { create(:dex_connector_ldap) }
-
-    context "without certificate" do
-      before do
-        get :edit, id: dex_connector_ldap.id
-      end
-
-      it "assigns dex_connector_ldap to @dex_connector_ldap" do
-        expect(assigns(:dex_connector_ldap)).not_to be_a_new(DexConnectorLdap)
-      end
-
-      it "assigns a new Certificate to @cert" do
-        expect(assigns(:cert)).to be_a_new(Certificate)
-      end
-    end
 
     context "with certificate" do
-      before do
-        CertificateService.create!(service:     dex_connector_ldap_with_cert,
-                                   certificate: certificate)
-        get :edit, id: dex_connector_ldap_with_cert.id
-      end
-
-      it "assigns dex_connector_ldap to @certificate_holder" do
-        expect(assigns(:certificate_holder)).not_to be_a_new(DexConnectorLdap)
-      end
-
-      it "assigns the existing certificate to @cert" do
-        expect(assigns(:cert)).not_to be_a_new(Certificate)
+      it "assigns the existing certificate to @certificate" do
+        expect(dex_connector_ldap.certificate).to eq("test")
       end
     end
 
@@ -96,7 +64,7 @@ RSpec.describe Settings::DexConnectorLdapsController, type: :controller do
                                             host:               "test.com",
                                             port:               389,
                                             start_tls:          false,
-                                            certificate:        certificate_file,
+                                            certificate:        certificate_text,
                                             bind_anon:          false,
                                             bind_dn:            "cn=admin,dc=example,dc=org",
                                             bind_pw:            "admin",
@@ -127,7 +95,7 @@ RSpec.describe Settings::DexConnectorLdapsController, type: :controller do
         expect(dex_connector_ldap.start_tls).to eq(false)
       end
       it "saves the correct certificate" do
-        expect(dex_connector_ldap.certificate.certificate).to eq(certificate_text)
+        expect(dex_connector_ldap.certificate).to eq(certificate_text)
       end
       it "saves the correct bind_anon value" do
         expect(dex_connector_ldap.bind_anon).to eq(false)
@@ -178,13 +146,8 @@ RSpec.describe Settings::DexConnectorLdapsController, type: :controller do
   end
 
   describe "PATCH #update" do
-    let!(:dex_connector_ldap) { create(:dex_connector_ldap) }
-
-    before do
-      CertificateService.create!(service: dex_connector_ldap, certificate: certificate)
-    end
-
     it "updates a ldap connector" do
+      dex_connector_ldap = create(:dex_connector_ldap)
       dex_connector_ldap_params = { name: "new name" }
       put :update, id: dex_connector_ldap.id, dex_connector_ldap: dex_connector_ldap_params
       expect(DexConnectorLdap.find(dex_connector_ldap.id).name).to eq("new name")

--- a/spec/factories/dex_connectors_ldap_factory.rb
+++ b/spec/factories/dex_connectors_ldap_factory.rb
@@ -42,5 +42,6 @@ FactoryGirl.define do
     group_attr_user "uid"
     group_attr_group "member"
     group_attr_name "name"
+    certificate "test"
   end
 end

--- a/spec/features/settings/dex_connector_ldap_feature_spec.rb
+++ b/spec/features/settings/dex_connector_ldap_feature_spec.rb
@@ -9,7 +9,6 @@ describe "Feature: LDAP connector settings", js: true, order: :defined do
   let!(:dex_connector_ldap3) { create(:dex_connector_ldap) }
   let!(:admin_cert) { create(:certificate) }
   let(:admin_cert_text) { admin_cert.certificate.strip }
-  let(:admin_cert_file) { to_fixture_file(admin_cert.certificate, full_path: true) }
 
   before do
     setup_done
@@ -66,7 +65,7 @@ describe "Feature: LDAP connector settings", js: true, order: :defined do
       fill_in "Host", with: "ldaptest.com"
       fill_in "Port", with: "1234"
       fill_in "Identifying User Attribute", with: "pass"
-      attach_file "Certificate", admin_cert_file
+      fill_in "Certificate", with: admin_cert_text
       fill_in id: "dex_connector_ldap_bind_dn", with: "cn=admin,dc=ldaptest,dc=com"
       fill_in id: "dex_connector_ldap_bind_pw", with: "pass"
       fill_in id: "dex_connector_ldap_user_attr_username", with: "username"
@@ -99,7 +98,7 @@ describe "Feature: LDAP connector settings", js: true, order: :defined do
 
     it "shows an error message if model validation fails" do
       fill_in "Port", with: "AAA"
-      attach_file "Certificate", admin_cert_file
+      fill_in "Certificate", with: admin_cert_text
       fill_in "Password", with: "pass"
       fill_in "Identifying User Attribute", with: "pass"
       fill_in id: "dex_connector_ldap_bind_dn", with: "cn=admin,dc=ldaptest,dc=com"
@@ -121,7 +120,7 @@ describe "Feature: LDAP connector settings", js: true, order: :defined do
 
     it "allows a user to edit an ldap connector" do
       fill_in "Port", with: 626
-      attach_file "Certificate", admin_cert_file
+      fill_in "Certificate", with: admin_cert_text
       page.execute_script("$('#ldap_conn_save').removeProp('disabled')")
       click_button("Save")
 
@@ -130,7 +129,7 @@ describe "Feature: LDAP connector settings", js: true, order: :defined do
 
     it "shows an error message if model validation fails" do
       fill_in "Port", with: "AAA"
-      attach_file "Certificate", admin_cert_file
+      fill_in "Certificate", with: admin_cert_text
       page.execute_script("$('#ldap_conn_save').removeProp('disabled')")
       click_button("Save")
 


### PR DESCRIPTION
The change from a text box to enter certificate content to a file upload broke the functionality of the LDAP external auth feature. That feature requires the inforation entered to be tested to connect to the ldap server before saving. No one tested that after the file upload change and hence it is broken and had to be updated. These changes make it work once more.

The file upload could not be used for the ldap external auth as modern browsers block getting the contents of a file selected for upload in javascript when that file has the extension ".crt" or ".pem". As a result the only way to fetch the cert to use it for the check would be to upload it to the backend somewhere temporarily.

The cert for external auth, though, should never have been changed to a file upload. The planned addition is a button to fetch from the server automatically and confirm to the user the fingerprint and information of the cert. Connecting the external auth to the other certificate handling in the system is not appropriate at this point in time.

This change also includes another fix for ldap connection test to be able to properly fetch the password. That is another breaking change that was not detected, also because there is no automated UI capybara test against the ldap connection stuff. An automated test to prevent this from breaking repeatedly will need to be added in the future as well. It is not included in this commit intentionally. This commit is intended just to get the feature back into a working state having been left broken.