### PR TITLE
[3.0] [CPI] OpenStack Cloud Provider config file doesn't exist (bsc#1111361)

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -61,7 +61,7 @@ setup_cpi() {
   CPI_CONFIG="/etc/caasp/cpi/openstack.conf"
   if [ -f "${CPI_CONFIG}" ]; then
     # Import Cloud Provider config
-    bundle exec rake cpi:openstack['${CPI_CONFIG}']
+    bundle exec rake cpi:openstack["${CPI_CONFIG}"]
   fi
 }
 


### PR DESCRIPTION
(cherry picked from commit a17a674e6e6d8b54d2b103a5b1d5d730192f7319)