### PR TITLE
[3.0] update sprockets to fix cve-2018-3760 cve#2018-3760

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
Backport of  https://github.com/kubic-project/velum/pull/591

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>
(cherry picked from commit f94cdfd33a544c072cd7d924ce5cb721c212ef8a)