### PR TITLE
OIDC Connector support

### DIFF
--- a/app/controllers/internal_api/v1/pillars_controller.rb
+++ b/app/controllers/internal_api/v1/pillars_controller.rb
@@ -1,4 +1,5 @@
 require "velum/dex/ldap"
+require "velum/dex/oidc"
 
 # Serve the pillar information
 # rubocop:disable Metrics/ClassLength
@@ -192,6 +193,7 @@ class InternalApi::V1::PillarsController < InternalApiController
   def dex_connectors_as_pillar
     connectors = []
     connectors.concat(Velum::Dex.ldap_connectors_as_pillar)
+    connectors.concat(Velum::Dex.oidc_connectors_as_pillar)
     { dex: { connectors: connectors } }
   end
 end

--- a/app/controllers/settings/dex_connector_oidcs_controller.rb
+++ b/app/controllers/settings/dex_connector_oidcs_controller.rb
@@ -1,0 +1,98 @@
+# Settings::DexConnectorOidcsController is responsible to manage requests
+# related to OIDC connectors.
+class Settings::DexConnectorOidcsController < SettingsController
+  # populate @data_holder with existing database record
+  before_action :set_data_holder, except: [:index, :new, :create]
+
+  def index
+    @oidc_connectors = DexConnectorOidc.all
+  end
+
+  def new
+    @is_data_valid = false
+    @data_holder = data_holder_type.new
+  end
+
+  def edit
+    @is_data_valid = false
+  end
+
+  def create
+    @data_holder = data_holder_type.new(data_holder_params)
+
+    if params[:validate]
+      @is_data_valid = @data_holder.valid?
+      if @is_data_valid
+        flash.now[:notice] = "#{friendly_name} is valid"
+      else
+        flash.now[:alert]  = "#{friendly_name} is invalid"
+      end
+      render action: :new
+    else
+      @data_holder.save!
+      redirect_to settings_dex_connector_oidcs_path,
+                  notice: "#{friendly_name} was successfully created."
+    end
+  rescue ActiveRecord::RecordInvalid
+    render action: :new, status: :unprocessable_entity
+  end
+
+  def destroy
+    @data_holder.destroy!
+
+    redirect_to settings_dex_connector_oidcs_path,
+                notice: "OIDC Connector was successfully removed."
+  end
+
+  def update
+    if params[:validate]
+      # merge form values with DB record so form redisplays properly
+      data_holder_update_params.each do |key, value|
+        @data_holder[key] = value
+      end
+      @is_data_valid = @data_holder.valid?
+      if @is_data_valid
+        flash.now[:notice] = "#{friendly_name} is valid"
+      else
+        flash.now[:alert]  = "#{friendly_name} is invalid"
+      end
+      render action: :edit
+    else
+      @data_holder.update_attributes!(data_holder_update_params)
+      redirect_to [:settings, @data_holder],
+                  notice: "#{friendly_name} was successfully updated."
+    end
+  rescue ActiveRecord::RecordInvalid
+    render action: :edit, status: :unprocessable_entity
+  end
+
+  protected
+
+  def data_holder_type
+    DexConnectorOidc
+  end
+
+  def data_holder_params
+    oidc_connector_params
+  end
+
+  def data_holder_update_params
+    oidc_connector_params
+  end
+
+  def friendly_name
+    "OIDC Connector"
+  end
+
+  private
+
+  def oidc_connector_params
+    params.require(:dex_connector_oidc).permit(
+      :name, :provider_url, :client_id, :client_secret, :callback_url, :basic_auth
+    )
+  end
+
+  def set_data_holder
+    @data_holder = data_holder_type.find(params[:id])
+  end
+end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -28,6 +28,10 @@ module SettingsHelper
     request.fullpath.starts_with?(settings_dex_connector_ldaps_path)
   end
 
+  def settings_dex_connector_oidcs_path?
+    request.fullpath.starts_with?(settings_dex_connector_oidcs_path)
+  end
+
   def registries_options_for_select
     registries = Registry.suse + Registry.displayable
     registries_for_options = registries.collect { |r| [r.name, r.id] }

--- a/app/models/dex_connector_oidc.rb
+++ b/app/models/dex_connector_oidc.rb
@@ -1,0 +1,11 @@
+# Model that represents a dex authentication connector for OIDC
+class DexConnectorOidc < ActiveRecord::Base
+  self.table_name = "dex_connectors_oidc"
+
+  validates :name,          presence: true
+  validates :provider_url,  presence: true, oidc_provider: true
+  validates :client_id,     presence: true
+  validates :client_secret, presence: true
+  validates :callback_url,  presence: true, http_url: true
+  validates :basic_auth,    presence: true
+end

--- a/app/validators/http_url_validator.rb
+++ b/app/validators/http_url_validator.rb
@@ -1,0 +1,18 @@
+# Validate that a URL is a legal http/https format URL
+class HttpUrlValidator < ActiveModel::EachValidator
+  def self.compliant?(value)
+    # Ruby URI complains if any underscores are in the FQDN
+    # value = value.gsub('_','')
+    uri = URI.parse(value)
+    # https inherits from http, so both "is a" http
+    uri.is_a?(URI::HTTP) && !uri.host.nil?
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def validate_each(record, attribute, value)
+    return true if value.present? && self.class.compliant?(value)
+    record.errors.add(attribute, "is not a valid HTTP URL")
+    false
+  end
+end

