### PR TITLE
Bootstrap settings: cilium support

### DIFF
--- a/app/assets/javascripts/setup/setup.js
+++ b/app/assets/javascripts/setup/setup.js
@@ -33,6 +33,12 @@ $(function () {
     $($(this).data('element')).collapse('show');
   });
 
+  $(document).on('click', '.cni-btn-group .btn', function () {
+    $('.flannel-desc, .cilium-desc').collapse('hide');
+    $($(this).data('element')).collapse('show');
+  });
+
+
   function toggleOpenStackSettings() {
     if ($('input[name="settings[cloud_provider]"]').val() === 'openstack') {
       openstackSettings.settingsEnabled();

--- a/app/assets/stylesheets/pages/setup.scss
+++ b/app/assets/stylesheets/pages/setup.scss
@@ -9,3 +9,7 @@
 .runtime-btn-group {
   margin-bottom: 10px;
 }
+
+.cni-btn-group {
+  margin-bottom: 10px;
+}

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -57,6 +57,8 @@ class SetupController < ApplicationController
     # container runtime setting
     @cri = Pillar.value(pillar: :container_runtime) || "docker"
 
+    @cni = Pillar.value(pillar: :cni_plugin) || "flannel"
+
     # allow adding system certificate: required if a user uses CPI with a
     # self-signed certificate
     @system_certificate = if session[:system_certificate_name].present?

--- a/app/views/setup/settings/_cni_plugin.html.slim
+++ b/app/views/setup/settings/_cni_plugin.html.slim
@@ -1,0 +1,36 @@
+.panel.panel-default
+  .panel-heading
+    h3.panel-title
+      | CNI Plugin
+      | &nbsp;
+      i class='glyphicon glyphicon-info-sign' title="Software that Kubernetes uses to manage the containers."
+  .panel-body
+    p The choice of CNI plugin is completely transparent to end-users of the
+      cluster. Neither Kubernetes manifests nor container images need to be changed.
+
+    .form-group
+      = f.label :cni, "Choose the cni"
+      br
+        .btn-group.btn-group-toggle.cni-btn-group data-toggle="buttons"
+          = label_tag :cni_plugin, nil, class: "flannel btn btn-default #{'btn-primary active' if @cni == "flannel"}", data: { element: '.flannel-desc' }
+            = f.radio_button :cni_plugin, "flannel", checked: @cni == "flannel"
+            | flannel
+          = label_tag :cni_plugin, nil, class: "cilium btn btn-default #{'btn-primary active' if @cni == "cilium"}", data: { element: '.cilium-desc' }
+            = f.radio_button :cni_plugin, "cilium", checked: @cni == "cilium"
+            | cilium
+
+      .flannel-desc.collapse class="#{'in' if @cni == "flannel"}"
+        | <em>Flannel</em> (<strong>default</strong>) is a production-ready cni plugin, fully supported by SUSE.
+
+      .cilium-desc.collapse class="#{'in' if @cni == "cilium"}"
+        p <em>cilium</em> is open source software for providing and transparently securing
+          network connectivity and loadbalancing between application workloads such as
+          application containers or processes. Cilium operates at Layer 3/4 to provide
+          traditional networking and security services.
+
+        .alert.alert-warning role="alert"
+          span NOTE: cilium is a <em>technology feature preview</em>. SUSE welcomes your
+              feedback on cilium. As a preview, cilium is <strong>not supported</strong>.
+              Previews may be functionally incomplete, unstable or in other ways not suitable
+              for production use. They are mainly included to give customers a chance to test
+              new technologies within an enterprise environment.

--- a/app/views/setup/welcome.html.slim
+++ b/app/views/setup/welcome.html.slim
@@ -25,6 +25,7 @@ h1 Initial #{product_name} Configuration
             = f.check_box "tiller", { checked: @tiller }, "true", "false"
             | Install Tiller (Helm's server component)
 
+  = render partial: 'setup/settings/cni_plugin', locals: { f: f }
   .panel.panel-default
     .panel-heading.clearfix
       h3.panel-title Overlay network settings


### PR DESCRIPTION
cilium support has been added to salt already https://github.com/kubic-project/salt/pull/491
With this PR I am trying to complete support for cilium in CaaSP. cilium support in velum bootstrap is also need for adding/Extending CI  