### PR TITLE
Velum: Add more log filters for user's secrets, pass, and tokens

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :certificate, :bind_pw]
+Rails.application.config.filter_parameters += [:pass, :password, :bind_pw, :cert, :certificate, \
+                                               :client_secret, \
+                                               :authenticity_token, :id_token, :refresh_token]


### PR DESCRIPTION
Velum uses pass, password, and bind_pw symbols accordingly.
Diverse symbols in velum are exposed in Velum logs. 
After symbols were added in log filters, logs in admin:/var/log/containers  will shows:

{"log":"Processing by SetupController#configure as HTML\n","stream":"stdout","time":"2018-10-18T00:37:42.923336515Z"}
{"log":"  Parameters: {\"utf8\"=\u003e\"✓\", \"authenticity_token\"=\u003e\"[FILTERED]\", \"settings\"=\u003e{\"dashboard\"=\u003e\"10.17.1.0\", \"tiller\"=\u003e\"false\", \"cluster_cidr\"=\u003e\"172.16.0.0/13\", \"cluster_cidr_min\"=\u003e\"172.16.0.0\", \"cluster_cidr_max\"=\u003e\"172.23.255.255\", \"cluster_cidr_len\"=\u003e\"23\", \"services_cidr\"=\u003e\"172.24.0.0/16\", \"api_cluster_ip\"=\u003e\"172.24.0.1\", \"dns_cluster_ip\"=\u003e\"172.24.0.2\", \"enable_proxy\"=\u003e\"disable\", \"http_proxy\"=\u003e\"\", \"https_proxy\"=\u003e\"\", \"no_proxy\"=\u003e\"localhost, 127.0.0.1\", \"proxy_systemwide\"=\u003e\"false\", \"suse_registry_mirror_enabled\"=\u003e\"disable\", \"suse_registry_mirror\"=\u003e{\"url\"=\u003e\"\", \"certificate\"=\u003e\"[FILTERED]\"}, \"suse_registry_mirror_certificate_enabled\"=\u003e\"[FILTERED]\", \"container_runtime\"=\u003e\"docker\", \"system_certificate\"=\u003e\"[FILTERED]\"}, \"commit\"=\u003e\"Next\"}\n","stream":"stdout","time":"2018-10-18T00:37:42.923397952Z"}

