### PR TITLE
Add global orchestration indicator

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -4,6 +4,7 @@ State = {
   assignableErrors: [],
   pendingRemovalMinionId: null,
   hasPendingStateNode: false,
+  lastOrchestration: null,
 },
 
 MinionPoller = {
@@ -149,7 +150,7 @@ MinionPoller = {
         }
 
         State.minions = minions;
-        State.lastOrchestrationAt = data.last_orchestration_at;
+        State.lastOrchestration = data.last_orchestration;
 
         var pendingStateMinion = minions.find(function (minion) {
           return minion.highstate == "pending";
@@ -214,6 +215,7 @@ MinionPoller = {
 
         MinionPoller.handleAdminUpdate(data.admin || {});
         MinionPoller.handleRetryableOrchestrations(data);
+        MinionPoller.handleOrchestrationStatus();
 
         handleBootstrapErrors();
         handleUnsupportedClusterConfiguration();
@@ -286,6 +288,26 @@ MinionPoller = {
     ';
   },
 
+  handleOrchestrationStatus: function() {
+    if (!State.lastOrchestration) {
+      return;
+    }
+
+    $('.orchestration-status').removeClass('failed succeeded in_progress text-sucess text-danger');
+    $('.orchestration-status').addClass(State.lastOrchestration.status);
+
+    switch (State.lastOrchestration.status) {
+      case 'succeeded':
+        $('.orchestration-status').addClass('text-success');
+        break;
+      case 'failed':
+        $('.orchestration-status').addClass('text-danger');
+        break;
+      default:
+        break;
+    }
+  },
+
   handleAdminUpdate: function(admin) {
     var $notification = $('.admin-outdated-notification');
 
@@ -332,7 +354,7 @@ MinionPoller = {
     var cachedFailedLastOrchestration = window.localStorage.getItem('failedLastOrchestrationAt');
 
     if ($('.failed-bootstrap-alert').length ||
-        cachedFailedLastOrchestration === State.lastOrchestrationAt) {
+        (State.lastOrchestration && cachedFailedLastOrchestration === State.lastOrchestration.created_at)) {
       return;
     }
 
@@ -340,7 +362,7 @@ MinionPoller = {
 
     window.localStorage.removeItem('failedLastOrchestrationAt');
     $alert.on('closed.bs.alert', function () {
-      window.localStorage.setItem('failedLastOrchestrationAt', State.lastOrchestrationAt);
+      window.localStorage.setItem('failedLastOrchestrationAt', State.lastOrchestration.created_at);
       $alert.off('closed.bs.alert');
     })
   },

--- a/app/assets/stylesheets/pages/nodes_list.scss
+++ b/app/assets/stylesheets/pages/nodes_list.scss
@@ -76,6 +76,24 @@
   .right-column dd {
     margin-left: 235px;
   }
+
+  .orchestration-status {
+    > div {
+      display: none;
+    }
+
+    &.in_progress .in_progress {
+      display: block;
+    }
+
+    &.failed .failed {
+      display: block;
+    }
+
+    &.succeeded .succeeded {
+      display: block;
+    }
+  }
 }
 
 .admin-outdated-notification {

--- a/app/controllers/concerns/discovery.rb
+++ b/app/controllers/concerns/discovery.rb
@@ -19,7 +19,7 @@ module Discovery
           admin:                             Minion.find_by(minion_id: "admin"),
           retryable_bootstrap_orchestration: Orchestration.retryable?(kind: :bootstrap),
           retryable_upgrade_orchestration:   Orchestration.retryable?(kind: :upgrade),
-          last_orchestration_at:             Orchestration.last.try(:created_at)
+          last_orchestration:                Orchestration.last
         }
         render json: hsh
       end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -8,8 +8,7 @@ class SettingsController < ApplicationController
   end
 
   def apply
-    Minion.mark_pending_bootstrap!
-    Orchestration.run(kind: :bootstrap)
+    Orchestration.run kind: :bootstrap
     redirect_to root_path, notice: "Registry settings are applied once orchestration is done."
   rescue Orchestration::OrchestrationOngoing
     redirect_to request.referer,

--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -111,15 +111,8 @@ class Minion < ApplicationRecord
   # rubocop:enable SkipsModelValidations
 
   # rubocop:disable Rails/SkipsModelValidations
-  # Updates all nodes in `not_applied` or `failed` highstate to a pending highstate
-  def self.mark_pending_bootstrap
-    Minion.cluster_role.where(highstate: [Minion.highstates[:not_applied],
-                                          Minion.highstates[:failed]])
-          .update_all highstate: Minion.highstates[:pending]
-  end
-
   # Forcefully updates all nodes to a pending highstate
-  def self.mark_pending_bootstrap!
+  def self.mark_pending_bootstrap
     Minion.cluster_role.update_all highstate: Minion.highstates[:pending]
   end
   # rubocop:enable Rails/SkipsModelValidations

--- a/app/models/salt_handler/minion_highstate.rb
+++ b/app/models/salt_handler/minion_highstate.rb
@@ -26,9 +26,9 @@ class SaltHandler::MinionHighstate
 
     data = JSON.parse(salt_event.data)
 
-    highstate_succeeded = data["success"]
+    minion_state = data["success"] ? Minion.highstates[:applied] : Minion.highstates[:failed]
     # rubocop:disable SkipsModelValidations
-    minion.update_column(:highstate, Minion.highstates[:failed]) unless highstate_succeeded
+    minion.update_column :highstate, minion_state
     # rubocop:enable SkipsModelValidations
 
     true

--- a/app/models/salt_handler/orchestration_result.rb
+++ b/app/models/salt_handler/orchestration_result.rb
@@ -49,7 +49,7 @@ class SaltHandler::OrchestrationResult < SaltHandler::Orchestration
   def update_minions(orchestration_type:, orchestration_succeeded:)
     case orchestration_type
     when "orch.kubernetes", "orch.update"
-      update_pending_minions orchestration_succeeded: orchestration_succeeded
+      update_all_minions orchestration_succeeded: orchestration_succeeded
     when "orch.removal"
       update_pending_removal_minions orchestration:           orchestration,
                                      orchestration_succeeded: orchestration_succeeded
@@ -58,12 +58,12 @@ class SaltHandler::OrchestrationResult < SaltHandler::Orchestration
     end
   end
 
-  def update_pending_minions(orchestration_succeeded:)
+  def update_all_minions(orchestration_succeeded:)
     # rubocop:disable SkipsModelValidations
     if orchestration_succeeded
-      Minion.pending.update_all highstate: Minion.highstates[:applied]
+      Minion.assigned_role.update_all highstate: Minion.highstates[:applied]
     else
-      Minion.pending.update_all highstate: Minion.highstates[:failed]
+      Minion.assigned_role.update_all highstate: Minion.highstates[:failed]
     end
     # rubocop:enable SkipsModelValidations
   end

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -34,6 +34,17 @@ h1 Cluster Status
               span#out_dated_nodes 0
               = link_to update_path, id: "update-all-nodes", class: "hidden", method: :post do
                 | (update all nodes)
+            dt Orchestration
+            dd.orchestration-status
+              .in-progress
+                i.fa.fa-spinner.fa-spin.fa-pulse
+                |  In progress
+              .succeeded
+                i.fa.fa-check
+                |  Succeeded
+              .failed
+                i.fa.fa-times
+                |  Failed
     .panel-footer.admin-outdated-notification.hidden
       .message
         i.fa.fw.fa-exclamation-circle

--- a/spec/models/minion_spec.rb
+++ b/spec/models/minion_spec.rb
@@ -280,7 +280,7 @@ describe Minion do
     end
   end
 
-  describe "#mark_pending_bootstrap!" do
+  describe "#mark_pending_bootstrap" do
     before do
       minions
       described_class.second.assign_role :master, remote: false
@@ -292,7 +292,7 @@ describe Minion do
 
     context "when a bootstrap is triggered" do
       it "sets the highstate of all minions as pending" do
-        expect { described_class.mark_pending_bootstrap! }.to change {
+        expect { described_class.mark_pending_bootstrap }.to change {
           described_class.cluster_role.pending.count
         }.from(0).to(3)
       end

--- a/spec/models/salt_handler/minion_highstate_spec.rb
+++ b/spec/models/salt_handler/minion_highstate_spec.rb
@@ -71,11 +71,11 @@ describe SaltHandler::MinionHighstate do
       expect(handler.process_event).to be(true)
     end
 
-    it "does not update the matching Minion's highstate column if it's success" do
+    it "updates the matching Minion's highstate column if it's success" do
       matching_minion
 
       expect { handler.process_event }
-        .not_to(change { matching_minion.reload.highstate })
+        .to(change { matching_minion.reload.highstate }.from("pending").to("applied"))
     end
 
     it "updates the matching Minion's highstate column if it's failure" do

--- a/spec/models/salt_handler/orchestration_result_spec.rb
+++ b/spec/models/salt_handler/orchestration_result_spec.rb
@@ -198,8 +198,10 @@ describe SaltHandler::OrchestrationResult do
         expect { handler.process_event }.to change { pending_minion.reload.highstate }
           .from("pending").to("failed")
       end
-      it "does not affect applied minions" do
-        expect { handler.process_event }.not_to change { Minion.cluster_role.applied.count }.from(1)
+
+      it "marks applied minions as failed" do
+        expect { handler.process_event }.to change { applied_minion.reload.highstate }
+          .from("applied").to("failed")
       end
     end
 


### PR DESCRIPTION
- [x] Include the global orchestration indicator in the UI

This allows us to mark machines as succeeded as soon as we know the
highstate on that machine succeeded, providing a better timely
feedback to the user.

Fixes: bsc#1064610