### PR TITLE
remove hack, not anymore needed 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ cache:
     - $PWD/travis_phantomjs
 
 before_install:
-  - gem update --system
   - phantomjs --version
   - export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi


### PR DESCRIPTION
The `gem update --system` hack got fixed. this Pr should stabilze more build travis.

See https://github.com/travis-ci/travis-ci/issues/8978
and https://github.com/plataformatec/devise/commit/8e49661fd167eed7a97281aa09aea7bc6bfd1bf5

# Note for reviewers:
Travis ruby-head fails but i think it failed also before. I'm not familiar with that. HTH! :rocket: 