### PR TITLE
[bsc#1109025] LDAP connector can't be saved if anonymous bind

### DIFF
--- a/app/assets/javascripts/settings/ldap-connector.js
+++ b/app/assets/javascripts/settings/ldap-connector.js
@@ -1,0 +1,13 @@
+$(function () {
+    // Link browser form requirements for bindDN and password to anonymous bind status
+    // There is no 'toggle' event for this Bootstrap element, so both buttons must be monitored for change
+    $('#dex_connector_ldap_bind_anon_true').on('change', function () {
+        $('#dex_connector_ldap_bind_dn').removeAttr('required')
+        $("#dex_connector_ldap_bind_pw[type='password']").removeAttr('required')
+    })
+
+    $('#dex_connector_ldap_bind_anon_false').on('change', function () {
+        $('#dex_connector_ldap_bind_dn').attr('required', 'required')
+        $("#dex_connector_ldap_bind_pw[type='password']").attr('required', 'required')
+    })
+})


### PR DESCRIPTION
Links browser form requirements for bindDN and password to anonymous bind status. Addresses [bsc#1109025](https://bugzilla.suse.com/show_bug.cgi?id=1109025).