### PR TITLE
cloud_cluster: fix current_cluster_size (bsc#1113316)

### DIFF
--- a/app/models/cloud_cluster.rb
+++ b/app/models/cloud_cluster.rb
@@ -21,7 +21,7 @@ class CloudCluster
   end
 
   def current_cluster_size
-    SaltJob.all_open.count + Minion.where.not(role: :admin).count
+    SaltJob.all_open.count + Minion.where.not(role: Minion.roles[:admin]).count
   end
 
   def min_nodes_required


### PR DESCRIPTION
Cherry-picked commit from https://github.com/kubic-project/velum/pull/690.