### PR TITLE
[bsc#1117152] No really... don't remove nodes in the public cloud!

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,3 +25,5 @@
 $('body').on('click', '[disabled], .disabled', function (e) {
   e.preventDefault();
 });
+
+const PUBLIC_CLOUDS = ['azure', 'ec2', 'gce'];

--- a/app/assets/javascripts/dashboard/dashboard.js
+++ b/app/assets/javascripts/dashboard/dashboard.js
@@ -404,7 +404,7 @@ MinionPoller = {
     }
 
     // Public Cloud frameworks do not currently support removing nodes
-    if (['azure', 'ec2', 'gce'].indexOf(minion.cloud_framework) > -1) {
+    if (PUBLIC_CLOUDS.indexOf(minion.cloud_framework) > -1) {
       actionsHtml = '';
     } else {
       if (State.pendingRemovalMinionId || State.hasPendingStateNode) {
@@ -479,11 +479,15 @@ MinionPoller = {
       </td>\
     ';
 
-    var actionHtml = '\
-      <td class="action-column">\
-        <a class="remove-minion '+ disabledClass +'" href="#" data-minion-id="' + minion.minion_id + '" data-minion-fqdn="' + minion.fqdn + '">Remove</a>\
-      </td>\
-    ';
+    if (PUBLIC_CLOUDS.indexOf(minion.cloud_framework) > -1) {
+      var actionHtml = '';
+    } else {
+      var actionHtml = '\
+        <td class="action-column">\
+          <a class="remove-minion '+ disabledClass +'" href="#" data-minion-id="' + minion.minion_id + '" data-minion-fqdn="' + minion.fqdn + '">Remove</a>\
+        </td>\
+      ';
+    }
 
     switch (minion.highstate) {
       case "pending_removal":

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,4 +45,8 @@ class ApplicationController < ActionController::Base
       format.any { head :not_found }
     end
   end
+
+  def in_public_cloud?
+    Rails.application.config.public_clouds.include? Pillar.value(pillar: :cloud_framework)
+  end
 end

--- a/app/controllers/minions_controller.rb
+++ b/app/controllers/minions_controller.rb
@@ -23,7 +23,7 @@ class MinionsController < ApplicationController
 
   # Public Cloud frameworks do not currently support removing nodes
   def not_implemented_in_public_cloud
-    return unless ["azure", "ec2", "gce"].include? Pillar.value(pillar: :cloud_framework)
+    return unless in_public_cloud?
     render nothing: true, status: :not_implemented
   end
 

--- a/app/controllers/salt_controller.rb
+++ b/app/controllers/salt_controller.rb
@@ -1,6 +1,7 @@
 require "velum/salt"
 # SaltController holds methods for triggering updates of nodes
 class SaltController < ApplicationController
+  before_action :not_implemented_in_public_cloud
   skip_before_action :redirect_to_setup
 
   def update
@@ -40,7 +41,15 @@ class SaltController < ApplicationController
     end
   end
 
+  private
+
   def minion_id_param
     params.require(:minion_id)
+  end
+
+  # Public Cloud frameworks do not currently support removing nodes
+  def not_implemented_in_public_cloud
+    return unless in_public_cloud?
+    render nothing: true, status: :not_implemented
   end
 end

--- a/config/initializers/public_clouds.rb
+++ b/config/initializers/public_clouds.rb
@@ -1,0 +1,3 @@
+# Which cloud_framework pillar values represent public cloud frameworks?
+
+Rails.application.config.public_clouds = ["azure", "ec2", "gce"]

--- a/spec/controllers/salt_controller_spec.rb
+++ b/spec/controllers/salt_controller_spec.rb
@@ -30,4 +30,15 @@ RSpec.describe SaltController, type: :controller do
       end
     end
   end
+
+  describe "POST /minions/*/remove-minion" do
+
+    it "is not implemented in public cloud" do
+      create(:ec2_pillar)
+
+      post :remove_minion, minion_id: master_minion
+      expect(response).to have_http_status(:not_implemented)
+    end
+  end
+
 end

--- a/spec/features/bootstrap_cluster_feature_spec.rb
+++ b/spec/features/bootstrap_cluster_feature_spec.rb
@@ -147,6 +147,18 @@ describe "Bootstrap cluster feature" do
       expect(page).not_to have_content("Pending removal")
     end
 
+    it "does not allow pending nodes to be removed in public clouds", js: true do
+      setup_stubbed_pending_minions!(stubbed: [minions[1].minion_id])
+      setup_stubbed_pending_minions!(stubbed: [minions[2].minion_id])
+      setup_stubbed_pending_minions!(stubbed: [minions[3].minion_id])
+      setup_stubbed_pending_minions!(stubbed: [minions[4].minion_id])
+      create(:ec2_pillar)
+
+      visit setup_discovery_path
+
+      expect(page).not_to have_content("Remove")
+    end
+
     it "A user selects a subset of nodes to be bootstrapped", js: true do
       # select master minion0.k8s.local
       find(".minion_#{minions[0].id} .master-btn").click


### PR DESCRIPTION
Removing nodes in the public cloud is not implemented (partially due to upstream bugs) and will not ship as part of our v3 release. #631 is included to instantiate this fact, but was rendered invalid shortly thereafter by adding _another_ Remove path in #647 . This was discovered in QA, as [bsc#1117152](https://bugzilla.suse.com/show_bug.cgi?id=1117152) (which has been incorrectly marked resolved+fixed; it _is not resolved_ in the assigned component: public cloud.

This patch intends to, once again, remove the 'remove' functionality, until such time as it is fully implemented and supported in the public cloud, when, like #631, it can be reverted.