### PR TITLE
[3.0][bsc#1108740] dont allow updating admin again when cluster update failed

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -287,8 +287,11 @@ MinionPoller = {
 
   handleAdminUpdate: function(admin) {
     var $notification = $('.admin-outdated-notification');
+    var failedToUpdate = State.minions.filter(function (m) {
+      return m.tx_update_reboot_needed && m.highstate === "failed"
+    }).length > 0
 
-    if (State.hasPendingStateNode || State.pendingRemovalMinionId) {
+    if (State.hasPendingStateNode || State.pendingRemovalMinionId || failedToUpdate) {
       State.updateAdminNode = false;
       return;
     }


### PR DESCRIPTION
bsc#1108740

Signed-off-by: Maximilian Meister <mmeister@suse.de>
(cherry picked from commit c16eda7129e646fa8f9d5add02f5e78c986fff71)

backport of https://github.com/kubic-project/velum/pull/660