### PR TITLE
[3.0][bsc#1118907] require uglifier only during packaging

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,9 @@ Rails.application.configure do
   config.serve_static_files = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  if ENV["RPM_BUILD_ROOT"]
+    config.assets.js_compressor = Uglifier.new(harmony: true)
+  end
   # config.assets.css_compressor = :sass
 
   # include svg in the precompile


### PR DESCRIPTION
the constant `Uglifier` is not accessible when opening a
rails console or running a rake command

fix#uglifier

Signed-off-by: Maximilian Meister <mmeister@suse.de>
(cherry picked from commit 68e42c9d9bf3d589b8ffede158ed51e5f2149664)

bsc#1118907

### Backport of

#630 #632 

`Uglifier::Error: Unexpected token: keyword (const). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).`