### PR TITLE
External certs hostname check

### DIFF
--- a/app/views/settings/external_cert/_form.html.slim
+++ b/app/views/settings/external_cert/_form.html.slim
@@ -23,7 +23,20 @@
     .form-group.form-group-certificate
       p Select "Choose File" to upload a new #{_service_name} SSL Certificate:
       = f.file_field _cert_file_field, required: false
-    br
+
+    #accordion.panel-group aria-multiselectable="true" role="tablist" 
+    .panel.panel-default
+      .panel-heading.active role="tab" id=_heading
+        h4.panel-title
+          a.collapsed aria-controls=_collapse aria-expanded="false" data-parent="#accordion" data-toggle="collapse" href="##{_collapse}" role="button" 
+            | Show list of required Subject Alternative Names for #{_service_name}
+      .panel-collapse.collapse aria-labelledby=_heading role="tabpanel" id=_collapse
+        .panel-body
+          ul
+            - _subjectaltnames.each do |name|
+              li #{name}
+
+    hr
     - if _key
       .cert-table
         h5.cert-parse-heading Current #{_service_name} SSL Key Info:

--- a/app/views/settings/external_cert/index.html.slim
+++ b/app/views/settings/external_cert/index.html.slim
@@ -10,13 +10,13 @@ p Enable the use of External SSL Certificates for CaaSP and Kubernetes services.
 
   br
   = render template: 'settings/external_cert/_form', 
-  locals: { f: f , _service_name: "Velum" , _cert: @velum_cert, _key: @velum_key, _cert_file_field: :velum_cert , _key_file_field: :velum_key, _heading: "headingOne", _collapse: "collapseOne", _subjectaltnames: @subject_alt_names[:velum] }
+  locals: { f: f , _service_name: "Velum" , _cert: @velum_cert, _key: @velum_key, _cert_file_field: :velum_cert , _key_file_field: :velum_key, _heading: "headingVelum", _collapse: "collapseVelum", _subjectaltnames: @subject_alt_names[:velum] }
   br
   = render template: 'settings/external_cert/_form', 
-  locals: { f: f , _service_name: "Kubernetes API" , _cert: @kubeapi_cert, _key: @kubeapi_key, _cert_file_field: :kubeapi_cert , _key_file_field: :kubeapi_key, _heading: "headingTwo", _collapse: "collapseTwo", _subjectaltnames: @subject_alt_names[:kubeapi] }
+  locals: { f: f , _service_name: "Kubernetes API" , _cert: @kubeapi_cert, _key: @kubeapi_key, _cert_file_field: :kubeapi_cert , _key_file_field: :kubeapi_key, _heading: "headingKubeAPI", _collapse: "collapseKubeAPI", _subjectaltnames: @subject_alt_names[:kubeapi] }
   br
   = render template: 'settings/external_cert/_form', 
-  locals: { f: f , _service_name: "Dex" , _cert: @dex_cert, _key: @dex_key, _cert_file_field: :dex_cert , _key_file_field: :dex_key, _heading: "headingThree", _collapse: "collapseThree", _subjectaltnames: @subject_alt_names[:dex] }
+  locals: { f: f , _service_name: "Dex" , _cert: @dex_cert, _key: @dex_key, _cert_file_field: :dex_cert , _key_file_field: :dex_key, _heading: "headingDex", _collapse: "collapseDex", _subjectaltnames: @subject_alt_names[:dex] }
 
   .clearfix.text-right.steps-container
     = submit_tag "Save", id: "save", class: "btn btn-primary pull-right"

--- a/app/views/settings/external_cert/index.html.slim
+++ b/app/views/settings/external_cert/index.html.slim
@@ -10,13 +10,13 @@ p Enable the use of External SSL Certificates for CaaSP and Kubernetes services.
 
   br
   = render template: 'settings/external_cert/_form', 
-  locals: { f: f , _service_name: "Velum" , _cert: @velum_cert, _key: @velum_key, _cert_file_field: :velum_cert , _key_file_field: :velum_key }
+  locals: { f: f , _service_name: "Velum" , _cert: @velum_cert, _key: @velum_key, _cert_file_field: :velum_cert , _key_file_field: :velum_key, _heading: "headingOne", _collapse: "collapseOne", _subjectaltnames: @subject_alt_names[:velum] }
   br
   = render template: 'settings/external_cert/_form', 
