### PR TITLE
[BSC#1107545] Migrate subnet pillar name v2.1 -> v3

### DIFF
--- a/app/models/pillar.rb
+++ b/app/models/pillar.rb
@@ -92,7 +92,7 @@ class Pillar < ApplicationRecord
         cloud_worker_subnet:
           "cloud:profiles:cluster_node:subnet",
         cloud_worker_security_group:
-          "cloud:profiles:cluster_node:network_interfaces:SecurityGroupId",
+          "cloud:profiles:cluster_node:security_group",
         cloud_worker_net:
           "cloud:profiles:cluster_node:network",
         cloud_worker_resourcegroup:

--- a/db/migrate/20181715075511_rename_cloud_subnet_pillar.rb
+++ b/db/migrate/20181715075511_rename_cloud_subnet_pillar.rb
@@ -1,0 +1,29 @@
+class RenameCloudSubnetPillar < ActiveRecord::Migration
+  def up
+    rename_pillar(
+      from: "cloud:profiles:cluster_node:network_interfaces:0:SubnetId",
+      to:   "cloud:profiles:cluster_node:subnet"
+    )
+    rename_pillar(
+      from: "cloud:profiles:cluster_node:network_interfaces:0:SecurityGroupId",
+      to:   "cloud:profiles:cluster_node:security_group"
+    )
+  end
+
+  def down
+    rename_pillar(
+      from: "cloud:profiles:cluster_node:subnet",
+      to:   "cloud:profiles:cluster_node:network_interfaces:0:SubnetId"
+    )
+    rename_pillar(
+      from: "cloud:profiles:cluster_node:security_group",
+      to:   "cloud:profiles:cluster_node:network_interfaces:0:SecurityGroupId"
+    )
+  end
+
+  def rename_pillar(from:, to:)
+    return unless Pillar.find_by_pillar(from)
+    return if Pillar.find_by_pillar(to)
+    Pillar.find_by_pillar(from).update(pillar: to)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181715075510) do
+ActiveRecord::Schema.define(version: 20181715075511) do
 
   create_table "certificate_services", force: :cascade do |t|
     t.integer  "certificate_id", limit: 4
@@ -28,6 +28,32 @@ ActiveRecord::Schema.define(version: 20181715075510) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "dex_connectors_ldap", force: :cascade do |t|
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "name",               limit: 255
+    t.string   "host",               limit: 255
+    t.integer  "port",               limit: 2
+    t.boolean  "start_tls",                      null: false
+    t.boolean  "bind_anon",                      null: false
+    t.string   "bind_dn",            limit: 255
+    t.string   "bind_pw",            limit: 255
+    t.string   "username_prompt",    limit: 255
+    t.string   "user_base_dn",       limit: 255
+    t.string   "user_filter",        limit: 255
+    t.string   "user_attr_username", limit: 255
+    t.string   "user_attr_id",       limit: 255
+    t.string   "user_attr_email",    limit: 255, null: false
+    t.string   "user_attr_name",     limit: 255
+    t.string   "group_base_dn",      limit: 255
+    t.string   "group_filter",       limit: 255
+    t.string   "group_attr_user",    limit: 255
+    t.string   "group_attr_group",   limit: 255
+    t.string   "group_attr_name",    limit: 255
+  end
+
+  add_index "dex_connectors_ldap", ["id"], name: "index_dex_connectors_ldap_on_id", unique: true, using: :btree
 
   create_table "jids", id: false, force: :cascade do |t|
     t.string "jid",  limit: 255,      null: false
@@ -168,29 +194,4 @@ ActiveRecord::Schema.define(version: 20181715075510) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
-  create_table "dex_connectors_ldap", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "name",               limit: 255
-    t.string   "host",               limit: 255
-    t.integer  "port",               limit: 2 
-    t.boolean  "start_tls",                          null: false
-    t.boolean  "bind_anon",                          null: false
-    t.string   "bind_dn",            limit: 255
-    t.string   "bind_pw",            limit: 255
-    t.string   "username_prompt",    limit: 255 
-    t.string   "user_base_dn",       limit: 255 
-    t.string   "user_filter",        limit: 255 
-    t.string   "user_attr_username", limit: 255 
-    t.string   "user_attr_id",       limit: 255 
-    t.string   "user_attr_email",    limit: 255,     null: false
-    t.string   "user_attr_name",     limit: 255
-    t.string   "group_base_dn",      limit: 255
-    t.string   "group_filter",       limit: 255
-    t.string   "group_attr_user",    limit: 255
-    t.string   "group_attr_group",   limit: 255
-    t.string   "group_attr_name",    limit: 255
-  end
-
-  add_index "dex_connectors_ldap", ["id"], name: "index_dex_connectors_ldap_on_id", unique: true, using: :btree
 end

--- a/spec/controllers/internal_api/v1/pillars_controller_spec.rb
+++ b/spec/controllers/internal_api/v1/pillars_controller_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe InternalApi::V1::PillarsController, type: :controller do
       )
       create(
         :pillar,
-        pillar: "cloud:profiles:cluster_node:network_interfaces:SecurityGroupId",
+        pillar: "cloud:profiles:cluster_node:security_group",
         value:  security_group_id
       )
     end


### PR DESCRIPTION
In v3, the subnet ID is stored in the same Pillar for all public clouds, then arranged into the appropriate pillar structure by InternalApi::V1::PillarsController#cloud_framework_contents

In v2.1, AWS had a different name for the subnet ID (for Azure & GCP, the name is consistent); therefore it is necessary to modify the pillar, if already assigned, in order to prevent losing the customer's entered data.