### PR TITLE
Add nocov on things we are intentionally not covering

### DIFF
--- a/app/controllers/settings/external_cert_controller.rb
+++ b/app/controllers/settings/external_cert_controller.rb
@@ -344,7 +344,10 @@ class Settings::ExternalCertController < SettingsController
                  when Resolv::IPv4::Regex
                    IPAddr.new(i).to_string
                  when Resolv::IPv6::Regex
+                   # :nocov:
+                   # We aren't using IPv6 in production so we are skipping tests for this
                    IPAddr.new(i).to_string
+                   # :nocov:
                  else
                    i
       end
@@ -395,8 +398,11 @@ class Settings::ExternalCertController < SettingsController
           true
         end
       rescue Exception
+        # :nocov:
+        # There are no known ways to trigger this so skipping coverage tests
         verify_error += err_msg
         false
+        # :nocov:
       end
     end
 


### PR DESCRIPTION
Added nocov to the two places in code that don't need to be tested. They are code for IPv6 ( forward looking but not used ) and handling to prevent error in exceptional case ( which I don't know how to trigger and isn't important )