-  locals: { f: f , _service_name: "Kubernetes API" , _cert: @kubeapi_cert, _key: @kubeapi_key, _cert_file_field: :kubeapi_cert , _key_file_field: :kubeapi_key }
+  locals: { f: f , _service_name: "Kubernetes API" , _cert: @kubeapi_cert, _key: @kubeapi_key, _cert_file_field: :kubeapi_cert , _key_file_field: :kubeapi_key, _heading: "headingTwo", _collapse: "collapseTwo", _subjectaltnames: @subject_alt_names[:kubeapi] }
   br
   = render template: 'settings/external_cert/_form', 
-  locals: { f: f , _service_name: "Dex" , _cert: @dex_cert, _key: @dex_key, _cert_file_field: :dex_cert , _key_file_field: :dex_key }
+  locals: { f: f , _service_name: "Dex" , _cert: @dex_cert, _key: @dex_key, _cert_file_field: :dex_cert , _key_file_field: :dex_key, _heading: "headingThree", _collapse: "collapseThree", _subjectaltnames: @subject_alt_names[:dex] }
 
   .clearfix.text-right.steps-container
     = submit_tag "Save", id: "save", class: "btn btn-primary pull-right"

--- a/config/ext_cert_minion.yaml
+++ b/config/ext_cert_minion.yaml
@@ -1,0 +1,9 @@
+# Used by external_cert_controller.rb to create a mock salt minion hash
+key1:
+  machine_id: "bf2fc52b4f5e4d8c9903573e3c55f4a4"
+  nodename: "admin"
+  roles: "admin"
+key2:
+  machine_id: "cb74502e91b740c8aabffae60b7aba59"
+  nodename: "master-0"
+  roles: "kube-master"

--- a/config/ext_cert_minion.yaml
+++ b/config/ext_cert_minion.yaml
@@ -1,9 +1,9 @@
 # Used by external_cert_controller.rb to create a mock salt minion hash
 key1:
-  machine_id: "bf2fc52b4f5e4d8c9903573e3c55f4a4"
+  machine_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   nodename: "admin"
   roles: "admin"
 key2:
-  machine_id: "cb74502e91b740c8aabffae60b7aba59"
+  machine_id: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
   nodename: "master-0"
   roles: "kube-master"

--- a/config/ext_cert_pillar.yaml
+++ b/config/ext_cert_pillar.yaml
@@ -1,0 +1,12 @@
+# Used by external_cert_controller.rb to create a mock salt pillar hash
+dashboard_external_fqdn: "admin.devenv.caasp.suse.net"
+dashboard: "10.17.1.0"
+internal_infra_domain: "infra.caasp.local"
+api:
+  server:
+    external_fqdn: "kube-api-x3.devenv.caasp.suse.net"
+    extra_names:
+    extra_ips:
+  cluster_ip: "172.24.0.1"
+dns: 
+  domain: "cluster.local"

--- a/spec/features/settings/external_cert_feature_spec.rb
+++ b/spec/features/settings/external_cert_feature_spec.rb
@@ -41,238 +41,258 @@ describe "Feature: External Cerificate settings", js: true do
     login_as user, scope: :user
   end
 
-  # describe "#index" do
-  #   before do
-  #     visit settings_external_cert_index_path
-  #   end
+  describe "#index" do
+    before do
+      visit settings_external_cert_index_path
+    end
 
-  #   # Success Conditions
+    # Success Conditions
 
-  #   it "correctly shows notice messages" do
-  #     # Does not contain 'expect(page).to have_http_status' assertion because of a
-  #     # race condition that detects the redirect http status and not the final status.
-  #     # This problem occurs when this assertion is before any Capybara actions.
-  #     expect(page).to have_content("Enable the use of External SSL Certificates for " \
-  #     "CaaSP and Kubernetes services. Certificates and matching keys must be in armored " \
-  #     "PEM format.")
-  #     expect(page).to have_content("Certificate not available, please upload a certificate",
-  #     count: 3)
-  #     expect(page).to have_content("Key not available, please upload a key", count: 3)
-  #   end
+    it "correctly shows notice messages" do
+      # Does not contain 'expect(page).to have_http_status' assertion because of a
+      # race condition that detects the redirect http status and not the final status.
+      # This problem occurs when this assertion is before any Capybara actions.
+      expect(page).to have_content("Enable the use of External SSL Certificates for " \
+      "CaaSP and Kubernetes services. Certificates and matching keys must be in armored " \
+      "PEM format.")
+      expect(page).to have_content("Certificate not available, please upload a certificate",
+      count: 3)
+      expect(page).to have_content("Key not available, please upload a key", count: 3)
+    end
 
-  #   it "saves the form with nothing attached" do
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:success)
-  #     expect(page).to have_content(success_message)
-  #   end
+    it "saves the form with nothing attached" do
+      click_button("Save")
+      expect(page).to have_http_status(:success)
+      expect(page).to have_content(success_message)
+    end
 
