### PR TITLE
Remove gem-install workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.1.9
 
   # Other ruby versions
-  - 2.2.7
+  - 2.3.0
   - 2.3.4
   - 2.4.1
 
@@ -29,7 +29,6 @@ cache:
     - $PWD/travis_phantomjs
 
 before_install:
-  - gem update --system
   - phantomjs --version
   - export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi


### PR DESCRIPTION
# Description:

this is a backport from https://github.com/kubic-project/velum/pull/709

 Don't run gem update --system

Related to `gem update --system`:
- travis-ci/travis-ci#8978
- rubygems/rubygems#2123

