### PR TITLE
specs: fixed TempFile usage for file fixtures

### DIFF
--- a/spec/controllers/settings/dex_connector_ldaps_controller_spec.rb
+++ b/spec/controllers/settings/dex_connector_ldaps_controller_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Settings::DexConnectorLdapsController, type: :controller do
   let(:certificate) { create(:certificate) }
   let(:certificate_text) { certificate.certificate.strip }
   let(:certificate_file) do
-    fixture_file_upload(to_fixture_file(certificate.certificate), "application/x-x509-user-cert")
+    filename = to_file_fixture_name(certificate.certificate)
+    fixture_file_upload(filename, "application/x-x509-user-cert")
   end
 
   before do

--- a/spec/controllers/settings/registries_controller_spec.rb
+++ b/spec/controllers/settings/registries_controller_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe Settings::RegistriesController, type: :controller do
   let(:pem_cert) { create(:certificate) }
   let(:pem_cert_text) { pem_cert.certificate.strip }
   let(:pem_cert_file) do
-    fixture_file_upload(to_fixture_file(pem_cert.certificate), "application/x-x509-user-cert")
+    filename = to_file_fixture_name(pem_cert.certificate)
+    fixture_file_upload(filename, "application/x-x509-user-cert")
   end
   let(:empty_file) do
-    fixture_file_upload(to_fixture_file(""), "text/plain")
+    fixture_file_upload(to_file_fixture_name(""), "text/plain")
   end
 
   before do

--- a/spec/controllers/settings/registry_mirrors_controller_spec.rb
+++ b/spec/controllers/settings/registry_mirrors_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Settings::RegistryMirrorsController, type: :controller do
   let(:pem_cert) { create(:certificate) }
   let(:pem_cert_text) { pem_cert.certificate.strip }
   let(:pem_cert_file) do
-    fixture_file_upload(to_fixture_file(pem_cert.certificate), "application/x-x509-user-cert")
+    fixture_file_upload(to_file_fixture_name(pem_cert.certificate), "application/x-x509-user-cert")
   end
 
   before do

--- a/spec/controllers/settings/system_certificates_controller_spec.rb
+++ b/spec/controllers/settings/system_certificates_controller_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Settings::SystemCertificatesController, type: :controller do
   let(:pem_cert) { create(:certificate) }
   let(:pem_cert_text) { pem_cert.certificate.strip }
   let(:pem_cert_file) do
-    fixture_file_upload(to_fixture_file(pem_cert.certificate), "application/x-x509-user-cert")
+    fixture_file_upload(to_file_fixture_name(pem_cert.certificate), "application/x-x509-user-cert")
   end
   let(:empty_file) do
-    fixture_file_upload(to_fixture_file(""), "text/plain")
+    fixture_file_upload(to_file_fixture_name(""), "text/plain")
   end
 
   before do

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe SetupController, type: :controller do
   let(:pem_cert) { create(:certificate) }
   let(:pem_cert_text) { pem_cert.certificate.strip }
   let(:pem_cert_file) do
-    fixture_file_upload(to_fixture_file(pem_cert.certificate), "application/x-x509-user-cert")
+    filename = File.basename(to_file_fixture(pem_cert.certificate))
+    fixture_file_upload(filename, "application/x-x509-user-cert")
   end
 
   before do

--- a/spec/features/settings/dex_connector_ldap_feature_spec.rb
+++ b/spec/features/settings/dex_connector_ldap_feature_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 # rubocop:disable RSpec/ExampleLength
 # run in order to fix an issue with the `new_cert` test.
-describe "Feature: LDAP connector settings", js: true, order: :defined do
+describe "Feature: LDAP connector settings", js: true do
   let!(:user) { create(:user) }
   let!(:dex_connector_ldap) { create(:dex_connector_ldap) }
   let!(:dex_connector_ldap2) { create(:dex_connector_ldap) }
   let!(:dex_connector_ldap3) { create(:dex_connector_ldap) }
