### PR TITLE
[3.0] [bsc#1109320] Fix external auth group mapping for group attr name

### DIFF
--- a/lib/velum/dex/ldap.rb
+++ b/lib/velum/dex/ldap.rb
@@ -59,7 +59,7 @@ module Velum
           attr_map: {
             user:  con.group_attr_user,
             group: con.group_attr_group,
-            name:  con.group_attr_group
+            name:  con.group_attr_name
           }
         }
       end


### PR DESCRIPTION
[bsc#1109320] Fix external auth group mapping for group attr name

Cherry-picked commit [4a672de](https://github.com/kubic-project/velum/commit/4a672de7cc6903b2682d7d2381eddf473278f857).

Link to bug:  https://bugzilla.suse.com/show_bug.cgi?id=1109320