-  #   it "sucessfully uploads velum cert/key" do
-  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_velum_key", ssl_key_file_a)
+    it "sucessfully uploads velum cert/key" do
+      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+      attach_file("external_certificate_velum_key", ssl_key_file_a)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:success)
-  #     expect(page).to have_content(success_message)
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:success)
+      expect(page).to have_content(success_message)
+    end
 
-  #   it "sucessfully uploads kubeAPI cert/key" do
-  #     attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
+    it "sucessfully uploads kubeAPI cert/key" do
+      attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
+      attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:success)
-  #     expect(page).to have_content(success_message)
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:success)
+      expect(page).to have_content(success_message)
+    end
 
-  #   it "sucessfully uploads dex cert/key" do
-  #     attach_file("external_certificate_dex_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_dex_key", ssl_key_file_a)
+    it "sucessfully uploads dex cert/key" do
+      attach_file("external_certificate_dex_cert", ssl_cert_file_a)
+      attach_file("external_certificate_dex_key", ssl_key_file_a)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:success)
-  #     expect(page).to have_content(success_message)
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:success)
+      expect(page).to have_content(success_message)
+    end
 
-  #   it "sucessfully uploads velum, kubeAPI, and dex cert/key" do
-  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_velum_key", ssl_key_file_a)
-  #     attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
-  #     attach_file("external_certificate_dex_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_dex_key", ssl_key_file_a)
+    it "sucessfully uploads velum, kubeAPI, and dex cert/key" do
+      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+      attach_file("external_certificate_velum_key", ssl_key_file_a)
+      attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
+      attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
+      attach_file("external_certificate_dex_cert", ssl_cert_file_a)
+      attach_file("external_certificate_dex_key", ssl_key_file_a)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:success)
-  #     expect(page).to have_content(success_message)
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:success)
+      expect(page).to have_content(success_message)
+    end
 
-  #   it "sucessfully lists Subject Alternative Names" do
-  #     attach_file("external_certificate_velum_cert", ssl_cert_file_b)
-  #     attach_file("external_certificate_velum_key", ssl_key_file_b)
+    it "sucessfully lists Subject Alternative Names" do
+      attach_file("external_certificate_velum_cert", ssl_cert_file_b)
+      attach_file("external_certificate_velum_key", ssl_key_file_b)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:success)
-  #     expect(page).to have_content("ftp.example.com")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:success)
+      expect(page).to have_content("ftp.example.com")
+    end
 
-  #   it "uploads velum cert with a weak RSA bit length key (<= 2048)" do
-  #     attach_file("external_certificate_velum_cert", weak_key_cert)
-  #     attach_file("external_certificate_velum_key", key_for_weak_key_cert)
+    it "uploads velum cert with a weak RSA bit length key (<= 2048)" do
+      attach_file("external_certificate_velum_cert", weak_key_cert)
+      attach_file("external_certificate_velum_key", key_for_weak_key_cert)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:success)
-  #     expect(page).to have_content("RSA key bit length should be greater than or equal to 2048")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:success)
+      expect(page).to have_content("RSA key bit length should be greater than or equal to 2048")
+    end
 
-  #   it "uploads velum cert with a weak hash algorithm (sha1)" do
-  #     attach_file("external_certificate_velum_cert", weak_hash_cert)
-  #     attach_file("external_certificate_velum_key", key_for_weak_hash_cert)
+    it "uploads velum cert with a weak hash algorithm (sha1)" do
+      attach_file("external_certificate_velum_cert", weak_hash_cert)
+      attach_file("external_certificate_velum_key", key_for_weak_hash_cert)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:success)
-  #     expect(page).to have_content("Certificate includes a weak signature hash algorithm")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:success)
+      expect(page).to have_content("Certificate includes a weak signature hash algorithm")
+    end
 
-  #   # Failure Conditions
+    it "page contains required Velum hostnames" do
 
-  #   it "uploads malformed velum certificate" do
-  #     attach_file("external_certificate_velum_cert", ssl_cert_file_malformed)
-  #     attach_file("external_certificate_velum_key", ssl_key_file_a)
+      # find("collapseVelum").click
+      # click_link('#collapseVelum')
+      find('a[href="#collapseVelum"]').click
+      expect(page).to have_http_status(:success)
+      expect(page).to have_content("bf2fc52b4f5e4d8c9903573e3c55f4a4.infra.caasp.local", wait: 1)
+    end
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Invalid Velum certificate, check format and try again")
-  #   end
+    it "is missing required SubjectAltNames in certificate" do
+      attach_file("external_certificate_velum_cert", ssl_cert_file_b)
+      attach_file("external_certificate_velum_key", ssl_key_file_b)
 