-  let!(:admin_cert) { create(:certificate) }
+  let(:admin_cert) { create(:certificate) }
   let(:admin_cert_text) { admin_cert.certificate.strip }
-  let(:admin_cert_file) { to_fixture_file(admin_cert.certificate, full_path: true) }
+  let(:admin_cert_file) { to_file_fixture(admin_cert.certificate) }
 
   before do
     setup_done
@@ -56,7 +56,7 @@ describe "Feature: LDAP connector settings", js: true, order: :defined do
     end
   end
 
-  describe "#new_cert" do
+  describe "#new" do
     before do
       visit new_settings_dex_connector_ldap_path
     end
@@ -66,7 +66,7 @@ describe "Feature: LDAP connector settings", js: true, order: :defined do
       fill_in "Host", with: "ldaptest.com"
       fill_in "Port", with: "1234"
       fill_in "Identifying User Attribute", with: "pass"
-      attach_file "Certificate", admin_cert_file
+      attach_file "Certificate", admin_cert_file.path
       fill_in id: "dex_connector_ldap_bind_dn", with: "cn=admin,dc=ldaptest,dc=com"
       fill_in id: "dex_connector_ldap_bind_pw", with: "pass"
       fill_in id: "dex_connector_ldap_user_attr_username", with: "username"
@@ -77,7 +77,6 @@ describe "Feature: LDAP connector settings", js: true, order: :defined do
       fill_in id: "dex_connector_ldap_user_base_dn", with: "bdn"
       fill_in id: "dex_connector_ldap_user_filter", with: "filter"
       fill_in id: "dex_connector_ldap_group_filter", with: "filter"
-      fill_in id: "dex_connector_ldap_name", with: "name"
       fill_in id: "dex_connector_ldap_group_attr_user", with: "user"
       fill_in id: "dex_connector_ldap_group_attr_group", with: "group"
       fill_in id: "dex_connector_ldap_user_attr_id", with: "uid"
@@ -85,21 +84,14 @@ describe "Feature: LDAP connector settings", js: true, order: :defined do
       page.execute_script("$('#ldap_conn_save').removeProp('disabled')")
       click_button("Save")
       last_ldap_connector = DexConnectorLdap.last
-      expect(page.text).to have_text(admin_cert_text)
+      expect(page).to have_content(admin_cert_text)
       expect(page).to have_content("DexConnectorLdap was successfully created.")
       expect(page).to have_current_path(settings_dex_connector_ldap_path(last_ldap_connector))
     end
 
-  end
-
-  describe "#new" do
-    before do
-      visit new_settings_dex_connector_ldap_path
-    end
-
     it "shows an error message if model validation fails" do
       fill_in "Port", with: "AAA"
-      attach_file "Certificate", admin_cert_file
+      attach_file "Certificate", admin_cert_file.path
       fill_in "Password", with: "pass"
       fill_in "Identifying User Attribute", with: "pass"
       fill_in id: "dex_connector_ldap_bind_dn", with: "cn=admin,dc=ldaptest,dc=com"
@@ -121,7 +113,7 @@ describe "Feature: LDAP connector settings", js: true, order: :defined do
 
     it "allows a user to edit an ldap connector" do
       fill_in "Port", with: 626
-      attach_file "Certificate", admin_cert_file
+      attach_file "Certificate", admin_cert_file.path
       page.execute_script("$('#ldap_conn_save').removeProp('disabled')")
       click_button("Save")
 
@@ -130,7 +122,7 @@ describe "Feature: LDAP connector settings", js: true, order: :defined do
 
     it "shows an error message if model validation fails" do
       fill_in "Port", with: "AAA"
-      attach_file "Certificate", admin_cert_file
+      attach_file "Certificate", admin_cert_file.path
       page.execute_script("$('#ldap_conn_save').removeProp('disabled')")
       click_button("Save")
 

