### PR TITLE
[bsc#1126208] Do not block updates on minions

### DIFF
--- a/app/controllers/salt_controller.rb
+++ b/app/controllers/salt_controller.rb
@@ -1,7 +1,7 @@
 require "velum/salt"
 # SaltController holds methods for triggering updates of nodes
 class SaltController < ApplicationController
-  before_action :not_implemented_in_public_cloud
+  before_action :not_implemented_in_public_cloud, only: [:remove_minion]
   skip_before_action :redirect_to_setup
 
   def update

--- a/spec/controllers/salt_controller_spec.rb
+++ b/spec/controllers/salt_controller_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe SaltController, type: :controller do
         expect(response.status).to eq 302
       end
     end
+
+    it "is implemented in the public cloud" do
+      create(:ec2_pillar)
+
+      VCR.use_cassette("salt/update_orch", record: :none) do
+        post :update
+        expect(response.status).to eq 302
+      end
+    end
   end
 
   describe "POST /accept-minion" do


### PR DESCRIPTION
https://github.com/kubic-project/velum/pull/704 inadvertently blocked an excessive amount of functionality. This went unnoticed as the function `remove_minion` was intended to be blocked; the functions `add_minion` and `reject_minion` do not apply in the public cloud (minions are _automatically_ joined to the salt cluster by `salt-cloud`), leaving the `update` function... which has no comment or clarification in the source or specs that it is the trigger for an action unrelation to the other functions in this scope.