-  #   it "uploads malformed velum key" do
-  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_velum_key", ssl_key_file_malformed)
+      click_button("Save")
+      expect(page).to have_http_status(:success)
+      expect(page).to have_content("Missing the following hostnames in the certificate: " \
+        "admin.devenv.caasp.suse.net 10.17.1.0 admin admin.infra.caasp.local " \
+        "bf2fc52b4f5e4d8c9903573e3c55f4a4 bf2fc52b4f5e4d8c9903573e3c55f4a4.infra.caasp.local")
+    end
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Invalid Velum key, check format and try again.")
-  #   end
+    # Failure Conditions
 
-  #   it "uploads malformed kubeAPI certificate" do
-  #     attach_file("external_certificate_kubeapi_cert", ssl_cert_file_malformed)
-  #     attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
+    it "uploads malformed velum certificate" do
+      attach_file("external_certificate_velum_cert", ssl_cert_file_malformed)
+      attach_file("external_certificate_velum_key", ssl_key_file_a)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Invalid Kubernetes API certificate, check format " \
-  #       "and try again")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Invalid Velum certificate, check format and try again")
+    end
 
-  #   it "uploads malformed kubeAPI key" do
-  #     attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_kubeapi_key", ssl_key_file_malformed)
+    it "uploads malformed velum key" do
+      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+      attach_file("external_certificate_velum_key", ssl_key_file_malformed)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Invalid Kubernetes API key, check format and try " \
-  #       "again.")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Invalid Velum key, check format and try again.")
+    end
 
-  #   it "uploads malformed dex certificate" do
-  #     attach_file("external_certificate_dex_cert", ssl_cert_file_malformed)
-  #     attach_file("external_certificate_dex_key", ssl_key_file_a)
+    it "uploads malformed kubeAPI certificate" do
+      attach_file("external_certificate_kubeapi_cert", ssl_cert_file_malformed)
+      attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Invalid Dex certificate, check format and try again")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Invalid Kubernetes API certificate, check format " \
+        "and try again")
+    end
 
-  #   it "uploads malformed dex key" do
-  #     attach_file("external_certificate_dex_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_dex_key", ssl_key_file_malformed)
+    it "uploads malformed kubeAPI key" do
+      attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
+      attach_file("external_certificate_kubeapi_key", ssl_key_file_malformed)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Invalid Dex key, check format and try again.")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Invalid Kubernetes API key, check format and try " \
+        "again.")
+    end
 
-  #   it "uploads only velum certificate" do
-  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+    it "uploads malformed dex certificate" do
+      attach_file("external_certificate_dex_cert", ssl_cert_file_malformed)
+      attach_file("external_certificate_dex_key", ssl_key_file_a)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
-  #       "together.")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Invalid Dex certificate, check format and try again")
+    end
 
-  #   it "uploads only velum key" do
-  #     attach_file("external_certificate_velum_key", ssl_key_file_a)
+    it "uploads malformed dex key" do
+      attach_file("external_certificate_dex_cert", ssl_cert_file_a)
+      attach_file("external_certificate_dex_key", ssl_key_file_malformed)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
-  #       "together.")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Invalid Dex key, check format and try again.")
+    end
 
-  #   it "uploads only velum, kubeAPI, and dex certificates" do
-  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_dex_cert", ssl_cert_file_a)
+    it "uploads only velum certificate" do
+      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
-  #       "together.")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
+        "together.")
+    end
 
-  #   it "uploads only velum, kubeAPI, and dex keys" do
-  #     attach_file("external_certificate_velum_key", ssl_key_file_a)
-  #     attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
-  #     attach_file("external_certificate_dex_key", ssl_key_file_a)
+    it "uploads only velum key" do
+      attach_file("external_certificate_velum_key", ssl_key_file_a)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
-  #       "together.")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
+        "together.")
+    end
 
-  #   it "uploads mismatched velum cert/key 1" do
-  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_velum_key", ssl_key_file_b)
+    it "uploads only velum, kubeAPI, and dex certificates" do
+      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+      attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
+      attach_file("external_certificate_dex_cert", ssl_cert_file_a)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Certificate/Key pair invalid.  Ensure Certificate and Key " \
-  #       "are matching.")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
+        "together.")
+    end
 
