### PR TITLE
[bsc#1121165] changed kubeconfig download from get to post request

### DIFF
--- a/app/views/oidc/done.html.slim
+++ b/app/views/oidc/done.html.slim
@@ -16,7 +16,8 @@ p
   | Alternatively, you can also save it to your home in `~/.kube/config`, `kubectl` will automatically
   |  read this file without the need to specify the <strong>KUBECONFIG</strong> environment variable.
 
-p= link_to "Click here if the download has not started automatically.", @redirect_target
+= form_tag @redirect_target, method: "post"
+  button type="submit" class="btn btn-primary" Click here if the download has not started automatically.
 
 h2 Option 2: Manually configure kubeconfig file
 
@@ -49,5 +50,5 @@ pre
 = content_for :page_javascript do
   javascript:
     $(function() {
-      window.location.href = "#{@redirect_target}"
+      document.querySelector('form').submit();
     });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
 
   get "/oidc", to: "oidc#index"
   get "/oidc/done", to: "oidc#done"
-  get "/oidc/kubeconfig", to: "oidc#kubeconfig"
+  post "/oidc/kubeconfig", to: "oidc#kubeconfig"
 
   namespace :orchestrations do
     resource :bootstrap, only: :create, controller: :bootstrap


### PR DESCRIPTION
The kubeconfig download request was previously done via GET request and
the file content could be easily modified through url parameters.

With this patch we've changed from GET to POST method and now taking
advantage of CSRF protection.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

bsc#1121165