### PR TITLE
[3.0] followup fix for bsc#1108740

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -292,8 +292,8 @@ MinionPoller = {
 
   handleAdminUpdate: function(admin) {
     var $notification = $('.admin-outdated-notification');
-    var failedToUpdate = State.minions.filter(function (m) {
-      return m.tx_update_reboot_needed && m.highstate === "failed"
+    var failedToUpdate = admin.tx_update_reboot_needed && State.minions.filter(function (m) {
+      return m.highstate === "failed"
     }).length > 0
 
     if (State.hasPendingStateNode || State.pendingRemovalMinionId || failedToUpdate) {


### PR DESCRIPTION
we need to check the admin for `tx_update_reboot_needed`, not the
minions

Signed-off-by: Maximilian Meister <mmeister@suse.de>
(cherry picked from commit 820cfb85d7b8e11fd5961dbab39aece9f35c518b)

## Backport of

https://github.com/kubic-project/velum/pull/693