-  #   it "uploads mismatched velum cert/key 2" do
-  #     attach_file("external_certificate_velum_cert", ssl_cert_file_b)
-  #     attach_file("external_certificate_velum_key", ssl_key_file_a)
+    it "uploads only velum, kubeAPI, and dex keys" do
+      attach_file("external_certificate_velum_key", ssl_key_file_a)
+      attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
+      attach_file("external_certificate_dex_key", ssl_key_file_a)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Certificate/Key pair invalid.  Ensure Certificate and Key " \
-  #       "are matching.")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
+        "together.")
+    end
 
-  #   it "uploads mismatched velum, kubeAPI, and dex cert/key" do
-  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_velum_key", ssl_key_file_b)
-  #     attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_kubeapi_key", ssl_key_file_b)
-  #     attach_file("external_certificate_dex_cert", ssl_cert_file_a)
-  #     attach_file("external_certificate_dex_key", ssl_key_file_b)
+    it "uploads mismatched velum cert/key 1" do
+      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+      attach_file("external_certificate_velum_key", ssl_key_file_b)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Certificate/Key pair invalid.  Ensure Certificate and Key " \
-  #       "are matching.")
-  #   end
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Certificate/Key pair invalid.  Ensure Certificate and Key " \
+        "are matching.")
+    end
 
-  #   it "uploads velum cert with invalid date range" do
-  #     attach_file("external_certificate_velum_cert", expired_cert)
-  #     attach_file("external_certificate_velum_key", key_for_expired_cert)
+    it "uploads mismatched velum cert/key 2" do
+      attach_file("external_certificate_velum_cert", ssl_cert_file_b)
+      attach_file("external_certificate_velum_key", ssl_key_file_a)
 
-  #     click_button("Save")
-  #     expect(page).to have_http_status(:unprocessable_entity)
-  #     expect(page).to have_content("Certificate out of valid date range")
-  #   end
-  # end
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Certificate/Key pair invalid.  Ensure Certificate and Key " \
+        "are matching.")
+    end
+
+    it "uploads mismatched velum, kubeAPI, and dex cert/key" do
+      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+      attach_file("external_certificate_velum_key", ssl_key_file_b)
+      attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
+      attach_file("external_certificate_kubeapi_key", ssl_key_file_b)
+      attach_file("external_certificate_dex_cert", ssl_cert_file_a)
+      attach_file("external_certificate_dex_key", ssl_key_file_b)
+
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Certificate/Key pair invalid.  Ensure Certificate and Key " \
+        "are matching.")
+    end
+
+    it "uploads velum cert with invalid date range" do
+      attach_file("external_certificate_velum_cert", expired_cert)
+      attach_file("external_certificate_velum_key", key_for_expired_cert)
+
+      click_button("Save")
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_content("Certificate out of valid date range")
+    end
+  end
 end
 # rubocop:enable RSpec/ExampleLength

--- a/spec/features/settings/external_cert_feature_spec.rb
+++ b/spec/features/settings/external_cert_feature_spec.rb
@@ -41,238 +41,238 @@ describe "Feature: External Cerificate settings", js: true do
     login_as user, scope: :user
   end
 
-  describe "#index" do
-    before do
-      visit settings_external_cert_index_path
-    end
+  # describe "#index" do
+  #   before do
+  #     visit settings_external_cert_index_path
+  #   end
 
-    # Success Conditions
+  #   # Success Conditions
 
-    it "correctly shows notice messages" do
-      # Does not contain 'expect(page).to have_http_status' assertion because of a
-      # race condition that detects the redirect http status and not the final status.
-      # This problem occurs when this assertion is before any Capybara actions.
-      expect(page).to have_content("Enable the use of External SSL Certificates for " \
-      "CaaSP and Kubernetes services. Certificates and matching keys must be in armored " \
-      "PEM format.")
-      expect(page).to have_content("Certificate not available, please upload a certificate",
-      count: 3)
-      expect(page).to have_content("Key not available, please upload a key", count: 3)
-    end
+  #   it "correctly shows notice messages" do
+  #     # Does not contain 'expect(page).to have_http_status' assertion because of a
+  #     # race condition that detects the redirect http status and not the final status.
+  #     # This problem occurs when this assertion is before any Capybara actions.
+  #     expect(page).to have_content("Enable the use of External SSL Certificates for " \
+  #     "CaaSP and Kubernetes services. Certificates and matching keys must be in armored " \
+  #     "PEM format.")
+  #     expect(page).to have_content("Certificate not available, please upload a certificate",
+  #     count: 3)
+  #     expect(page).to have_content("Key not available, please upload a key", count: 3)
+  #   end
 
-    it "saves the form with nothing attached" do
-      click_button("Save")
-      expect(page).to have_http_status(:success)
-      expect(page).to have_content(success_message)
-    end
+  #   it "saves the form with nothing attached" do
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:success)
+  #     expect(page).to have_content(success_message)
+  #   end
 