--- a/app/validators/oidc_provider_validator.rb
+++ b/app/validators/oidc_provider_validator.rb
@@ -1,0 +1,71 @@
+# Validate that column contains a reachable OIDC Provider
+class OidcProviderValidator < HttpUrlValidator
+  def self.validate_issuer?(i)
+    url = URI.parse(i)
+    # collapse things like trailing slashes, etc in URL
+    url.path = File.absolute_path(url.path)
+
+    c = HTTPClient.new
+    # disable TLS validation :/
+    # TODO: enable specifying self-signed cert in upstream dex (or disabling cert validation)
+    # TODO: enable checking system certificates in Velum container
+    # do not enable cert validation until the above are done
+    c.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    # c.ssl_config.add_trust_ca cert_file "a.pem" # to use a specific cert
+    unparsed_response = c.get_content "#{url}/.well-known/openid-configuration"
+    response = JSON.parse(unparsed_response)
+
+    iss = URI.parse(response["issuer"])
+    unless iss == url
+      raise OpenIDConnect::Discovery::DiscoveryFailed, "provider '#{url}' !=  issuer '#{iss}'"
+    end
+    true
+
+    # TODO: also check supported methods?
+
+    # Once we get CA certs working, this is perhaps better than the above:
+    # This is also why all the errors raise DiscoveryFailed exceptions
+    #
+    # parsed_uri = URI.parse(value)
+    # unless parsed_uri.is_a?(URI::HTTPS)
+    #   # SWD will be replaced with Webfinger in OIDC gem eventually.
+    #   # Setting both here should help future-proof things
+    #   SWD.url_builder = URI::HTTP
+    #   WebFinger.url_builder = URI::HTTP
+    # end
+    # response = OpenIDConnect::Discovery::Provider::Config.discover!(i)
+    # response.validate(i)
+  end
+
+  def self.compliant?(value)
+    return false unless super
+    validate_issuer?(value)
+  # SSl validation errors should be turned back on eventually
+  rescue OpenSSL::SSL::SSLError => e
+    raise OpenIDConnect::Discovery::DiscoveryFailed, e
+  # pass through timeout and socket errors
+  rescue SocketError => e
+    raise e
+  rescue TimeoutError => e
+    raise e
+  # any other error just gets converted to a discovery error w/ same content
+  rescue StandardError => e
+    raise OpenIDConnect::Discovery::DiscoveryFailed, e
+  end
+
+  def validate_each(record, attribute, value)
+    return false unless super
+    return true if value.present? && self.class.compliant?(value)
+    # record.errors.add(attribute, "is not a valid OIDC provider")
+    # false
+  rescue OpenIDConnect::Discovery::DiscoveryFailed => e
+    record.errors.add(attribute, "is not a valid OIDC provider: discovery failure (error: #{e})")
+    false # any error with webfinger / issuer mismatch
+  rescue SocketError
+    record.errors.add(attribute, "is not a valid OIDC provider: bad/unresolvable hostname")
+    false # hostname not resolvable
+  rescue TimeoutError
+    record.errors.add(attribute, "is not a valid OIDC provider: connection timeout")
+    false # The System Is Down
+  end
+end

--- a/app/views/settings/_sidebar.html.slim
+++ b/app/views/settings/_sidebar.html.slim
@@ -10,7 +10,9 @@ aside.settings-sidebar-section
   h5.title External Authentication
   ul.list
     li class="#{active_class?(settings_dex_connector_ldaps_path?)}"
-      = link_to "LDAP Connectors", settings_dex_connector_ldaps_path
+      = link_to "LDAP Servers", settings_dex_connector_ldaps_path
+    li class="#{active_class?(settings_dex_connector_oidcs_path?)}"
+      = link_to "OIDC Providers", settings_dex_connector_oidcs_path  
   h5.title Kubernetes
   ul.list
     li class="#{active_class?(settings_kubelet_compute_resources_reservations_path?)}"

--- a/app/views/settings/dex_connector_oidcs/_form.html.slim
+++ b/app/views/settings/dex_connector_oidcs/_form.html.slim
@@ -1,0 +1,70 @@
+= form_for [:settings, @data_holder], html: { class: "dex-connectors-form", autocomplete: "false" } do |f|
+  / Chrome may autocomplete username into text field before a password field, regardless of name
+  / This *should* prevent that (in combination with 'autocomplete=false' on the form_for; "off" no longer works)
+  / Explanation: Chrome looks for the first password field, while newer versions prefer one named "password"
+  / Firefox behaves similarly.  Hopefully they don't figure out the hidden workaround soon...
+  = f.text_field     :username, style: "display:none", value:"autocomplete trap"
+  = f.password_field :password, style: "display:none", value:"autocomplete bait"
+
+
+  .form-group class="#{error_class_for(@data_holder, :name)}"
+    = f.label :name
+    = f.text_field :name, id: "oidc_name", class: "form-control", value: @data_holder.name, required: true
+    = error_messages_for(@data_holder, :name)
+    small.form-text.text-muted
+      | Name shown to user when selecting a connector
+
+  h4 Provider
+
+  .form-group class="#{error_class_for(@data_holder, :provider_url)}"
+    = f.label :provider_url, "Provider URL"
+    = f.text_field :provider_url, id: "oidc_provider", class: "form-control", value: @data_holder.provider_url, required: true
+    = error_messages_for(@data_holder, :provider_url)
+    small.form-text.text-muted
+      | Issuer used by OIDC Provider
+    
+  .form-group class="#{error_class_for(@data_holder, :basic_auth)}"
+    = f.label :basic_auth, "Negotiate client auth"
+    br
+    .btn-group.btn-group-toggle data-toggle="buttons"
+      = f.label :basic_auth, nil, class: "btn btn-default #{'btn-primary active' if @data_holder.basic_auth}"
+        = f.radio_button :basic_auth, "true", checked: @data_holder.basic_auth
+        | Enable
+      = f.label :basic_auth, nil, class: "btn btn-default #{'btn-primary active' unless @data_holder.basic_auth}"
+        = f.radio_button :basic_auth, "false", checked: !@data_holder.basic_auth
+        | Disable
+    = error_messages_for(@data_holder, :basic_auth)
+    br
+    small.form-text.text-muted
+      | Set to "Disable" only if this provider requires client credentials to be sent using POST but doesn't publish that requirement in discovery response (this is uncommon)
+    
+  h4 Client
+  
+  / The 'https' and '3200' seem to be hard-coded elsewhere, so I assume they're not discoverable :/
+  - external_api_url = "https://#{Pillar.value(pillar: :apiserver)}:32000/callback"
+  .form-group class="#{error_class_for(@data_holder, :callback_url)}"
+    = f.label :callback_url, "Callback URL:"
+    span.show
+      = external_api_url
+    small.form-text.text-muted
+      | URL which will be provided to OIDC provider as the callback location
+    = f.hidden_field :callback_url, id: "oidc_callback_url", class: "form-control", value: external_api_url, readonly: true
+
+  .form-group class="#{error_class_for(@data_holder, :client_id)}"
+    = f.label :client_id, "ID"
+    = f.text_field :client_id, id: "oidc_client_id", class: "form-control", value: @data_holder.client_id, required: true
+    = error_messages_for(@data_holder, :client_id)
+    small.form-text.text-muted
+      | Client ID provided by OIDC Provider
+    
+  .form-group class="#{error_class_for(@data_holder, :client_secret)}"
+    = f.label :client_secret, "Secret"
+    = f.password_field :client_secret, id: "oidc_client_secret", class: "form-control", value: @data_holder.client_secret, required: true
+    = error_messages_for(@data_holder, :client_secret)
+    small.form-text.text-muted
+      | Secret associated with Relying Party's Client ID
+
+  .form-actions.clearfix
+    = f.submit "Save", class: "btn btn-primary action", id: "oidc_conn_save", name: "submit", disabled: !@is_data_valid
+    = link_to "Cancel", settings_dex_connector_oidcs_path, class: "btn btn-default action"
+    = f.submit "Test Connection", class: "btn btn-primary", id: "oidc_conn_validate", name: "validate"

