### PR TITLE
[bsc#1121147] Do not allow '.' or '/' symbols in system certificate names.

### DIFF
--- a/app/models/system_certificate.rb
+++ b/app/models/system_certificate.rb
@@ -4,7 +4,7 @@ class SystemCertificate < ActiveRecord::Base
   has_one :certificate_service, as: :service, dependent: :destroy
   has_one :certificate, through: :certificate_service
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true, system_certificate_name: true
 
   class << self
     # Create a new SystemCertificate from parameters

--- a/app/validators/system_certificate_name_validator.rb
+++ b/app/validators/system_certificate_name_validator.rb
@@ -1,0 +1,12 @@
+require "openssl"
+
+# Verifies that the name of a system certificate can not contain any
+# components that could be relative paths on the file system.
+class SystemCertificateNameValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    suspicious_path = /[\.\/]/ =~ value
+    return true if suspicious_path.nil?
+    record.errors[attribute] << "Invalid certificate name." \
+                                "Do not include '.' or '/' in the name."
+  end
+end

--- a/spec/models/system_certificate_spec.rb
+++ b/spec/models/system_certificate_spec.rb
@@ -2,4 +2,21 @@ require "rails_helper"
 
 RSpec.describe SystemCertificate, type: :model do
   it { is_expected.to validate_presence_of(:name) }
+
+  context "when a name was set" do
+    it "accepts usual names" do
+      cert = described_class.new(name: "test_file")
+      expect(cert.valid?).to eq(true)
+    end
+
+    it "rejects dots in the name" do
+      cert = described_class.new(name: "test.file")
+      expect(cert.valid?).to eq(false)
+    end
+
+    it "rejects slashes in the name" do
+      cert = described_class.new(name: "test/file")
+      expect(cert.valid?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
This way when salt extracts the name to construct the certificate path,
it will not be able to break out of the folder for trusted certificates.

This is a first layer fix for bnc#1121147.