-    it "sucessfully uploads velum cert/key" do
-      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
-      attach_file("external_certificate_velum_key", ssl_key_file_a)
+  #   it "sucessfully uploads velum cert/key" do
+  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_velum_key", ssl_key_file_a)
 
-      click_button("Save")
-      expect(page).to have_http_status(:success)
-      expect(page).to have_content(success_message)
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:success)
+  #     expect(page).to have_content(success_message)
+  #   end
 
-    it "sucessfully uploads kubeAPI cert/key" do
-      attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
-      attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
+  #   it "sucessfully uploads kubeAPI cert/key" do
+  #     attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
 
-      click_button("Save")
-      expect(page).to have_http_status(:success)
-      expect(page).to have_content(success_message)
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:success)
+  #     expect(page).to have_content(success_message)
+  #   end
 
-    it "sucessfully uploads dex cert/key" do
-      attach_file("external_certificate_dex_cert", ssl_cert_file_a)
-      attach_file("external_certificate_dex_key", ssl_key_file_a)
+  #   it "sucessfully uploads dex cert/key" do
+  #     attach_file("external_certificate_dex_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_dex_key", ssl_key_file_a)
 
-      click_button("Save")
-      expect(page).to have_http_status(:success)
-      expect(page).to have_content(success_message)
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:success)
+  #     expect(page).to have_content(success_message)
+  #   end
 
-    it "sucessfully uploads velum, kubeAPI, and dex cert/key" do
-      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
-      attach_file("external_certificate_velum_key", ssl_key_file_a)
-      attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
-      attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
-      attach_file("external_certificate_dex_cert", ssl_cert_file_a)
-      attach_file("external_certificate_dex_key", ssl_key_file_a)
+  #   it "sucessfully uploads velum, kubeAPI, and dex cert/key" do
+  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_velum_key", ssl_key_file_a)
+  #     attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
+  #     attach_file("external_certificate_dex_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_dex_key", ssl_key_file_a)
 
-      click_button("Save")
-      expect(page).to have_http_status(:success)
-      expect(page).to have_content(success_message)
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:success)
+  #     expect(page).to have_content(success_message)
+  #   end
 
-    it "sucessfully lists Subject Alternative Names" do
-      attach_file("external_certificate_velum_cert", ssl_cert_file_b)
-      attach_file("external_certificate_velum_key", ssl_key_file_b)
+  #   it "sucessfully lists Subject Alternative Names" do
+  #     attach_file("external_certificate_velum_cert", ssl_cert_file_b)
+  #     attach_file("external_certificate_velum_key", ssl_key_file_b)
 
-      click_button("Save")
-      expect(page).to have_http_status(:success)
-      expect(page).to have_content("ftp.example.com")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:success)
+  #     expect(page).to have_content("ftp.example.com")
+  #   end
 
-    it "uploads velum cert with a weak RSA bit length key (<= 2048)" do
-      attach_file("external_certificate_velum_cert", weak_key_cert)
-      attach_file("external_certificate_velum_key", key_for_weak_key_cert)
+  #   it "uploads velum cert with a weak RSA bit length key (<= 2048)" do
+  #     attach_file("external_certificate_velum_cert", weak_key_cert)
+  #     attach_file("external_certificate_velum_key", key_for_weak_key_cert)
 
-      click_button("Save")
-      expect(page).to have_http_status(:success)
-      expect(page).to have_content("RSA key bit length should be greater than or equal to 2048")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:success)
+  #     expect(page).to have_content("RSA key bit length should be greater than or equal to 2048")
+  #   end
 
-    it "uploads velum cert with a weak hash algorithm (sha1)" do
-      attach_file("external_certificate_velum_cert", weak_hash_cert)
-      attach_file("external_certificate_velum_key", key_for_weak_hash_cert)
+  #   it "uploads velum cert with a weak hash algorithm (sha1)" do
+  #     attach_file("external_certificate_velum_cert", weak_hash_cert)
+  #     attach_file("external_certificate_velum_key", key_for_weak_hash_cert)
 
-      click_button("Save")
-      expect(page).to have_http_status(:success)
-      expect(page).to have_content("Certificate includes a weak signature hash algorithm")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:success)
+  #     expect(page).to have_content("Certificate includes a weak signature hash algorithm")
+  #   end
 
-    # Failure Conditions
+  #   # Failure Conditions
 
