### PR TITLE
Jenkinsfile: Switch to dynamic library fetching and drop branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
-def targetBranch = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
-
-library "kubic-jenkins-library@${targetBranch}"
+library identifier: "kubic-jenkins-library@master", retriever: modernSCM(
+    [$class: 'GitSCMSource',
+    remote: 'https://github.com/suse/caasp-jenkins-library.git',
+    credentialsId: 'github-token'])
 
 coreKubicProjectCi()

--- a/Jenkinsfile.housekeeping
+++ b/Jenkinsfile.housekeeping
@@ -1,5 +1,6 @@
-def targetBranch = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
-
-library "kubic-jenkins-library@${targetBranch}"
+library identifier: "kubic-jenkins-library@master", retriever: modernSCM(
+    [$class: 'GitSCMSource',
+    remote: 'https://github.com/suse/caasp-jenkins-library.git',
+    credentialsId: 'github-token'])
 
 coreKubicProjectHousekeeping()


### PR DESCRIPTION
Instead of having the library hardcoded to Jenkins master, we can fetch
it dynamically. We also drop the usage of library branches since it does
not make sense to maintain such a thing in the CI. The master branch
should be able to handle both development and release branches.