### PR TITLE
FIX bsc#1099985 removes unassigned nodes and add a reject node link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle
+/.bundler
 /bundle
 /**/*.swp
 /log/*

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ and much more.
 
 You can start a Velum development environment by following the instructions in [caasp-kvm](https://github.com/kubic-project/automation/caasp-kvm).
 
+## Testing
+
+After you started a Velum development [environment](https://github.com/kubic-project/automation#caasp-devenv). Follow this steps:
+
+1. ssh into the admin node (normally the IP is `10.17.1.0`)
+
+2. run this docker command
+
+    `docker exec -it $(docker ps -q -f 'name=velum-dashboard') entrypoint.sh bash -c "RAILS_ENV=test rspec spec"`
+
+    This will execute the test battery inside the velum-dashboard container. To run a specific test file specify it like this:
+
+    `docker exec -it $(docker ps -q -f 'name=velum-dashboard') entrypoint.sh bash -c "RAILS_ENV=test rspec spec/features/file_name_spec.rb"`
+
 ## Licensing
 
 Velum is licensed under the Apache License, Version 2.0. See

--- a/app/controllers/salt_controller.rb
+++ b/app/controllers/salt_controller.rb
@@ -21,6 +21,25 @@ class SaltController < ApplicationController
     end
   end
 
+  def remove_minion
+    Minion.mark_pending_removal(minion_ids: minion_id_param)
+    Velum::Salt.remove_minion(minion_id: minion_id_param)
+
+    respond_to do |format|
+      format.html { redirect_to root_path }
+      format.json { head :ok }
+    end
+  end
+
+  def reject_minion
+    Velum::Salt.reject_minion(minion_id: minion_id_param)
+
+    respond_to do |format|
+      format.html { redirect_to root_path }
+      format.json { head :ok }
+    end
+  end
+
   def minion_id_param
     params.require(:minion_id)
   end

--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -131,6 +131,10 @@ class Minion < ApplicationRecord
   end
   # rubocop:enable Rails/SkipsModelValidations
 
+  def self.remove_minion(minion_id)
+    Minion.delete_all(minion_id: minion_id)
+  end
+
   # Returns the proxy for the salt minion
   def salt
     @salt ||= Velum::SaltMinion.new minion: self

--- a/app/models/salt_event.rb
+++ b/app/models/salt_event.rb
@@ -13,7 +13,8 @@ class SaltEvent < ApplicationRecord
     SaltHandler::MinionHighstate,
     SaltHandler::OrchestrationTrigger,
     SaltHandler::OrchestrationResult,
-    SaltHandler::CloudBootstrap
+    SaltHandler::CloudBootstrap,
+    SaltHandler::AuthEvent
   ].freeze
 
   scope :not_processed, -> { where(processed_at: nil) }

--- a/app/models/salt_handler/auth_event.rb
+++ b/app/models/salt_handler/auth_event.rb
@@ -1,0 +1,39 @@
+require "velum/salt"
+
+# This class is responsible to handle the salt events with tag "salt/auth".
+# When such an event occurs, we want the minion to be saved in our database
+# if not already there.
+class SaltHandler::AuthEvent
+  attr_reader :salt_event
+
+  def self.can_handle_event?(event)
+    event.tag == "salt/auth"
+  end
+
+  def initialize(salt_event)
+    @salt_event = salt_event
+  end
+
+  # This method is responsible for all actions needed when a minion starts.
+  # For now we simply store the Minion in our database.
+  def process_event
+    parsed_data = salt_event.parsed_data
+    act = parsed_data["act"]
+
+    # Ignore ca and admin minions. It shouldn't be used as part of
+    # the k8s cluster.
+    id = parsed_data["id"]
+    return false if ["ca", "admin"].include? id
+
+    case act
+    when "accept"
+      minion_info = Velum::Salt.minions[id]
+      return false if minion_info.blank?
+      # false if a minion with this minion_id or fqdn already exists (uniqueness validation)
+      Minion.new(minion_id: id, fqdn: minion_info["fqdn"]).save
+    when "pend"
+      # false if a minion with this minion_id is not on DB
+      Minion.remove_minion(id)
+    end
+  end
+end

--- a/app/views/dashboard/unassigned_nodes.html.slim
+++ b/app/views/dashboard/unassigned_nodes.html.slim
@@ -26,6 +26,7 @@ h1 Unassigned Nodes
     button.btn.btn-sm.btn-default.pull-right.hidden.deselect-nodes-btn title="Deselect all the nodes"
       i.fa.fa-times.fa-fw
       | Deselect all nodes
+
   .panel-body
     = form_tag(assign_nodes_url, method: "post")
       div class="nodes-container new-nodes-container" data-url=authenticated_root_path data-current-hostnames='#{@assigned_minions_hostnames}'
@@ -38,6 +39,8 @@ h1 Unassigned Nodes
                 | Hostname
               th width="235"
                 | Role
+              th width="90"
+                | Actions
           tbody
             tr
               td colspan=4

--- a/app/views/setup/discovery.html.slim
+++ b/app/views/setup/discovery.html.slim
@@ -73,6 +73,8 @@ h1 Select nodes and roles
                 | Hostname
               th width="235"
                 | Role
+              th width="90"
+                | Actions
           tbody
             tr
               th colspan=4

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,6 @@ Rails.application.routes.draw do
   get "/kubeconfig", to: "oidc#index"
   get "/_health", to: "health#index"
   post "/update", to: "salt#update"
-  post "/accept-minion", to: "salt#accept_minion"
 
   get "/oidc", to: "oidc#index"
   get "/oidc/done", to: "oidc#done"
@@ -48,6 +47,9 @@ Rails.application.routes.draw do
 
   resources :minions, only: :destroy do
     delete :force, action: :force_destroy, on: :member
+    post "accept-minion", to: "salt#accept_minion"
+    post "remove-minion", to: "salt#remove_minion"
+    post "reject-minion", to: "salt#reject_minion"
   end
 
   namespace :internal_api, path: "internal-api" do

--- a/lib/velum/salt.rb
+++ b/lib/velum/salt.rb
@@ -70,6 +70,24 @@ module Velum
       JSON.parse(res.body)["return"].first["data"]["return"]["minions"]
     end
 
+    # Removes a minion from the cluster
+    def self.remove_minion(minion_id: "")
+      res = perform_request(endpoint: "/", method: "post",
+                            data: { client: "wheel",
+                                    fun:    "key.delete",
+                                    match:  minion_id })
+      JSON.parse(res.code)
+    end
+
+    # Rejects a minion from the cluster
+    def self.reject_minion(minion_id: "")
+      res = perform_request(endpoint: "/", method: "post",
+                            data: { client: "wheel",
+                                    fun:    "key.reject",
+                                    match:  minion_id })
+      JSON.parse(res.code)
+    end
+
     # Returns the list of jobs
     def self.jobs
       res = perform_request(endpoint: "/jobs", method: "get")

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -89,7 +89,7 @@ describe "Bootstrap cluster feature" do
       find(".minion_#{minions[2].id} .worker-btn").click
 
       expect(page).to have_content(minions[3].minion_id)
-      expect(page).to have_content("Accept Node")
+      expect(page).to have_content("Accept | Reject")
 
       click_on_when_enabled "#set-roles"
 
@@ -105,7 +105,7 @@ describe "Bootstrap cluster feature" do
 
       # means it can accept pending node
       expect(page).to have_content(minions[3].minion_id)
-      expect(page).to have_content("Accept Node")
+      expect(page).to have_content("Accept | Reject")
     end
 
     it "removes node from pending acceptance state if accepted", js: true do
@@ -114,8 +114,8 @@ describe "Bootstrap cluster feature" do
 
       visit setup_discovery_path
 
-      expect(page).to have_content("Accept Node")
-      click_on("Accept Node")
+      expect(page).to have_content("Accept | Reject")
+      click_on("Accept")
 
       expect(page).to have_content("Acceptance in progress")
       is_pending = evaluate_script("hasPendingAcceptance('#{minions[3].minion_id}')")
@@ -126,6 +126,25 @@ describe "Bootstrap cluster feature" do
       expect(page).not_to have_content("Acceptance in progress")
       is_pending = evaluate_script("hasPendingAcceptance('#{minions[3].minion_id}')")
       expect(is_pending).to be false
+    end
+
+    it "removes node from unassigned state if removed", js: true do
+      setup_stubbed_pending_minions!(stubbed: [minions[1].minion_id])
+      setup_stubbed_pending_minions!(stubbed: [minions[2].minion_id])
+      setup_stubbed_pending_minions!(stubbed: [minions[3].minion_id])
+      setup_stubbed_pending_minions!(stubbed: [minions[4].minion_id])
+      visit setup_discovery_path
+
+      expect(page).to have_content("Remove")
+      within ".minion_#{minions[0].id}" do
+        click_on "Remove"
+      end
+
+      expect(page).to have_content("Pending removal")
+
+      setup_stubbed_remove_minion!(stubbed: minions[0].minion_id)
+
+      expect(page).not_to have_content("Pending removal")
     end
 
     it "A user selects a subset of nodes to be bootstrapped", js: true do

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -114,12 +114,30 @@ describe "Dashboard" do
       visit authenticated_root_path
 
       expect(page).to have_content(minions[3].minion_id)
-      expect(page).to have_content("Accept Node")
+      expect(page).to have_content("Accept | Reject")
 
       # one of the minions is pending (bootstrapping or update in progress)
       minions[1].update(highstate: Minion.highstates[:pending])
 
-      expect(page).not_to have_content("Accept Node")
+      expect(page).not_to have_content("Accept | Reject")
+    end
+
+    it "reject node from pending acceptance state", js: true do
+      setup_stubbed_pending_minions!(stubbed: [minions[3].minion_id])
+
+      visit authenticated_root_path
+
+      expect(page).to have_content("Accept | Reject")
+
+      within ".minion_#{minions[3].minion_id}" do
+        click_on "Reject"
+      end
+
+      expect(page).to have_content("Rejection in progress")
+
+      setup_stubbed_reject_minion!(stubbed: minions[3].minion_id)
+
+      expect(page).to have_content("Rejection in progress")
     end
 
     it "A user doesn't see (new) link if there's a pending highstate node", js: true do

--- a/spec/lib/velum/salt_spec.rb
+++ b/spec/lib/velum/salt_spec.rb
@@ -95,4 +95,24 @@ describe Velum::Salt do
       end
     end
   end
+
+  describe "remove_minion" do
+    minion_id = "81ad05b9d7ae4d26a83c421b64ca1952"
+    it "removes a minion" do
+      VCR.use_cassette("salt/remove_minion", record: :none) do
+        responses = described_class.remove_minion(minion_id: minion_id)
+        expect(responses).to be(200)
+      end
+    end
+  end
+
+  describe "reject_minion" do
+    minion_id = "81ad05b9d7ae4d26a83c421b64ca1952"
+    it "rejects a minion" do
+      VCR.use_cassette("salt/reject_minion", record: :none) do
+        responses = described_class.reject_minion(minion_id: minion_id)
+        expect(responses).to be(200)
+      end
+    end
+  end
 end

--- a/spec/models/minion_spec.rb
+++ b/spec/models/minion_spec.rb
@@ -317,4 +317,20 @@ describe Minion do
       end
     end
   end
+
+  describe "#remove_minion" do
+    before do
+      minions
+    end
+
+    let(:minion_ids) { [described_class.unassigned_role.first.minion_id] }
+
+    context "when a minion is marked for removal" do
+      it "updates the minion to have pending_removal state" do
+        expect do
+          described_class.remove_minion(minion_ids[0])
+        end.to change { described_class.unassigned_role.count }.from(3).to(2)
+      end
+    end
+  end
 end

--- a/spec/models/salt_event_spec.rb
+++ b/spec/models/salt_event_spec.rb
@@ -143,6 +143,33 @@ describe SaltEvent do
       expect(salt_event.handler).to be_an_instance_of(SaltHandler::OrchestrationResult)
     end
 
+    it "must return an instance of SaltHandler::AuthEvent for salt.auth reject" do
+      salt_event = described_class.new(
+        tag:  "salt/auth",
+        data: { fun: "key.reject" }.to_json
+      )
+
+      expect(salt_event.handler).to be_an_instance_of(SaltHandler::AuthEvent)
+    end
+
+    it "must return an instance of SaltHandler::AuthEvent for salt.auth delete" do
+      salt_event = described_class.new(
+        tag:  "salt/auth",
+        data: { fun: "key.delete" }.to_json
+      )
+
+      expect(salt_event.handler).to be_an_instance_of(SaltHandler::AuthEvent)
+    end
+
+    it "must return an instance of SaltHandler::AuthEvent for salt.auth accept" do
+      salt_event = described_class.new(
+        tag:  "salt/auth",
+        data: { fun: "key.accept" }.to_json
+      )
+
+      expect(salt_event.handler).to be_an_instance_of(SaltHandler::AuthEvent)
+    end
+
     # rubocop:disable RSpec/ExampleLength
     it "must not return an instance of SaltHandler::MinionOrchestration for"\
       " orch.update_etc_hosts" do

--- a/spec/models/salt_handler/auth_event_spec.rb
+++ b/spec/models/salt_handler/auth_event_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+describe SaltHandler::AuthEvent do
+  let(:minion_id) do
+    "3bcb66a2e50646dcabf779e50c6f3232"
+  end
+
+  # rubocop:disable Metrics/LineLength
+  let(:salt_accept_event) do
+    event_data =
+      {
+        "_stamp" => "2018-09-03T13:54:56.605784",
+        "act" => "accept",
+        "id" => minion_id,
+        "pub" => "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArqE0PfawKs3sIOkh1hvH\nf9XB1Zt2fAufGv0fdFzILSsr8Te9nuz9OIRVNUxVkXONUv5BGw0yNxTY4whvSRLs\ng3HetqG1akLD8psQYWgI2VGOuyIV1fwsV4wx/yQ
+            Rb9RqSDWghvFrPLvNKmzkxy3C\nbF75+MzrM67jfktKUDKWABhET2JEMo+nQhgQtxrJ5LVXreJ3097QXVLRZnFMYGQr\nzcjiGzVvvWzQ+uf5fe0mKz5yervqK/GTVA/SBDTVdksuoxFhc1B9xNvXpAjsahJb\noOrcVLhNtT5P3YUDrDpDiLdOG6Pp7mUftp8lTNdQ/b83cIBXP0hm
+            gZ8NH50vORbf\n9wIDAQAB\n-----END PUBLIC KEY-----\n",
+        "result" => true, "pretag" => nil,
+        "tag" => "salt/auth"
+      }.to_json
+
+    FactoryGirl.create(:salt_event, tag: "salt/auth", data: event_data)
+
+  end
+  # rubocop:enable Metrics/LineLength
+
+  # rubocop:disable Metrics/LineLength
+  let(:salt_pend_event) do
+    event_data =
+      {
+        "_stamp" => "2018-09-03T13:54:56.605784",
+        "act" => "pend",
+        "id" => minion_id,
+        "pub" => "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArqE0PfawKs3sIOkh1hvH\nf9XB1Zt2fAufGv0fdFzILSsr8Te9nuz9OIRVNUxVkXONUv5BGw0yNxTY4whvSRLs\ng3HetqG1akLD8psQYWgI2VGOuyIV1fwsV4wx/yQ
+            Rb9RqSDWghvFrPLvNKmzkxy3C\nbF75+MzrM67jfktKUDKWABhET2JEMo+nQhgQtxrJ5LVXreJ3097QXVLRZnFMYGQr\nzcjiGzVvvWzQ+uf5fe0mKz5yervqK/GTVA/SBDTVdksuoxFhc1B9xNvXpAjsahJb\noOrcVLhNtT5P3YUDrDpDiLdOG6Pp7mUftp8lTNdQ/b83cIBXP0hm
+            gZ8NH50vORbf\n9wIDAQAB\n-----END PUBLIC KEY-----\n",
+        "result" => true, "pretag" => nil,
+        "tag" => "salt/auth"
+      }.to_json
+
+    FactoryGirl.create(:salt_event, tag: "salt/auth", data: event_data)
+  end
+
+  # rubocop:enable Metrics/LineLength
+
+  describe "process_event" do
+    # rubocop:disable RSpec/ExampleLength
+    it "removes a minion from salt cluster" do
+      Minion.create! [{ minion_id: minion_id, fqdn: "minion0.k8s.local", role: "master" }]
+      handler = described_class.new(salt_pend_event)
+      VCR.use_cassette("salt/minion_remove", record: :none) do
+        expect { handler.process_event }.to(change { Minion.where(minion_id: minion_id).count }
+        .from(1).to(0))
+      end
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it "creates a new Minion when one with the specified id does not exist" do
+      handler = described_class.new(salt_accept_event)
+      VCR.use_cassette("salt/minion_list", record: :none) do
+        expect { handler.process_event }.to(change { Minion.where(minion_id: minion_id).count }
+          .from(0).to(1))
+      end
+    end
+  end
+end

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -5,6 +5,17 @@ module Utils
     allow(::Velum::Salt).to receive(:pending_minions).and_return(stubbed)
   end
 
+  # Stubs the ::Velum::Salt.remove_minion method with the given data.
+  def setup_stubbed_remove_minion!(stubbed: "")
+    allow(::Velum::Salt).to receive(:remove_minion).and_return(true)
+    Minion.remove_minion(stubbed)
+  end
+
+  # Stubs the ::Velum::Salt.reject_minion method with the given data.
+  def setup_stubbed_reject_minion!(*)
+    allow(::Velum::Salt).to receive(:reject_minion).and_return(true)
+  end
+
   # Initializes the necessary fields for the setup to be considered completed
   def setup_done(dashboard: true, apiserver: true)
     Pillar.create pillar: Pillar.all_pillars[:dashboard], value: "localhost" if dashboard

--- a/spec/vcr_cassettes/salt/reject_minion.yml
+++ b/spec/vcr_cassettes/salt/reject_minion.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"0COpCmgadWq9/91eNjOaoKOR0giqni+FrAFsgGnnKg/izEOOk1JlP7CHLyhY8b5wr7aog+UeWmr8","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '217'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Fri, 23 Jun 2017 11:42:58 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Auth-Token:
+      - 03fd871e370f40ddb14aedc0acf048a505ce01d3
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=03fd871e370f40ddb14aedc0acf048a505ce01d3; expires=Fri, 23 Jun 2017
+        21:42:58 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
+        "start": 1498218178.687943, "token": "03fd871e370f40ddb14aedc0acf048a505ce01d3",
+        "expire": 1498261378.687944, "user": "saltapi", "eauth": "pam"}]}'
+    http_version:
+  recorded_at: Fri, 23 Jun 2017 11:42:58 GMT
+- request:
+    method: post
+    uri: https://127.0.0.1:8000/
+    body:
+      encoding: UTF-8
+      string: '{"client":"wheel","fun":"key.reject","match":"81ad05b9d7ae4d26a83c421b64ca1952"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Auth-Token:
+      - 03fd871e370f40ddb14aedc0acf048a505ce01d3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '303'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Cache-Control:
+      - private
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Fri, 23 Jun 2017 11:42:58 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=03fd871e370f40ddb14aedc0acf048a505ce01d3; expires=Fri, 23 Jun 2017
+        21:42:58 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": []}'
+    http_version:
+  recorded_at: Fri, 23 Jun 2017 11:42:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/salt/remove_minion.yml
+++ b/spec/vcr_cassettes/salt/remove_minion.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://127.0.0.1:8000/login
+    body:
+      encoding: UTF-8
+      string: '{"username":"saltapi","password":"0COpCmgadWq9/91eNjOaoKOR0giqni+FrAFsgGnnKg/izEOOk1JlP7CHLyhY8b5wr7aog+UeWmr8","eauth":"pam"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '217'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Fri, 23 Jun 2017 11:42:58 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Auth-Token:
+      - 03fd871e370f40ddb14aedc0acf048a505ce01d3
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=03fd871e370f40ddb14aedc0acf048a505ce01d3; expires=Fri, 23 Jun 2017
+        21:42:58 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{"perms": [".*", "@wheel", "@runner", "@jobs", "@events"],
+        "start": 1498218178.687943, "token": "03fd871e370f40ddb14aedc0acf048a505ce01d3",
+        "expire": 1498261378.687944, "user": "saltapi", "eauth": "pam"}]}'
+    http_version:
+  recorded_at: Fri, 23 Jun 2017 11:42:58 GMT
+- request:
+    method: post
+    uri: https://127.0.0.1:8000/
+    body:
+      encoding: UTF-8
+      string: '{"client":"wheel","fun":"key.delete","match":"81ad05b9d7ae4d26a83c421b64ca1952"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:8000
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Auth-Token:
+      - 03fd871e370f40ddb14aedc0acf048a505ce01d3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '303'
+      Access-Control-Expose-Headers:
+      - GET, POST
+      Cache-Control:
+      - private
+      Vary:
+      - Accept-Encoding
+      Server:
+      - CherryPy/3.6.0
+      Allow:
+      - GET, HEAD, POST
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Date:
+      - Fri, 23 Jun 2017 11:42:58 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - session_id=03fd871e370f40ddb14aedc0acf048a505ce01d3; expires=Fri, 23 Jun 2017
+        21:42:58 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"return": [{]}'
+    http_version:
+  recorded_at: Fri, 23 Jun 2017 11:42:58 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This adds the possibility to remove an unassigned node, from the assign_nodes page.
I also added a reject node link to the unassigned nodes, seemed to me that that functionality was missing.
*The setup step discovery can also do this.

**CATCH/HELP:** There is a time between when the remove node it's clicked and accepted and when the salt event removes that node from the DB, that the user could assign that node to a role and apply the changes, that leaves the cluster in an unstable state. If someone could help me to figure this out I would appreciate it, maybe disabling it via JS or something, don't know the correct way to approach it.