-    it "uploads malformed velum certificate" do
-      attach_file("external_certificate_velum_cert", ssl_cert_file_malformed)
-      attach_file("external_certificate_velum_key", ssl_key_file_a)
+  #   it "uploads malformed velum certificate" do
+  #     attach_file("external_certificate_velum_cert", ssl_cert_file_malformed)
+  #     attach_file("external_certificate_velum_key", ssl_key_file_a)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Invalid Velum certificate, check format and try again")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Invalid Velum certificate, check format and try again")
+  #   end
 
-    it "uploads malformed velum key" do
-      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
-      attach_file("external_certificate_velum_key", ssl_key_file_malformed)
+  #   it "uploads malformed velum key" do
+  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_velum_key", ssl_key_file_malformed)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Invalid Velum key, check format and try again.")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Invalid Velum key, check format and try again.")
+  #   end
 
-    it "uploads malformed kubeAPI certificate" do
-      attach_file("external_certificate_kubeapi_cert", ssl_cert_file_malformed)
-      attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
+  #   it "uploads malformed kubeAPI certificate" do
+  #     attach_file("external_certificate_kubeapi_cert", ssl_cert_file_malformed)
+  #     attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Invalid Kubernetes API certificate, check format " \
-        "and try again")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Invalid Kubernetes API certificate, check format " \
+  #       "and try again")
+  #   end
 
-    it "uploads malformed kubeAPI key" do
-      attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
-      attach_file("external_certificate_kubeapi_key", ssl_key_file_malformed)
+  #   it "uploads malformed kubeAPI key" do
+  #     attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_kubeapi_key", ssl_key_file_malformed)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Invalid Kubernetes API key, check format and try " \
-        "again.")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Invalid Kubernetes API key, check format and try " \
+  #       "again.")
+  #   end
 
-    it "uploads malformed dex certificate" do
-      attach_file("external_certificate_dex_cert", ssl_cert_file_malformed)
-      attach_file("external_certificate_dex_key", ssl_key_file_a)
+  #   it "uploads malformed dex certificate" do
+  #     attach_file("external_certificate_dex_cert", ssl_cert_file_malformed)
+  #     attach_file("external_certificate_dex_key", ssl_key_file_a)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Invalid Dex certificate, check format and try again")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Invalid Dex certificate, check format and try again")
+  #   end
 
-    it "uploads malformed dex key" do
-      attach_file("external_certificate_dex_cert", ssl_cert_file_a)
-      attach_file("external_certificate_dex_key", ssl_key_file_malformed)
+  #   it "uploads malformed dex key" do
+  #     attach_file("external_certificate_dex_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_dex_key", ssl_key_file_malformed)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Invalid Dex key, check format and try again.")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Invalid Dex key, check format and try again.")
+  #   end
 
-    it "uploads only velum certificate" do
-      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+  #   it "uploads only velum certificate" do
+  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
-        "together.")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
+  #       "together.")
+  #   end
 
-    it "uploads only velum key" do
-      attach_file("external_certificate_velum_key", ssl_key_file_a)
+  #   it "uploads only velum key" do
+  #     attach_file("external_certificate_velum_key", ssl_key_file_a)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
-        "together.")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
+  #       "together.")
+  #   end
 
-    it "uploads only velum, kubeAPI, and dex certificates" do
-      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
-      attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
-      attach_file("external_certificate_dex_cert", ssl_cert_file_a)
+  #   it "uploads only velum, kubeAPI, and dex certificates" do
+  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_dex_cert", ssl_cert_file_a)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
-        "together.")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
+  #       "together.")
+  #   end
 
-    it "uploads only velum, kubeAPI, and dex keys" do
-      attach_file("external_certificate_velum_key", ssl_key_file_a)
-      attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
-      attach_file("external_certificate_dex_key", ssl_key_file_a)
+  #   it "uploads only velum, kubeAPI, and dex keys" do
+  #     attach_file("external_certificate_velum_key", ssl_key_file_a)
+  #     attach_file("external_certificate_kubeapi_key", ssl_key_file_a)
+  #     attach_file("external_certificate_dex_key", ssl_key_file_a)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
-        "together.")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Error with Velum, certificate and key must be uploaded " \
+  #       "together.")
+  #   end
 
-    it "uploads mismatched velum cert/key 1" do
-      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
-      attach_file("external_certificate_velum_key", ssl_key_file_b)
+  #   it "uploads mismatched velum cert/key 1" do
+  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_velum_key", ssl_key_file_b)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Certificate/Key pair invalid.  Ensure Certificate and Key " \
-        "are matching.")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Certificate/Key pair invalid.  Ensure Certificate and Key " \
+  #       "are matching.")
+  #   end
 
