### PR TITLE
init: added check for ldap

### DIFF
--- a/bin/check_ldap.rb
+++ b/bin/check_ldap.rb
@@ -1,0 +1,21 @@
+# This is a rails runner that will print the status of the database
+# Possible outcomes:
+#
+#   * `LDAP_READY`: connection successfull
+#   * `LDAP_FAIL`: cannot authenticate within ldap server
+#   * `LDAP_DOWN`: cannot connect to the ldap server
+
+def ldap_ready?
+  ldap_config = Velum::LDAP.ldap_config
+  ldap = Net::LDAP.new(ldap_config)
+
+  if ldap.bind
+    puts "LDAP_READY"
+  else
+    puts "LDAP_FAIL"
+  end
+rescue Errno::ECONNREFUSED, Net::LDAP::Error
+  puts "LDAP_DOWN"
+end
+
+ldap_ready?

--- a/bin/run
+++ b/bin/run
@@ -8,5 +8,34 @@ setup_root_ca() {
   update-ca-certificates
 }
 
+check_ldap() {
+  set +e
+
+  TIMEOUT=90
+  COUNT=0
+  RETRY=1
+
+  while [ $RETRY -ne 0 ]; do
+    case $(bundle exec rails r bin/check_ldap.rb | grep LDAP) in
+      "LDAP_DOWN")
+        if [ "$COUNT" -ge "$TIMEOUT" ]; then
+          printf " [FAIL]\n"
+          echo "Timeout reached, exiting with error"
+          exit 1
+        fi
+        echo "Waiting for ldap to be ready in 5 seconds"
+        sleep 5
+        COUNT=$((COUNT+5))
+        ;;
+      *)
+        echo "LDAP is ready"
+        break
+        ;;
+    esac
+  done
+  set -e
+}
+
 setup_root_ca
+check_ldap
 bundle exec "puma -C config/puma.rb"


### PR DESCRIPTION
Added a new check to verify if the ldap instance is ready before running
velum dashboard in order to avoid a connection error when creating a new
user.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

bsc#1121064