--- a/app/views/settings/dex_connector_oidcs/edit.html.slim
+++ b/app/views/settings/dex_connector_oidcs/edit.html.slim
@@ -1,0 +1,3 @@
+h2 Edit
+
+= render 'form'

--- a/app/views/settings/dex_connector_oidcs/index.html.slim
+++ b/app/views/settings/dex_connector_oidcs/index.html.slim
@@ -1,0 +1,25 @@
+= render 'settings/apply'
+
+h2 OIDC Connectors
+
+= link_to "Add OIDC connector", new_settings_dex_connector_oidc_path, class: "btn btn-primary add-entry-btn"
+
+- if @oidc_connectors.present?
+    section
+      table.table
+        thead
+          tr
+            th Name
+            th width="110"
+        tbody
+          - @oidc_connectors.each do |conn|
+            tr class="dex_connector_oidc#{conn.id}"
+              td
+                = link_to conn.name, settings_dex_connector_oidc_path(conn)
+              td.actions
+                = link_to edit_settings_dex_connector_oidc_path(conn), class: "btn btn-default icon-only edit-btn" do
+                  i.fa.fa-pencil
+                = link_to settings_dex_connector_oidc_path(conn), method: "delete", class: "btn btn-danger icon-only delete-btn", data: { confirm: "Are you sure?" } do
+                  i.fa.fa-trash-o
+- else
+  p No OIDC connectors found.

--- a/app/views/settings/dex_connector_oidcs/new.html.slim
+++ b/app/views/settings/dex_connector_oidcs/new.html.slim
@@ -1,0 +1,3 @@
+h2  New OIDC Connector
+
+= render 'form'

--- a/app/views/settings/dex_connector_oidcs/show.html.slim
+++ b/app/views/settings/dex_connector_oidcs/show.html.slim
@@ -1,0 +1,26 @@
+= render 'settings/apply'
+
+header.settings-content-header.clearfix
+  .title.pull-left
+    h2 #{@data_holder.name} details
+  .actions.pull-right
+    = link_to settings_dex_connector_oidc_path(@data_holder), method: "delete", class: "btn btn-danger", data: { confirm: "Are you sure?" } do
+      | Delete
+    = link_to edit_settings_dex_connector_oidc_path(@data_holder), class: "btn btn-primary" do
+      | Edit
+
+section.settings-details
+  .field
+    .details-label ID
+    .details-value
+      = @data_holder.id
+  .field
+    .details-label Name
+    .details-value
+      = @data_holder.name
+
+  h4 Provider
+  .field
+    .details-label Provider URL
+    .details-value
+      = @data_holder.provider_url

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,6 +1,9 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:pass, :password, :bind_pw, :cert, :certificate, \
-                                               :client_secret, \
-                                               :authenticity_token, :id_token, :refresh_token]
+Rails.application.config.filter_parameters += [
+  :pass, :password, :bind_pw,
+  :cert, :certificate,
+  :client_secret,
+  :authenticity_token, :id_token, :refresh_token
+]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
     resources :system_certificates
     resources :ldap_test
     resources :dex_connector_ldaps, path: :ldap_connectors
+    resources :dex_connector_oidcs, path: :oidc_connectors
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/db/migrate/20182106194300_create_dex_connectors_oidc.rb
+++ b/db/migrate/20182106194300_create_dex_connectors_oidc.rb
@@ -1,0 +1,13 @@
+class CreateDexConnectorsOidc < ActiveRecord::Migration
+  def change
+    create_table :dex_connectors_oidc do |t|
+      t.timestamps                                               null: true
+      t.string   :name
+      t.string   :provider_url,       limit: 2048
+      t.string   :client_id
+      t.string   :client_secret
+      t.string   :callback_url,       limit: 2048
+      t.boolean  :basic_auth,                     default: true, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181715075511) do
+ActiveRecord::Schema.define(version: 20182106194300) do
 
   create_table "certificate_services", force: :cascade do |t|
     t.integer  "certificate_id", limit: 4
@@ -194,4 +194,14 @@ ActiveRecord::Schema.define(version: 20181715075511) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  create_table "dex_connectors_oidc", force: :cascade do |t|
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "name"
+    t.string   "provider_url",       limit: 2048
+    t.string   "client_id"
+    t.string   "client_secret"
+    t.string   "callback_url",       limit: 2048
+    t.boolean  "basic_auth",                     default: true, null: false
+  end
 end

