### PR TITLE
[BSC#1101219] Use MSI authorization in Azure

### DIFF
--- a/app/controllers/internal_api/v1/pillars_controller.rb
+++ b/app/controllers/internal_api/v1/pillars_controller.rb
@@ -106,16 +106,30 @@ class InternalApi::V1::PillarsController < InternalApiController
   end
 
   def azure_cloud_contents
+    tenant = Pillar.value(pillar: :azure_tenant_id)
+    client = Pillar.value(pillar: :azure_client_id)
+    secret = Pillar.value(pillar: :azure_secret)
+
+    if tenant && client && secret # rubocop:disable Style/ConditionalAssignment
+      # Using service principal credentials for authentication
+      azure_provider = {
+        subscription_id: Pillar.value(pillar: :azure_subscription_id),
+        tenant:          tenant,
+        client_id:       client,
+        secret:          secret
+      }
+    else
+      # Using MSI authorization
+      azure_provider = {
+        subscription_id: Pillar.value(pillar: :azure_subscription_id)
+      }
+    end
+
     {
       cloud: {
         framework: "azure",
         providers: {
-          azure: {
-            subscription_id: Pillar.value(pillar: :azure_subscription_id),
-            tenant:          Pillar.value(pillar: :azure_tenant_id),
-            client_id:       Pillar.value(pillar: :azure_client_id),
-            secret:          Pillar.value(pillar: :azure_secret)
-          }
+          azure: azure_provider
         },
         profiles:  {
           cluster_node: {

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -226,7 +226,7 @@ class SetupController < ApplicationController
   def cloud_cluster_params
     cloud_cluster = params.require(:cloud_cluster).permit(
       :cloud_framework,
-      :subscription_id, :tenant_id, :client_id, :secret,
+      :subscription_id,
       :instance_type, :instance_type_custom, :instance_count,
       :resource_group, :storage_account,
       :network_id, :subnet_id, :security_group_id

--- a/app/models/cloud_cluster.rb
+++ b/app/models/cloud_cluster.rb
@@ -6,7 +6,7 @@ class CloudCluster
   attr_accessor :cloud_framework,
     :instance_count, :instance_type, :instance_type_custom, :subnet_id,
     :security_group_id, # EC2 profile
-    :subscription_id, :tenant_id, :client_id, :secret, # Azure provider
+    :subscription_id, # Azure provider
     :storage_account, :resource_group, :network_id # Azure profile
 
   MIN_CLUSTER_SIZE = 3
@@ -56,9 +56,6 @@ class CloudCluster
   def save!
     # cloud.provider pillars
     persist_to_pillar!(:azure_subscription_id, @subscription_id)
-    persist_to_pillar!(:azure_tenant_id, @tenant_id)
-    persist_to_pillar!(:azure_client_id, @client_id)
-    persist_to_pillar!(:azure_secret, @secret)
     # cloud.profile pillars
     persist_to_pillar!(:cloud_worker_type, @instance_type)
     persist_to_pillar!(:cloud_storage_account, @storage_account)

--- a/app/views/setup/worker_bootstrap_azure.html.slim
+++ b/app/views/setup/worker_bootstrap_azure.html.slim
@@ -17,29 +17,17 @@ h1
 
   .panel.panel-default
     .panel-heading
-      h3.panel-title Service Principal Authentication
+      h3.panel-title Managed Service Identity
     .panel-body
       .col-lg-3.col-md-6
         .form-group
           label for="cloud_cluster_subscription_id" Subscription ID
           = form.text_field :subscription_id, class: "form-control"
-      .col-lg-3.col-md-6
-        .form-group
-          label for="cloud_cluster_tenant_id" Tenant ID
-          = form.text_field :tenant_id, class: "form-control"
-      .col-lg-3.col-md-6
-        .form-group
-          label for="cloud_cluster_client_id" Application ID
-          = form.text_field :client_id, class: "form-control"
-      .col-lg-3.col-md-6
-        .form-group
-          label for="cloud_cluster_secret" Client Secret
-          = form.password_field :secret, class: "form-control"
     .panel-footer
       h4 Tip
       p
-        ' Questions about services principals? Check out the
-        = link_to("Azure documentation", "https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal")
+        ' Questions about managed service identities? Check out the
+        = link_to("Azure documentation", "https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview")
         ' .
 
   = render "instance_type_panel",

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -262,9 +262,6 @@ RSpec.describe SetupController, type: :controller do
     let(:instance_type) { "Standard_DS3_v2" }
     let(:instance_count) { 5 }
     let(:subscription_id) { SecureRandom.uuid }
-    let(:tenant_id) { SecureRandom.uuid }
-    let(:client_id) { SecureRandom.uuid }
-    let(:secret) { SecureRandom.hex(16) }
     let(:resource_group) { "azureresourcegroup" }
     let(:storage_account) { "azurestorageaccount" }
     let(:subnet_id) { "azuresubnetname" }
@@ -272,9 +269,6 @@ RSpec.describe SetupController, type: :controller do
     let(:cloud_cluster_params) do
       {
         subscription_id: subscription_id,
-        tenant_id:       tenant_id,
-        client_id:       client_id,
-        secret:          secret,
         instance_type:   instance_type,
         instance_count:  instance_count,
         resource_group:  resource_group,
@@ -305,15 +299,6 @@ RSpec.describe SetupController, type: :controller do
 
       it "assigns the subscription id" do
         expect(assigns(:cloud_cluster).subscription_id).to eq(subscription_id)
-      end
-
-      it "assigns the tenant id" do
-        expect(assigns(:cloud_cluster).tenant_id).to eq(tenant_id)
-      end
-
-      it "assigns the service principal credentials" do
-        expect(assigns(:cloud_cluster).client_id).to eq(client_id)
-        expect(assigns(:cloud_cluster).secret).to eq(secret)
       end
 
       it "assigns the instance type" do

--- a/spec/models/cloud_cluster_spec.rb
+++ b/spec/models/cloud_cluster_spec.rb
@@ -4,9 +4,6 @@ require "velum/salt_api"
 describe CloudCluster do
   let(:custom_instance_type) { "custom-instance-type" }
   let(:subscription_id) { SecureRandom.uuid }
-  let(:tenant_id) { SecureRandom.uuid }
-  let(:client_id) { SecureRandom.uuid }
-  let(:secret) { SecureRandom.hex(16) }
   let(:resource_group) { "azureresourcegroup" }
   let(:network_id) { "azurenetworkname" }
   let(:subnet_id) { "subnet-9d4a7b6c" }
@@ -168,9 +165,6 @@ describe CloudCluster do
       described_class.new(
         cloud_framework: framework,
         subscription_id: subscription_id,
-        tenant_id:       tenant_id,
-        client_id:       client_id,
-        secret:          secret,
         instance_type:   custom_instance_type,
         resource_group:  resource_group,
         network_id:      network_id,
@@ -184,27 +178,6 @@ describe CloudCluster do
         expect(cluster.save).to be(true)
       end
       expect(Pillar.value(pillar: :azure_subscription_id)).to eq(subscription_id)
-    end
-
-    it "stores tenant id as :azure_tenant_id Pillar and refreshes" do
-      ensure_pillar_refresh do
-        expect(cluster.save).to be(true)
-      end
-      expect(Pillar.value(pillar: :azure_tenant_id)).to eq(tenant_id)
-    end
-
-    it "stores client id as :azure_client_id Pillar and refreshes" do
-      ensure_pillar_refresh do
-        expect(cluster.save).to be(true)
-      end
-      expect(Pillar.value(pillar: :azure_client_id)).to eq(client_id)
-    end
-
-    it "stores secret as :azure_secret Pillar and refreshes" do
-      ensure_pillar_refresh do
-        expect(cluster.save).to be(true)
-      end
-      expect(Pillar.value(pillar: :azure_secret)).to eq(secret)
     end
 
     it "stores storage account as :cloud_storage_account Pillar and refreshes" do


### PR DESCRIPTION
Supplying credentials is no longer required for starting instances in Azure; Azure MSI acts like machine accounts in AWS IAM, for example, where the instance is granted permission to interact with the framework (for starting cluster instances, in our case).

(cherry picked from commit 71c3c235557bb24cde810e619f743c8b30d9afaa)