### PR TITLE
[3.0][bsc#1108679] use online status during update for update status

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -384,7 +384,11 @@ MinionPoller = {
           appliedHtml = '<i class="fa fa-arrow-circle-up text-warning fa-2x" aria-hidden="true"></i> Update Failed - Retryable';
           break;
         case "pending":
-          appliedHtml += ' Update in progress'
+          if (!minion.online) {
+            appliedHtml += ' Rebooting'
+          } else {
+            appliedHtml += ' Update in progress'
+          }
           break;
         }
     } else if (minion.tx_update_failed) {


### PR DESCRIPTION
we can make use of the online status to have a more accurate status
during the update

if a node is offline during the update, it likely means that it's
rebooting

Signed-off-by: Maximilian Meister <mmeister@suse.de>
(cherry picked from commit 23bb090b5a8bd74a3f3af935701356d9aacf4276)

Backport of https://github.com/kubic-project/velum/pull/641