--- a/docs/oidc_testing/README.md
+++ b/docs/oidc_testing/README.md
@@ -1,0 +1,66 @@
+# Bring up a cluster
+1. Set up dev environment
+   ```
+   git clone git@github.com:kubic-project/automation
+   cd automation
+   ./caasp-devenv --setup
+   ```
+1. `cd ../automation && ./caasp-devenv --build --bootstrap` (with whatever other options, like `-L provo`)
+
+# Bring up the stand-alone dex OIDC Provider (OP)
+1. `cd ../velum/docs/oidc_testing`
+1. `cp examples/config-dev.yaml{.example,}`
+1. edit `examples/config-dev.yaml` as needed, paying special attention to the two places marked `NOTE`:
+   * set the `issuer:` URL to match the DNS host name of your development machine.  Note that this hostname must resolve _via DNS_ from the master and worker nodes running the dex_dex container.  You can check this via: `docker exec _container_id_ ping -c 1 _host_name_`.  You should get a response back, and it should show the IP address of the host.  The URL used as the issuer _must_ be exactly the URL you use in the OIDC provider URL field in Vellum".
+   * If you do not have a DNS-resolvable name, there are a variety of ways to fix that.  The easiest is to add an entry to the libvirt DNS resolver, which will make the hostname/IP mapping work from the VMs and containers within, but won't affect anything outside the cluster.  Say you're using `dexhost.do.main` as your issuer name, and it's listening on `192.168.0.213`.  Do this, and then retry the ping test above:
+     ```
+     virsh net-update caasp-dev-net add dns-host '<host ip="192.168.0.213"><hostname>dexhost.do.main</hostname></host>' --live --config
+     ```
+     Note that you can add multiple hostnames within the host, should that be necessary.
+1. still in the directory where docker-compose.yml is, run `docker-compose up -d`
+   * output should look roughly like this:
+     ```
+     sauer@lightning:~/dev/dex$ docker-compose up -d
+     Starting dex_base_1 ... done
+     Starting dex_dex_1  ... done
+     sauer@lightning:~/dev/dex$ 
+     ```
+   * logs can be accessed using `docker-compose logs` in the same directory; append `-f` to equivocate `tail -f` on the log
+1. it should be possible to use WebFinger to fetch the important data from Dex now, using `curl http://dexhost.do.main:5556/dex/.well-known/openid-configuration` on the admin node.  You should get back a JSON document listing the expected issuer, some endpoints, supported scopes, etc.  Note specifically that if the issuer URL is broken (`http:/host:5556/dex`, for example -- note the wrong number of slashes), dex may start up without emitting a warning, but the curl check will return a 404. Do not skip this test. :)
+
+# Configure and test the OIDC provider in velum
+1. log in to admin.devenv.caasp.suse.net
+1. under settings, click `new oidc provider`
+1. put an "x" in all the fields, and hit save (these values are currently not saved)
+1. click on the "edit" button next to the newly-created "oidc_provider_1"
+1. fill in the values correctly
+   * name is arbitrary (will be the string the user generally sees)
+   * Endpoint URL is the is the same as the issuer from the config file
+   * callback URL should be Kubernetes callback URL: `https://kube-api-x1.devenv.caasp.suse.net:32000/callback` (in config file's static client list)
+   * leave basic auth on (turning it off is for rare non-compliant OPs)
+   * client id is `example-app` (from the static clients in config file)
+   * client secret is `ZXhhbXBsZS1hcHAtc2VjcmV0` (from the static clients in config file)
+1. save and apply changes
+1. wait for orchestration to complete
+1. Go to https://admin.devenv.caasp.suse.net/oidc/
+1. Select the "Log in with X" button which matches the name you provided in the setup
+1. Select either option
+   * Log in with email: use the email and password from the example config (defaults are admin@example.com/password)
+   * Log in with Example: use the "mock" provider in dex, which doesn't prompt for anything, just returns success
+1. You should be redirected to Velum and be presented with a kubeconfig for the user you selected in the previous step
+1. You should also see a log message logged (use `docker-compose logs`); success with the mock option looks like this:
+   `dex_1   | time="2018-08-24T19:15:15Z" level=info msg="login successful: connector \"mock\", username=\"Kilgore Trout\", email=\"kilgore@kilgore.trout\", groups=[\"authors\"]"`
+
+# Clean up testing environment
+1. Tear down the dex container
+   * In the velum directory containing the docker-compose.yml: `docker-compose down`
+   * should look like this:
+     ```
+     sauer@lightning:~/dev/dex$ docker-compose down
+     Stopping dex_dex_1 ... done
+     Removing dex_base_1 ... done
+     Removing dex_dex_1  ... done
+     Removing network dex_default
+     ```
+1. Tear down the cluster
+   * In the automation directory:`./caasp-devenv --destroy`

--- a/docs/oidc_testing/docker-compose.yml
+++ b/docs/oidc_testing/docker-compose.yml
@@ -1,0 +1,19 @@
+# simple test dex instance
+version: "2.1"
+
+services:
+  base:
+    image: quay.io/coreos/dex:v2.10.0
+
+  dex:
+    extends:
+      service: base
+    volumes:
+      - "./examples/:/go/src/github.com/coreos/dex/examples"
+    # We're using the example developer config with a static entry
+    command: ["serve","/go/src/github.com/coreos/dex/examples/config-dev.yaml"]
+    ports:
+      - 5554:5554 # SSL port, if enabled
+      - 5556:5556 # non-SSL port (http://yourhost:5556/dex)
+      - 5558:5558 # metrics, prometheus style - http://yourhost:5558/metrics
+

--- a/docs/oidc_testing/examples/.gitignore
+++ b/docs/oidc_testing/examples/.gitignore
@@ -1,0 +1,2 @@
+config-dev.yaml
+dex.db

--- a/docs/oidc_testing/examples/config-dev.yaml.example
+++ b/docs/oidc_testing/examples/config-dev.yaml.example
@@ -1,0 +1,79 @@
+################################################################################
+# This is the test Dex config for verifying external OIDC connector support
+#
+# This config will give two options when trying to auth via OIDC:
+# * "mock", which always sends back a fake name ("Kilgore Trout") without any
+# further authentication. (this is hard-coded in the mock callback)
+# * "static", which uses an email (admin@example.com) as the username and a
+# password of "password", then returns a username of "admin"
+################################################################################
+
+################################################################################
+# you need to change this value
+################################################################################
+# The base path of dex and the external name of the OpenID Connect service.
+# This is the canonical URL that all clients MUST use to refer to dex. If a
+# path is provided, dex's HTTP service will listen at a non-root URL.
+# NOTE: This needs to exactly match the URL you'll use (in the Provider URL)
+#       Significantly, it will not work with an IP if you connect to a hostname
+#       It may not work with an IP at all. Just use a hostname.
+issuer: http://your.fqdn.here:5556/dex
+
+################################################################################
+# you probably don't need to change anything below here, but it's worth reading
+################################################################################
+
+connectors:
+- type: mockCallback
+  id: mock
+  name: Example
+
+staticPasswords:
+- email: "admin@example.com"
+  # bcrypt hash of the string "password"
+  hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+  # username which will be returned
+  username: "admin"
+  # Type 4 "random" UUID string; value is insignificant
+  userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+
+# This should be the Kubernetes callback, not Velum (the defaults should work)
+# The id and secret heere are what you paste in to Velum
+staticClients:
+- id: example-app
+  redirectURIs:
+  - 'https://kube-api-x1.devenv.caasp.suse.net:32000/callback'
+  name: 'Example App'
+  secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+
+# Configuration for the HTTP endpoints.  Only change this if you want to test
+# the use of TLS, which requires you to create a key/cert pair and trust the CA
+web:
+  http: 0.0.0.0:5556
+  # Uncomment for HTTPS options.
+  # https: 0.0.0.0:5554
+  # tlsCert: /etc/dex/tls.crt
+  # tlsKey: /etc/dex/tls.key
+
+################################################################################
+# you almost certainly don't need to change or care about anything below here
+################################################################################
+
+enablePasswordDB: true
+storage:
+  type: sqlite3
+  config:
+    file: /go/src/github.com/coreos/dex/examples/dex.db
+
+# metrics/logging; ideally, leave these unchanged
+telemetry:
+  http: 0.0.0.0:5558
+logger:
+  level: "debug"
+  format: "text" # can also be "json"
+
+# we need this for testing
+oauth2:
+  responseTypes: ["code"]
+  skipApprovalScreen: true
+

--- a/lib/velum/dex/oidc.rb
+++ b/lib/velum/dex/oidc.rb
@@ -1,0 +1,23 @@
+require "base64"
+
+module Velum
+  # This generates the JSON that SaltStack uses to list the OIDC connectors
+  module Dex
+    class << self
+      def oidc_connectors_as_pillar
+        DexConnectorOidc.all.map do |con|
+          {
+            type:          "oidc",
+            id:            "oidc-" + con.id.to_s,
+            name:          con.name,
+            provider_url:  con.provider_url,
+            client_id:     con.client_id,
+            client_secret: con.client_secret,
+            callback_url:  con.callback_url,
+            basic_auth:    con.basic_auth
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/settings/dex_connector_oidcs_controller_spec.rb
+++ b/spec/controllers/settings/dex_connector_oidcs_controller_spec.rb
@@ -1,0 +1,369 @@
+require "rails_helper"
+
+RSpec.describe Settings::DexConnectorOidcsController, type: :controller do
+  let(:user) { create(:user) }
+
+  before do
+    setup_done
+    sign_in user
+  end
+
+  describe "GET #index" do
+    let!(:connector) { create(:dex_connector_oidc, :skip_validation) }
+
+    before do
+      get :index
+    end
+
+    it "populates an array of oidc dex connectors" do
+      expect(assigns(:oidc_connectors)).to match_array([connector])
+    end
+  end
+
+  describe "GET #new" do
+    before do
+      get :new
+    end
+
+    it "sets data validity to be false" do
+      expect(assigns(:is_data_valid)).to be(false)
+    end
+  end
+
+  describe "GET #edit" do
+    let!(:connector) { create(:dex_connector_oidc, :skip_validation) }
+
+    before do
+      get :edit, id: connector.id
+    end
+
+    it "assigns dex_connector_oidc to @dex_connector_oidc" do
+      expect(assigns(:dex_connector_oidc)).not_to be_a_new(DexConnectorOidc)
+    end
+
+    it "return 404 if oidc connector does not exist" do
+      get :edit, id: DexConnectorOidc.last.id + 1
+      expect(response).to have_http_status(:not_found)
+    end
+
+  end
+
+  # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+  describe "GET #create" do
+    good_provider = "http://your.fqdn.here:5556/dex"
+
+    it "fails validation with a bad provider" do
+      get :create, validate: true, dex_connector_oidc: {
+        name:          "good oidc",
+        provider_url:  "dead",
+        callback_url:  "http://well.formed.but.invalid/",
+        basic_auth:    true,
+        client_id:     "client",
+        client_secret: "secret"
+      }
+      expect(response).to render_template("new")
+      expect(assigns(:is_data_valid)).to be(false)
+    end
+
+    it "passes validation with a good provider" do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        get :create, validate: true, dex_connector_oidc: {
+          name:          "good oidc",
+          provider_url:  good_provider,
+          callback_url:  "http://well.formed.but.invalid/",
+          basic_auth:    true,
+          client_id:     "client",
+          client_secret: "secret"
+        }
+      end
+      expect(response).to render_template("new")
+      expect(assigns(:is_data_valid)).to be(true)
+    end
+
+    it "fails creating with a bad provider" do
+      get :create, validate: false, dex_connector_oidc: {
+        name:          "good oidc",
+        provider_url:  "dead",
+        callback_url:  "http://well.formed.but.invalid/",
+        basic_auth:    true,
+        client_id:     "client",
+        client_secret: "secret"
+      }
+      expect(response).to render_template("new")
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "passes creating with a good provider" do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        get :create, validate: false, dex_connector_oidc: {
+          name:          "good oidc",
+          provider_url:  good_provider,
+          callback_url:  "http://well.formed.but.invalid/",
+          basic_auth:    true,
+          client_id:     "client",
+          client_secret: "secret"
+        }
+      end
+      expect(response).not_to have_http_status(:unprocessable_entity)
+      expect(response).to redirect_to(settings_dex_connector_oidcs_path)
+    end
+
+    context "with rendered views" do
+      render_views
+
+      it "shows an error message for empty name" do
+        VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+          get :create, validate: false, dex_connector_oidc: {
+            name:          "",
+            provider_url:  good_provider,
+            callback_url:  "http://well.formed.but.invalid/", # can't be blank in form
+            basic_auth:    true, # also can't be blank - only true/false
+            client_id:     "client",
+            client_secret: "secret"
+          }
+        end
+        expect(response).to render_template("new")
+        expect(response.body).to match(/Name can('|&#39;)t be blank/)
+        expect(assigns(:is_data_valid)).to be_falsey
+      end
+
+      it "shows an error message for empty provider" do
+        get :create, validate: false, dex_connector_oidc: {
+          name:          "good oidc",
+          provider_url:  "",
+          callback_url:  "http://well.formed.but.invalid/", # can't be blank in form
+          basic_auth:    true, # also can't be blank - only true/false
+          client_id:     "client",
+          client_secret: "secret"
+        }
+        expect(response).to render_template("new")
+        expect(response.body).to match(
+          /Provider Url (can('|&#39;)t be blank|is not a valid HTTP URL)/i
+        )
+        expect(assigns(:is_data_valid)).to be_falsey
+      end
+
+      it "shows an error message for empty client id" do
+        VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+          get :create, validate: false, dex_connector_oidc: {
+            name:          "good oidc",
+            provider_url:  good_provider,
+            callback_url:  "http://well.formed.but.invalid/", # can't be blank in form
+            basic_auth:    true, # also can't be blank - only true/false
+            client_id:     "",
+            client_secret: "secret"
+          }
+        end
+        expect(response).to render_template("new")
+        expect(response.body).to match(/Client (Id )?can('|&#39;)t be blank/i)
+        expect(assigns(:is_data_valid)).to be_falsey
+      end
+
+      it "shows an error message for empty client secret" do
+        VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+          get :create, validate: false, dex_connector_oidc: {
+            name:          "good oidc",
+            provider_url:  good_provider,
+            callback_url:  "http://well.formed.but.invalid/", # can't be blank in form
+            basic_auth:    true, # also can't be blank - only true/false
+            client_id:     "client",
+            client_secret: ""
+          }
+        end
+        expect(response).to render_template("new")
+        expect(response.body).to match(/Client Secret can('|&#39;)t be blank/i)
+        expect(assigns(:is_data_valid)).to be_falsey
+      end
+
+      it "shows an error message for non-http issuer entry" do
+        get :create, validate: false, dex_connector_oidc: {
+          name:          "good oidc",
+          provider_url:  "bare.hostname",
+          callback_url:  "http://well.formed.but.invalid/",
+          basic_auth:    true,
+          client_id:     "client",
+          client_secret: "secret"
+        }
+        expect(response).to render_template("new")
+        expect(response.body).to match(/is not a valid HTTP URL/)
+        expect(response.body).not_to match(/unresolvable hostname|discovery failure|timeout/)
+        expect(assigns(:is_data_valid)).to be_falsey
+      end
+
+      it "shows an error message for invalid OIDC issuer hostname" do
+        get :create, validate: false, dex_connector_oidc: {
+          name:          "good oidc",
+          provider_url:  "http://this.fqdn.is.invalid", # RFC 6761
+          callback_url:  "http://well.formed.but.invalid/",
+          basic_auth:    true,
+          client_id:     "client",
+          client_secret: "secret"
+        }
+        expect(response).to render_template("new")
+        expect(response.body).to match(/is not a valid OIDC provider/)
+        expect(response.body).to match(/unresolvable hostname|discovery failure/)
+        expect(assigns(:is_data_valid)).to be_falsey
+      end
+
+      it "shows an error message for mismatched OIDC issuer" do
+        VCR.use_cassette("oidc/invalid_connector", allow_playback_repeats: true, record: :none) do
+          get :create, validate: false, dex_connector_oidc: {
+            name:          "good oidc",
+            provider_url:  "http://your.fqdn.here:5556/bad",
+            callback_url:  "http://well.formed.but.invalid/",
+            basic_auth:    true,
+            client_id:     "client",
+            client_secret: "secret"
+          }
+        end
+        expect(response).to render_template("new")
+        expect(response.body).to match(/is not a valid OIDC provider/)
+        expect(response.body).to match(/discovery failure/)
+        expect(assigns(:is_data_valid)).to be_falsey
+      end
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
+
+  # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+  describe "GET #update" do
+    good_provider = "http://your.fqdn.here:5556/dex"
+    let!(:connector) { create(:dex_connector_oidc, :skip_validation) }
+
+    it "fails validation with a bad provider" do
+      get :update, id: connector.id, validate: true,
+        dex_connector_oidc: {
+          name:          connector.name,
+          provider_url:  "dead",
+          callback_url:  connector.callback_url,
+          basic_auth:    connector.basic_auth,
+          client_id:     connector.client_id,
+          client_secret: connector.client_secret
+        }
+      expect(response).to render_template("edit")
+      expect(response).to have_http_status(:ok)
+      expect(assigns(:is_data_valid)).to be_falsey
+    end
+
+    it "passes validation with a good provider" do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        get :update, id: connector.id, validate: true,
+          dex_connector_oidc: {
+            name:          connector.name,
+            provider_url:  good_provider,
+            callback_url:  connector.callback_url,
+            basic_auth:    connector.basic_auth,
+            client_id:     connector.client_id,
+            client_secret: connector.client_secret
+          }
+      end
+      expect(response).to render_template("edit")
+      expect(assigns(:is_data_valid)).to be(true)
+    end
+
+    context "with skipped validation" do
+      it "refuses updating with a bad provider" do
+        get :update, id: connector.id, validate: false,
+          dex_connector_oidc: {
+            name:          connector.name,
+            provider_url:  "dead",
+            callback_url:  connector.callback_url,
+            basic_auth:    connector.basic_auth,
+            client_id:     connector.client_id,
+            client_secret: connector.client_secret
+          }
+        expect(response).to render_template("edit")
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(assigns(:is_data_valid)).to be_falsey
+      end
+
+      it "passes updating with a good provider" do
+        VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+          get :update, id: connector.id, validate: false,
+            dex_connector_oidc: {
+              name:          connector.name,
+              provider_url:  good_provider,
+              callback_url:  connector.callback_url,
+              basic_auth:    connector.basic_auth,
+              client_id:     connector.client_id,
+              client_secret: connector.client_secret
+            }
+        end
+        expect(response).not_to have_http_status(:unprocessable_entity)
+        # expect(subject).to redirect_to([:settings, connector])
+        expect(response).to redirect_to([:settings, connector])
+      end
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
+
+  describe "POST #create" do
+    # rubocop:disable RSpec/ExampleLength
+    # TODO: can the post be moved out to a let() and still work?
+    it "can not save oidc connector with invalid field" do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        expect do
+          post :create, dex_connector_oidc: { name: "oidc_fail", invalid_whatevz: nil }
+        end.not_to change(DexConnectorOidc, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    context "with oidc connector saved in the database" do
+      let!(:connector) do
+        VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+          post :create, dex_connector_oidc: { name:          "oidc1",
+                                              provider_url:  "http://your.fqdn.here:5556/dex",
+                                              callback_url:  "http://some.fqdn.here/callback",
+                                              basic_auth:    true,
+                                              client_id:     "client",
+                                              client_secret: "secret_string" }
+
+        end
+        DexConnectorOidc.find_by(name: "oidc1")
+      end
+
+      it "saves the correct name" do
+        expect(connector.name).to eq("oidc1")
+      end
+      it "saves the correct provider_url" do
+        expect(connector.provider_url).to eq("http://your.fqdn.here:5556/dex")
+      end
+      it "saves the correct callback_url" do
+        expect(connector.callback_url).to eq("http://some.fqdn.here/callback")
+      end
+      it "saves the correct client_id" do
+        expect(connector.client_id).to eq("client")
+      end
+      it "saves the correct client_secret" do
+        expect(connector.client_secret).to eq("secret_string")
+      end
+      it "saves the correct basic_auth value" do
+        expect(connector.basic_auth).to eq(true)
+      end
+    end
+  end
+
+  describe "PATCH #update" do
+    let!(:connector) { create(:dex_connector_oidc, :skip_validation) }
+
+    it "updates an oidc connector" do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        dex_connector_oidc_params = { name: "new name" }
+        put :update, id: connector.id, dex_connector_oidc: dex_connector_oidc_params
+        expect(DexConnectorOidc.find(connector.id).name).to eq("new name")
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let!(:connector) { create(:dex_connector_oidc, :skip_validation) }
+
+    it "deletes an oidc connector" do
+      expect do
+        delete :destroy, id: connector.id
+      end.to change(DexConnectorOidc, :count).by(-1)
+    end
+  end
+end

--- a/spec/factories/dex_connectors_oidc_factory.rb
+++ b/spec/factories/dex_connectors_oidc_factory.rb
@@ -1,0 +1,14 @@
+FactoryGirl.define do
+  factory :dex_connector_oidc do
+    sequence(:name) { |n| "OIDC Server #{n}" }
+    provider_url  "http://your.fqdn.here:5556/dex"
+    callback_url  "http://well.formed.but.invalid/" # needed for database cleaner :/
+    client_id     "example-app"
+    client_secret "ZXhhbXBsZS1hcHAtc2VjcmV0"
+    basic_auth    true
+
+    trait :skip_validation do
+      to_create { |instance| instance.save(validate: false) }
+    end
+  end
+end

--- a/spec/features/settings/dex_connector_oidc_feature_spec.rb
+++ b/spec/features/settings/dex_connector_oidc_feature_spec.rb
@@ -1,0 +1,123 @@
+require "rails_helper"
+
+# rubocop:disable RSpec/ExampleLength
+describe "Feature: OIDC connector settings", js: true do
+  let!(:user)                { create(:user) }
+  let!(:dex_connector_oidc)  { create(:dex_connector_oidc, :skip_validation) }
+  let!(:dex_connector_oidc2) { create(:dex_connector_oidc, :skip_validation) }
+  let!(:dex_connector_oidc3) { create(:dex_connector_oidc, :skip_validation) }
+
+  before do
+    setup_done
+    login_as user, scope: :user
+  end
+
+  describe "#index" do
+    before do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        visit settings_dex_connector_oidcs_path
+      end
+    end
+
+    it "allows a user to delete an oidc connector" do
+      expect(page).to have_content(dex_connector_oidc.name)
+      accept_alert do
+        find(".dex_connector_oidc#{dex_connector_oidc.id} .delete-btn").click
+      end
+
+      expect(page).to have_content("OIDC Connector was successfully removed.")
+      expect(page).not_to have_content(dex_connector_oidc.name)
+    end
+
+    it "allows a user to go to an oidc connector's details page" do
+      click_link(dex_connector_oidc.name)
+
+      expect(page).to have_current_path(settings_dex_connector_oidc_path(dex_connector_oidc))
+    end
+
+    it "allows a user to go to an oidc connector's edit page" do
+      find(".dex_connector_oidc#{dex_connector_oidc.id} .edit-btn").click
+
+      expect(page).to have_current_path(edit_settings_dex_connector_oidc_path(dex_connector_oidc))
+    end
+
+    it "allows a user to go to the new oidc connector page" do
+      click_link("Add OIDC connector")
+
+      expect(page).to have_current_path(new_settings_dex_connector_oidc_path)
+    end
+
+    it "lists all the oidc connectors" do
+      expect(page).to have_content(dex_connector_oidc.name)
+      expect(page).to have_content(dex_connector_oidc2.name)
+      expect(page).to have_content(dex_connector_oidc3.name)
+    end
+  end
+
+  describe "#new" do
+    before do
+      visit new_settings_dex_connector_oidc_path
+    end
+
+    it "allows a user to create an OIDC connector" do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        fill_in id: "oidc_name",          with: "test oidc"
+        fill_in id: "oidc_provider",      with: "http://your.fqdn.here:5556/dex"
+        fill_in id: "oidc_client_id",     with: "client"
+        fill_in id: "oidc_client_secret", with: "secret_string"
+
+        click_button("Test Connection")
+        click_button("Save")
+        expect(page).to have_content("OIDC Connector was successfully created.")
+        expect(page).to have_current_path(settings_dex_connector_oidcs_path)
+      end
+    end
+  end
+
+  describe "#edit" do
+    before do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        visit edit_settings_dex_connector_oidc_path(dex_connector_oidc)
+      end
+    end
+
+    it "allows a user to edit an oidc connector clicking validate and then save" do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        fill_in id: "oidc_name", with: "a new name"
+
+        click_button("Test Connection")
+        click_button("Save")
+        expect(page).to have_content("OIDC Connector was successfully updated.")
+      end
+    end
+  end
+
+  describe "#show" do
+    before do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        visit settings_dex_connector_oidc_path(dex_connector_oidc)
+      end
+    end
+
+    it "allows a user to delete an oidc connector" do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        accept_alert do
+          click_on("Delete")
+
+          expect(page).not_to have_content(dex_connector_oidc.name)
+          expect(page).to have_content("OIDC Connector was successfully removed.")
+          expect(page).to have_current_path(settings_dex_connector_oidcs_path)
+        end
+      end
+    end
+
+    it "allows a user to go to an oidc connector's edit page" do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        click_on("Edit")
+
+        expect(page).to have_current_path(edit_settings_dex_connector_oidc_path(dex_connector_oidc))
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/ExampleLength

--- a/spec/models/dex_connector_oidc_spec.rb
+++ b/spec/models/dex_connector_oidc_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+describe DexConnectorOidc, type: :model do
+  good_provider_url = "http://your.fqdn.here:5556/dex"
+  mismatched_provider_url = "http://your.fqdn.here:5556/bad"
+  malformed_urls = [
+    "ftp://fqdn.is.invalid",
+    "",
+    "http:://x",
+    "fqdn.is.invalid",
+    "http://user:fqdn.is.invalid/"
+  ]
+  bad_but_well_formed_http_urls = [
+    "http://fqdn.is.invalid",
+    "http://user@fqdn.is.invalid/",
+    "https://user:pass@fqdn.is.invalid/",
+    # "https://192.0.2.0",      # RFC5737 TEST-NET-1, should trigger timeout
+    "http://192.0.2.0:65537", # too-high port
+    "https://1.2.3.256"       # invalid IP address
+  ]
+
+  VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+    subject(:connector) do
+      described_class.new(
+        name:          "oidc1",
+        provider_url:  good_provider_url,
+        callback_url:  good_provider_url,
+        basic_auth:    true,
+        client_id:     "client",
+        client_secret: "secret_string"
+      )
+    end
+  end
+
+  [:name, :basic_auth, :client_id, :client_secret, :provider_url, :callback_url].each do |field|
+    it "verifies " + field.to_s + " field" do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        expect(connector).to validate_presence_of(field)
+      end
+    end
+  end
+
+  malformed_urls.each do |bad_url|
+    [:callback_url, :provider_url].each do |field|
+      it "rejects non-nttp format URL '#{bad_url}' for " + field.to_s do
+        VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+          connector[field] = bad_url
+          expect(connector).not_to be_valid
+        end
+      end
+    end
+  end
+
+  bad_but_well_formed_http_urls.each do |sketchy_url|
+    it "accepts well-formed invalid issuer URL '#{sketchy_url}' for callback" do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        connector.callback_url = sketchy_url
+        expect(connector).to be_valid
+      end
+    end
+    it "rejects well-formed invalid issuer URL for issuer" do
+      connector.provider_url = sketchy_url
+      expect(connector).not_to be_valid
+    end
+  end
+
+  [:callback_url, :provider_url].each do |field|
+    it "accepts valid issuer URL for " + field.to_s do
+      VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+        connector[field] = good_provider_url
+        expect(connector).to be_valid
+      end
+    end
+  end
+
+  it "rejects mismatched issuer URL" do
+    VCR.use_cassette("oidc/invalid_connector", allow_playback_repeats: true, record: :none) do
+      connector[:provider_url] = mismatched_provider_url
+      expect(connector).not_to be_valid
+    end
+  end
+
+  # Using VCR seems to suppress the creation of SocketError, so raise it here.
+  it "catches an elusive exception just for code coverage" do
+    # rubocop:disable RSpec/MessageSpies
+    expect(OidcProviderValidator).to receive(:validate_issuer?).and_raise(SocketError)
+    # rubocop:enable RSpec/MessageSpies
+    connector.provider_url = good_provider_url
+    expect(connector).not_to be_valid
+  end
+
+  # Raise timeout error instead of making a connection actually time out
+  it "catches a TimeoutError" do
+    # rubocop:disable RSpec/MessageSpies
+    expect(OidcProviderValidator).to receive(:validate_issuer?).and_raise(TimeoutError)
+    # rubocop:enable RSpec/MessageSpies
+    connector.provider_url = good_provider_url
+    expect(connector).not_to be_valid
+  end
+
+  # Raise OpenSSL error instead of making a bad cert
+  it "catches an OpenSSL Error" do
+    # rubocop:disable RSpec/MessageSpies
+    expect(OidcProviderValidator).to receive(:validate_issuer?).and_raise(OpenSSL::SSL::SSLError)
+    # rubocop:enable RSpec/MessageSpies
+    connector.provider_url = good_provider_url
+    expect(connector).not_to be_valid
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,13 @@ VCR.configure do |c|
   c.ignore_request do |request|
     request.uri =~ /__identify__/
   end
+  # Don't try to playback under the RFC6761 .invalid TLD (should always return NXDOMAIN)
+  c.ignore_request do |request|
+    URI(request.uri).host.end_with?(".invalid")
+  end
+  # Also ignore the .0 IP in RFC5737 test-net-1, and an invalid IP address
+  c.ignore_hosts "192.0.2.0"
+  c.ignore_hosts "1.2.3.256"
 
   # To debug when a VCR goes wrong.
   # c.debug_logger = $stdout

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -10,9 +10,12 @@ require "database_cleaner"
 RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.clean_with :truncation
-    DatabaseCleaner.cleaning do
-      factories_to_lint = FactoryGirl.factories
-      FactoryGirl.lint factories_to_lint
+    # OIDC connector database validation makes a web call
+    VCR.use_cassette("oidc/validate_connector", allow_playback_repeats: true, record: :none) do
+      DatabaseCleaner.cleaning do
+        factories_to_lint = FactoryGirl.factories
+        FactoryGirl.lint factories_to_lint
+      end
     end
   end
 

--- a/spec/vcr_cassettes/oidc/invalid_connector.yml
+++ b/spec/vcr_cassettes/oidc/invalid_connector.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://your.fqdn.here:5556/bad/.well-known/openid-configuration
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - SWD (1.0.1) (2.8.3, ruby 2.1.9 (2016-03-30))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 11 Sep 2018 14:35:06 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '713'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 11 Sep 2018 14:35:06 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "issuer": "http://some.fqdn.here:5556/bad",
+          "authorization_endpoint": "http://some.fqdn.here:5556/bad/auth",
+          "token_endpoint": "http://some.fqdn.here:5556/bad/token",
+          "jwks_uri": "http://some.fqdn.here:5556/bad/keys",
+          "response_types_supported": [
+            "code"
+          ],
+          "subject_types_supported": [
+            "public"
+          ],
+          "id_token_signing_alg_values_supported": [
+            "RS256"
+          ],
+          "scopes_supported": [
+            "openid",
+            "email",
+            "groups",
+            "profile",
+            "offline_access"
+          ],
+          "token_endpoint_auth_methods_supported": [
+            "client_secret_basic"
+          ],
+          "claims_supported": [
+            "aud",
+            "email",
+            "email_verified",
+            "exp",
+            "iat",
+            "iss",
+            "locale",
+            "name",
+            "sub"
+          ]
+        }
+    http_version: 
+  recorded_at: Tue, 11 Sep 2018 14:35:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/oidc/validate_connector.yml
+++ b/spec/vcr_cassettes/oidc/validate_connector.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://your.fqdn.here:5556/dex/.well-known/openid-configuration
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - SWD (1.0.1) (2.8.3, ruby 2.1.9 (2016-03-30))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 11 Sep 2018 14:35:06 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '713'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 11 Sep 2018 14:35:06 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "issuer": "http://your.fqdn.here:5556/dex",
+          "authorization_endpoint": "http://your.fqdn.here:5556/dex/auth",
+          "token_endpoint": "http://your.fqdn.here:5556/dex/token",
+          "jwks_uri": "http://your.fqdn.here:5556/dex/keys",
+          "response_types_supported": [
+            "code"
+          ],
+          "subject_types_supported": [
+            "public"
+          ],
+          "id_token_signing_alg_values_supported": [
+            "RS256"
+          ],
+          "scopes_supported": [
+            "openid",
+            "email",
+            "groups",
+            "profile",
+            "offline_access"
+          ],
+          "token_endpoint_auth_methods_supported": [
+            "client_secret_basic"
+          ],
+          "claims_supported": [
+            "aud",
+            "email",
+            "email_verified",
+            "exp",
+            "iat",
+            "iss",
+            "locale",
+            "name",
+            "sub"
+          ]
+        }
+    http_version: 
+  recorded_at: Tue, 11 Sep 2018 14:35:06 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This set of changes implements external OIDC connector support within Velum.  It's based upon the LDAP connector, and should incorporate the majority of the relevant lessons learned from that implementation.