### PR TITLE
Include the name on the Pillar API response for the registry list

### DIFF
--- a/app/controllers/internal_api/v1/pillars_controller.rb
+++ b/app/controllers/internal_api/v1/pillars_controller.rb
@@ -38,6 +38,7 @@ class InternalApi::V1::PillarsController < InternalApiController
   def registry_contents
     registries = Registry.all.map do |reg|
       registry = {}
+      registry[:name] = reg.name
       registry[:url]  = reg.url
       registry[:cert] = reg.certificate.try(:certificate)
       reg.registry_mirrors.each do |mirror|


### PR DESCRIPTION
This allows us to include the descriptive name the user gave to each
registry, so when creating the resources on the cluster (specially when
we create custom resources) we can give the custom resources meaningful
names.