### PR TITLE
[3.0] ui: don't show failed alert for repeated orchestration

### DIFF
--- a/app/controllers/concerns/discovery.rb
+++ b/app/controllers/concerns/discovery.rb
@@ -18,7 +18,8 @@ module Discovery
           cloud_jobs_failed:                 SaltJob.failed.count,
           admin:                             Minion.find_by(minion_id: "admin"),
           retryable_bootstrap_orchestration: Orchestration.retryable?(kind: :bootstrap),
-          retryable_upgrade_orchestration:   Orchestration.retryable?(kind: :upgrade)
+          retryable_upgrade_orchestration:   Orchestration.retryable?(kind: :upgrade),
+          last_orchestration_at:             Orchestration.last.try(:created_at)
         }
         render json: hsh
       end


### PR DESCRIPTION
A failed alert is shown whenever one of the nodes fails to bootstrap.
This is an optimization to only show this alert once for a specific
orchestration run. If the user closes the alert, it won't come back
unless a new orchestration happens.

bsc#1097752

Signed-off-by: Vítor Avelino <vavelino@suse.com>
(cherry picked from commit e943e073e813cdea58bf0943e1caba226cb60131)

Backoprt of https://github.com/kubic-project/velum/pull/589