--- a/spec/features/settings/mirrors_feature_spec.rb
+++ b/spec/features/settings/mirrors_feature_spec.rb
@@ -9,9 +9,9 @@ describe "Feature: Mirrors settings", js: true do
   let!(:mirror2) { create(:registry_mirror, registry: registry) }
   let!(:mirror3) { create(:registry_mirror, registry: registry2) }
   let(:admin_cert_text) { file_fixture("admin.crt").read.strip }
-  let!(:pem_cert) { create(:certificate) }
+  let(:pem_cert) { create(:certificate) }
   let(:pem_cert_text) { pem_cert.certificate.strip }
-  let(:pem_cert_file) { to_fixture_file(pem_cert.certificate, full_path: true) }
+  let(:pem_cert_file) { to_file_fixture(pem_cert.certificate) }
 
   before do
     setup_done
@@ -79,7 +79,7 @@ describe "Feature: Mirrors settings", js: true do
       select registry.name
       fill_in "Name", with: "Mirror"
       fill_in "URL", with: "https://google.com"
-      attach_file "Certificate", pem_cert_file
+      attach_file "Certificate", pem_cert_file.path
       click_button("Save")
 
       last_mirror = RegistryMirror.last

--- a/spec/features/settings/registries_feature_spec.rb
+++ b/spec/features/settings/registries_feature_spec.rb
@@ -10,7 +10,7 @@ describe "Feature: Registries settings", js: true do
   let!(:mirror2) { create(:registry_mirror, registry: registry) }
   let(:pem_cert) { create(:certificate) }
   let(:pem_cert_text) { pem_cert.certificate.strip }
-  let(:pem_cert_file) { to_fixture_file(pem_cert.certificate, full_path: true) }
+  let(:pem_cert_file) { to_file_fixture(pem_cert.certificate) }
 
   before do
     setup_done
@@ -76,7 +76,7 @@ describe "Feature: Registries settings", js: true do
     it "allows an user to create a registry (w/ certificate)" do
       fill_in "Name", with: "Registry"
       fill_in "URL", with: "https://google.com"
-      attach_file "Certificate", pem_cert_file
+      attach_file "Certificate", pem_cert_file.path
       click_button("Save")
 
       last_registry = Registry.last

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,23 +40,25 @@ def file_fixture(fixture_name)
   end
 end
 
-# Create a new file in the fixture directory.
+# Creates a new temporary file in the fixture directory.
 #
 # @param content [String] The content of the new file in string format
-# @param full_path [Boolean] True if the full path should be returned, otherwise
-# will return only the filename.
 #
-# @return The name of the new fixture created or the full_path if full_path is
-# set to true.
-def to_fixture_file(content, full_path: false)
+# @return The TempFile instance of the temporary file fixture
+def to_file_fixture(content)
   file_fixture_path = RSpec.configuration.fixture_path
   Tempfile.open("test_fixture", file_fixture_path) do |file|
     file.write(content)
     file.close
-    if full_path
-      file.path
-    else
-      File.basename(file)
-    end
+    file
   end
+end
+
+# Returns a filename of a temporary file created in the fixture directory.
+#
+# @param content [String] The content of the new file in string format
+#
+# @return The filename of the new fixture created
+def to_file_fixture_name(content)
+  File.basename(to_file_fixture(content))
 end


### PR DESCRIPTION
During #635 review we detected some flakyness while some attempts of fixing Travis. After some investigation I was able to identify an issue with the `TempFile` usage used in our `to_fixture_file` function to create temporary dynamic content fixture.

From the ruby docs:

> When a Tempfile object is garbage collected, or when the Ruby interpreter exits, its associated temporary file is automatically deleted.

In some randomized seeds a temp file was being removed and no content was being uploaded, since the file didn't exist, and the file content wasn't being displayed on the screen as expected.

Since there's no way of controlling when GC is going to remove the temp files, the only way is trying to keep the reference on hold to be usable. The solution for this was to simply return the TempFile instance from `to_file_fixture` instead of the path or base name.

A practical example can be found at https://www.hilman.io/blog/2016/01/tempfile/

Signed-off-by: Vítor Avelino <contact@vitoravelino.me>