-    it "uploads mismatched velum cert/key 2" do
-      attach_file("external_certificate_velum_cert", ssl_cert_file_b)
-      attach_file("external_certificate_velum_key", ssl_key_file_a)
+  #   it "uploads mismatched velum cert/key 2" do
+  #     attach_file("external_certificate_velum_cert", ssl_cert_file_b)
+  #     attach_file("external_certificate_velum_key", ssl_key_file_a)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Certificate/Key pair invalid.  Ensure Certificate and Key " \
-        "are matching.")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Certificate/Key pair invalid.  Ensure Certificate and Key " \
+  #       "are matching.")
+  #   end
 
-    it "uploads mismatched velum, kubeAPI, and dex cert/key" do
-      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
-      attach_file("external_certificate_velum_key", ssl_key_file_b)
-      attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
-      attach_file("external_certificate_kubeapi_key", ssl_key_file_b)
-      attach_file("external_certificate_dex_cert", ssl_cert_file_a)
-      attach_file("external_certificate_dex_key", ssl_key_file_b)
+  #   it "uploads mismatched velum, kubeAPI, and dex cert/key" do
+  #     attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_velum_key", ssl_key_file_b)
+  #     attach_file("external_certificate_kubeapi_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_kubeapi_key", ssl_key_file_b)
+  #     attach_file("external_certificate_dex_cert", ssl_cert_file_a)
+  #     attach_file("external_certificate_dex_key", ssl_key_file_b)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Certificate/Key pair invalid.  Ensure Certificate and Key " \
-        "are matching.")
-    end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Certificate/Key pair invalid.  Ensure Certificate and Key " \
+  #       "are matching.")
+  #   end
 
-    it "uploads velum cert with invalid date range" do
-      attach_file("external_certificate_velum_cert", expired_cert)
-      attach_file("external_certificate_velum_key", key_for_expired_cert)
+  #   it "uploads velum cert with invalid date range" do
+  #     attach_file("external_certificate_velum_cert", expired_cert)
+  #     attach_file("external_certificate_velum_key", key_for_expired_cert)
 
-      click_button("Save")
-      expect(page).to have_http_status(:unprocessable_entity)
-      expect(page).to have_content("Certificate out of valid date range")
-    end
-  end
+  #     click_button("Save")
+  #     expect(page).to have_http_status(:unprocessable_entity)
+  #     expect(page).to have_content("Certificate out of valid date range")
+  #   end
+  # end
 end
 # rubocop:enable RSpec/ExampleLength

--- a/spec/features/settings/external_cert_feature_spec.rb
+++ b/spec/features/settings/external_cert_feature_spec.rb
@@ -134,12 +134,10 @@ describe "Feature: External Cerificate settings", js: true do
     end
 
     it "page contains required Velum hostnames" do
-
-      # find("collapseVelum").click
-      # click_link('#collapseVelum')
       find('a[href="#collapseVelum"]').click
+
       expect(page).to have_http_status(:success)
-      expect(page).to have_content("bf2fc52b4f5e4d8c9903573e3c55f4a4.infra.caasp.local", wait: 1)
+      expect(page).to have_content("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.infra.caasp.local", wait: 1)
     end
 
     it "is missing required SubjectAltNames in certificate" do
@@ -148,9 +146,20 @@ describe "Feature: External Cerificate settings", js: true do
 
       click_button("Save")
       expect(page).to have_http_status(:success)
-      expect(page).to have_content("Missing the following hostnames in the certificate: " \
-        "admin.devenv.caasp.suse.net 10.17.1.0 admin admin.infra.caasp.local " \
-        "bf2fc52b4f5e4d8c9903573e3c55f4a4 bf2fc52b4f5e4d8c9903573e3c55f4a4.infra.caasp.local")
+      expect(page).to have_content("Warning, Velum is missing the following hostnames in its " \
+        "certificate: admin.devenv.caasp.suse.net 10.17.1.0 admin admin.infra.caasp.local " \
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.infra.caasp.local")
+    end
+
+    it "is has no SubjectAltNames in certificate" do
+      attach_file("external_certificate_velum_cert", ssl_cert_file_a)
+      attach_file("external_certificate_velum_key", ssl_key_file_a)
+
+      click_button("Save")
+      expect(page).to have_http_status(:success)
+      expect(page).to have_content("Warning, Velum is missing the following hostnames in its " \
+        "certificate: admin.devenv.caasp.suse.net 10.17.1.0 admin admin.infra.caasp.local " \
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.infra.caasp.local")
     end
 
     # Failure Conditions


### PR DESCRIPTION
Added logic for checking of a certificates's SubjectAltNames against list of required hostnames for Velum, KubeAPI and Dex.